### PR TITLE
adding support for tab-separated translations

### DIFF
--- a/yomi_base/preferences.py
+++ b/yomi_base/preferences.py
@@ -105,7 +105,7 @@ class DialogPreferences(QtGui.QDialog, gen.preferences_ui.Ui_DialogPreferences):
         self.comboBoxModel.blockSignals(False)
 
         allowedTags = {
-            'vocab': ['expression', 'reading', 'glossary', 'sentence'],
+            'vocab': ['expression', 'reading', 'glossary', 'sentence','translation'],
             'kanji': ['character', 'onyomi', 'kunyomi', 'glossary'],
         }[name]
 

--- a/yomi_base/reader.py
+++ b/yomi_base/reader.py
@@ -507,9 +507,10 @@ class MainWindowReader(QtGui.QMainWindow, gen.reader_ui.Ui_MainWindowReader):
         lengthMatched = 0
         if self.dockVocab.isVisible():
             self.state.vocabDefs, lengthMatched = self.language.findTerm(contentSampleFlat)
-            sentence = reader_util.findSentence(content, samplePosStart)
+            sentence, translation = reader_util.findSentence(content, samplePosStart)
             for definition in self.state.vocabDefs:
                 definition['sentence'] = sentence
+                definition['translation'] = translation
             self.updateVocabDefs()
 
         if self.dockKanji.isVisible():

--- a/yomi_base/reader_util.py
+++ b/yomi_base/reader_util.py
@@ -78,20 +78,13 @@ def findSentence(content, position):
             quoteStack.pop()
         elif c in quotesFwd:
             quoteStack.insert(0, quotesFwd[c])
-    cend = len(content)
-    translation_start = 0
-    for i in xrange(end, cend):
-      if content[i] == '\t':
-          translation_start = i+1
-          break
-    translation_end = cend
-    for i in xrange(translation_start, cend):
-      if content[i] == '\n':
-          translation_end = i
-          break      
     translation = ''
-    if translation_start > 0:
-      translation = content[translation_start:translation_end].strip() 
+    translationStart = content.find('\t',end)
+    if translationStart >= 0:
+      translationEnd = content.find('\n',translationStart)
+      if translationEnd == -1:
+        translationEnd = len(content)
+      translation = content[translationStart+1:translationEnd].strip() 
     return content[start:end].strip(), translation  
 
 
@@ -121,6 +114,7 @@ def markupVocabExp(definition):
         'reading': definition['reading'] or unicode(),
         'glossary': definition['glossary'],
         'sentence': definition.get('sentence'),
+        'translation': definition.get('translation'),
         'summary': summary
     }
 
@@ -132,6 +126,7 @@ def markupVocabReading(definition):
             'reading': unicode(),
             'glossary': definition['glossary'],
             'sentence': definition.get('sentence'),
+            'translation': definition.get('translation'),
             'summary': definition['reading']
         }
 

--- a/yomi_base/reader_util.py
+++ b/yomi_base/reader_util.py
@@ -78,8 +78,21 @@ def findSentence(content, position):
             quoteStack.pop()
         elif c in quotesFwd:
             quoteStack.insert(0, quotesFwd[c])
-
-    return content[start:end].strip()
+    cend = len(content)
+    translation_start = 0
+    for i in xrange(end, cend):
+      if content[i] == '\t':
+          translation_start = i+1
+          break
+    translation_end = cend
+    for i in xrange(translation_start, cend):
+      if content[i] == '\n':
+          translation_end = i
+          break      
+    translation = ''
+    if translation_start > 0:
+      translation = content[translation_start:translation_end].strip() 
+    return content[start:end].strip(), translation  
 
 
 def formatFields(fields, markup):


### PR DESCRIPTION
With this small update, yomichan scans the entire line for a tab character. If it finds one, it treats the rest of the line as translation.

E.g. having the line 彼は洞察力のある人だ。\t"He is a man of vision."
彼は洞察力のある人だ。 becomes the definition's sentence
"He is a man of vision." becomes the definition's translation.

The proper field for the translation can be set in the preferences with {translation}. I made this update mainly to be able to import sentence lists from tatoeba.com more easily, because they export it with the same pattern like the example above.