### PR TITLE
Import terms/kanji with transactional adds instead of bulkAdd on async

### DIFF
--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -187,20 +187,19 @@ class Database {
                 callback(total, current);
             }
 
-            const rows = [];
-            for (const [expression, reading, tags, rules, score, ...glossary] of entries) {
-                rows.push({
-                    expression,
-                    reading,
-                    tags,
-                    rules,
-                    score,
-                    glossary,
-                    dictionary: title
-                });
-            }
-
-            await this.db.terms.bulkAdd(rows);
+            await this.db.transaction('rw', this.db.terms, async function() {
+                for (const [expression, reading, tags, rules, score, ...glossary] of entries) {
+                    this.db.terms.add({
+                        expression,
+                        reading,
+                        tags,
+                        rules,
+                        score,
+                        glossary,
+                        dictionary: title
+                    });
+                }
+            });
         };
 
         const kanjiLoaded = async (title, entries, total, current)  => {
@@ -208,19 +207,18 @@ class Database {
                 callback(total, current);
             }
 
-            const rows = [];
-            for (const [character, onyomi, kunyomi, tags, ...meanings] of entries) {
-                rows.push({
-                    character,
-                    onyomi,
-                    kunyomi,
-                    tags,
-                    meanings,
-                    dictionary: title
-                });
-            }
-
-            await this.db.kanji.bulkAdd(rows);
+            await this.db.transaction('rw', this.db.kanji, async function() {
+                for (const [character, onyomi, kunyomi, tags, ...meanings] of entries) {
+                    this.db.kanji.add({
+                        character,
+                        onyomi,
+                        kunyomi,
+                        tags,
+                        meanings,
+                        dictionary: title
+                    });
+                }
+            });
         };
 
         await Database.importDictionaryZip(archive, indexLoaded, termsLoaded, kanjiLoaded);


### PR DESCRIPTION
Re-implementation of #66 for async, since I guess behaviour was reverted. Also applied it to kanji import.

(the underlying, I suppose I/O with IndexedDB, issue reappeared for me when I was importing terms after my database disappeared during 1.3.5 upgrade)

I tried to use `await this.db.terms.add()` here but that was leading to an `InvalidStateError`. I'm not sure whether the 'await` is necessary there or not.
For reference: http://dexie.org/docs/Dexie/Dexie.transaction()#async-and-await