### PR TITLE
Allow glossary lists to have centered alignment

### DIFF
--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -169,7 +169,7 @@ templates['fields.html'] = template({"1":function(container,depth0,helpers,parti
 },"46":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return "<ol>"
+  return "<ol style=\"padding: 0\">"
     + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definition : depth0)) != null ? stack1.glossary : stack1),{"name":"each","hash":{},"fn":container.program(47, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</ol>";
 },"47":function(container,depth0,helpers,partials,data) {
@@ -199,7 +199,7 @@ templates['fields.html'] = template({"1":function(container,depth0,helpers,parti
 },"56":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return "<ol>"
+  return "<ol style=\"padding: 0\">"
     + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definition : depth0)) != null ? stack1.definitions : stack1),{"name":"each","hash":{},"fn":container.program(57, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</ol>";
 },"57":function(container,depth0,helpers,partials,data,blockParams,depths) {

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -157,7 +157,7 @@ templates['fields.html'] = template({"1":function(container,depth0,helpers,parti
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.modeKanji : depth0),{"name":"if","hash":{},"fn":container.program(44, data, 0, blockParams, depths),"inverse":container.program(53, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.html : depth0),{"name":"if","hash":{},"fn":container.program(66, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"42":function(container,depth0,helpers,partials,data) {
-    return "<div style=\"text-align: left;\">";
+    return "<div style=\"list-style-position: inside;\">";
 },"44":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/tmpl/fields.html
+++ b/tmpl/fields.html
@@ -51,7 +51,7 @@
 {{/inline}}
 
 {{#*inline "glossary"}}
-    {{~#if html}}<div style="text-align: left;">{{/if~}}
+    {{~#if html}}<div style="list-style-position: inside;">{{/if~}}
     {{~#if modeKanji~}}
         {{~#if definition.glossary.[1]~}}
             {{~#if html}}<ol>{{#each definition.glossary}}<li>{{.}}</li>{{/each}}</ol>

--- a/tmpl/fields.html
+++ b/tmpl/fields.html
@@ -54,7 +54,7 @@
     {{~#if html}}<div style="list-style-position: inside;">{{/if~}}
     {{~#if modeKanji~}}
         {{~#if definition.glossary.[1]~}}
-            {{~#if html}}<ol>{{#each definition.glossary}}<li>{{.}}</li>{{/each}}</ol>
+            {{~#if html}}<ol style="padding: 0">{{#each definition.glossary}}<li>{{.}}</li>{{/each}}</ol>
             {{~else}}{{#each definition.glossary}}{{.}}{{#unless @last}}, {{/unless}}{{/each}}{{/if~}}
         {{~else~}}
             {{definition.glossary.[0]}}
@@ -62,7 +62,7 @@
     {{~else~}}
         {{~#if group~}}
             {{~#if definition.definitions.[1]~}}
-                {{~#if html}}<ol>{{#each definition.definitions}}<li>{{> glossary-single html=../html brief=../brief}}</li>{{/each}}</ol>
+                {{~#if html}}<ol style="padding: 0">{{#each definition.definitions}}<li>{{> glossary-single html=../html brief=../brief}}</li>{{/each}}</ol>
                 {{~else}}{{#each definition.definitions}} * {{> glossary-single html=../html brief=../brief}}{{/each}}{{/if~}}
             {{~else~}}
                 {{~> glossary-single definition.definitions.[0] html=html brief=brief~}}


### PR DESCRIPTION
"list-style-position: inside" means the number will be together with the centered text instead of moved to the left

----

Fixes #69 

I figured this was simple enough I could just do it directly. Feel free to close if you disagree with this change or if you'd prefer to have it behind a setting.