### PR TITLE
Import terms with transactional adds instead of bulkAdd

### DIFF
--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -189,20 +189,19 @@ class Database {
         };
 
         const termsLoaded = (title, entries, total, current) => {
-            const rows = [];
-            for (const [expression, reading, tags, rules, score, ...glossary] of entries) {
-                rows.push({
-                    expression,
-                    reading,
-                    tags,
-                    rules,
-                    score,
-                    glossary,
-                    dictionary: title
-                });
-            }
-
-            return this.db.terms.bulkAdd(rows).then(() => {
+            return this.db.transaction('rw', this.db.terms, function() {
+                for (const [expression, reading, tags, rules, score, ...glossary] of entries) {
+                    this.db.terms.add({
+                        expression,
+                        reading,
+                        tags,
+                        rules,
+                        score,
+                        glossary,
+                        dictionary: title
+                    });
+                }
+            }).then(() => {
                 if (callback) {
                     callback(total, current);
                 }


### PR DESCRIPTION
I think I was running into some race or performance issue when attempting to import jmnedict.zip into Yomichan on Firefox 56 - having reliably run into the following failure more than 20 times (including on clean profiles):

![dfo6xwyu0aarqix](https://user-images.githubusercontent.com/1318013/28658858-0cee9b7e-7262-11e7-96bc-3cc6a1c27e6e.jpg)

(where it fails is sometimes the same but usually different)

From what I could see in the Browser Console, `UnknownErr`s were being thrown from the IndexedDB library in Firefox.

With this change, this no longer occurs for me.

I tried doing this on the dev branch with all the async changes but while the database imports worked, I'm not seeing any dropdown when I actually go to hover above words (they get highlighted but no dictionary entries show up).