### PR TITLE
Feature: result grouping by main dictionary sequence (along with some other changes)

### DIFF
--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -29,9 +29,11 @@ async function apiTermsFind(text) {
     const options = utilBackend().options;
     const translator = utilBackend().translator;
 
-    const searcher = (options.general.resultOutputMode === 'merge') && translator.findTermsMerged.bind(translator)
-        || (options.general.resultOutputMode === 'split') && translator.findTermsSplit.bind(translator)
-        || (options.general.resultOutputMode === 'group') && translator.findTermsGrouped.bind(translator);
+    const searcher = {
+        'merge': translator.findTermsMerged,
+        'split': translator.findTermsSplit,
+        'group': translator.findTermsGrouped
+    }[options.general.resultOutputMode].bind(translator);
 
     const {definitions, length} = await searcher(
         text,

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -29,9 +29,9 @@ async function apiTermsFind(text) {
     const options = utilBackend().options;
     const translator = utilBackend().translator;
 
-    const searcher = options.general.groupResults ?
-        translator.findTermsGrouped.bind(translator) :
-        translator.findTermsSplit.bind(translator);
+    const searcher = (options.general.resultOutputMode === 'merge') && translator.findTermsMerged.bind(translator)
+        || (options.general.resultOutputMode === 'split') && translator.findTermsSplit.bind(translator)
+        || (options.general.resultOutputMode === 'group') && translator.findTermsGrouped.bind(translator);
 
     const {definitions, length} = await searcher(
         text,

--- a/ext/bg/js/audio.js
+++ b/ext/bg/js/audio.js
@@ -140,8 +140,13 @@ async function audioInject(definition, fields, mode) {
     }
 
     try {
-        const url = await audioBuildUrl(definition, mode);
-        const filename = audioBuildFilename(definition);
+        let audioSourceDefinition = definition;
+        if (definition.hasOwnProperty('expressions')) {
+            audioSourceDefinition = definition.expressions[0];
+        }
+
+        const url = await audioBuildUrl(audioSourceDefinition, mode);
+        const filename = audioBuildFilename(audioSourceDefinition);
 
         if (url && filename) {
             definition.audio = {url, filename};

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -228,6 +228,21 @@ class Database {
         }
     }
 
+    async getTitlesWithSequences() {
+        if (!this.db) {
+            throw 'Database not initialized';
+        }
+
+        const titles = [];
+        await this.db.dictionaries.each(row => {
+            if (row.hasSequences) {
+                titles.push(row.title);
+            }
+        });
+
+        return titles;
+    }
+
     async importDictionary(archive, callback) {
         if (!this.db) {
             throw 'Database not initialized';

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -71,7 +71,7 @@ class Database {
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags),
+                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
                     termTags: dictFieldSplit(row.termTags || ''),
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
@@ -97,7 +97,7 @@ class Database {
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags),
+                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
                     termTags: dictFieldSplit(row.termTags || ''),
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
@@ -123,7 +123,7 @@ class Database {
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags),
+                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
                     termTags: dictFieldSplit(row.termTags || ''),
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -68,12 +68,11 @@ class Database {
         const results = [];
         await this.db.terms.where('expression').equals(term).or('reading').equals(term).each(row => {
             if (titles.includes(row.dictionary)) {
-                const tags = row.tags.split('\t');
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    tags: dictFieldSplit(tags[0]),
-                    termTags: tags.length > 1 ? dictFieldSplit(tags[1]) : [],
+                    definitionTags: dictFieldSplit(row.definitionTags),
+                    termTags: dictFieldSplit(row.termTags || ''),
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
                     score: row.score,
@@ -95,12 +94,11 @@ class Database {
         const results = [];
         await this.db.terms.where('sequence').equals(sequence).each(row => {
             if (row.dictionary === mainDictionary) {
-                const tags = row.tags.split('\t');
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    tags: dictFieldSplit(tags[0]),
-                    termTags: tags.length > 1 ? dictFieldSplit(tags[1]) : [],
+                    definitionTags: dictFieldSplit(row.definitionTags),
+                    termTags: dictFieldSplit(row.termTags || ''),
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
                     score: row.score,
@@ -229,11 +227,11 @@ class Database {
 
             const rows = [];
             if (summary.version === 1) {
-                for (const [expression, reading, tags, rules, score, ...glossary] of entries) {
+                for (const [expression, reading, definitionTags, rules, score, ...glossary] of entries) {
                     rows.push({
                         expression,
                         reading,
-                        tags,
+                        definitionTags,
                         rules,
                         score,
                         glossary,
@@ -241,15 +239,16 @@ class Database {
                     });
                 }
             } else {
-                for (const [expression, reading, tags, rules, score, glossary, sequence] of entries) {
+                for (const [expression, reading, definitionTags, rules, score, glossary, sequence, termTags] of entries) {
                     rows.push({
                         expression,
                         reading,
-                        tags,
+                        definitionTags,
                         rules,
                         score,
                         glossary,
                         sequence,
+                        termTags,
                         dictionary: summary.title
                     });
                 }

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -85,25 +85,26 @@ class Database {
         return results;
     }
 
-    async findTermsBySequence(sequence, dictionary) {
+    async findTermsBySequence(sequence, mainDictionary) {
         if (!this.db) {
             throw 'Database not initialized';
         }
 
         const results = [];
         await this.db.terms.where('sequence').equals(sequence).each(row => {
-            // if (dictionary === row.dictionary) {
-            results.push({
-                expression: row.expression,
-                reading: row.reading,
-                tags: dictFieldSplit(row.tags),
-                rules: dictFieldSplit(row.rules),
-                glossary: row.glossary,
-                score: row.score,
-                dictionary: row.dictionary,
-                id: row.id,
-                sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
-            });
+            if (row.dictionary === mainDictionary) {
+                results.push({
+                    expression: row.expression,
+                    reading: row.reading,
+                    tags: dictFieldSplit(row.tags),
+                    rules: dictFieldSplit(row.rules),
+                    glossary: row.glossary,
+                    score: row.score,
+                    dictionary: row.dictionary,
+                    id: row.id,
+                    sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
+                });
+            }
         });
 
         return results;

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -86,6 +86,32 @@ class Database {
         return results;
     }
 
+    async findTermsExact(term, reading, titles) {
+        if (!this.db) {
+            throw 'Database not initialized';
+        }
+
+        const results = [];
+        await this.db.terms.where('expression').equals(term).each(row => {
+            if (row.reading === reading && titles.includes(row.dictionary)) {
+                results.push({
+                    expression: row.expression,
+                    reading: row.reading,
+                    definitionTags: dictFieldSplit(row.definitionTags),
+                    termTags: dictFieldSplit(row.termTags || ''),
+                    rules: dictFieldSplit(row.rules),
+                    glossary: row.glossary,
+                    score: row.score,
+                    dictionary: row.dictionary,
+                    id: row.id,
+                    sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
+                });
+            }
+        });
+
+        return results;
+    }
+
     async findTermsBySequence(sequence, mainDictionary) {
         if (!this.db) {
             throw 'Database not initialized';

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -208,7 +208,7 @@ class Database {
                     });
                 }
             } else {
-                for (const [expression, reading, tags, rules, score, glossary] of entries) {
+                for (const [expression, reading, tags, rules, score, glossary, sequence] of entries) {
                     rows.push({
                         expression,
                         reading,
@@ -216,6 +216,7 @@ class Database {
                         rules,
                         score,
                         glossary,
+                        sequence,
                         dictionary: summary.title
                     });
                 }

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -68,10 +68,12 @@ class Database {
         const results = [];
         await this.db.terms.where('expression').equals(term).or('reading').equals(term).each(row => {
             if (titles.includes(row.dictionary)) {
+                const tags = row.tags.split('\t');
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    tags: dictFieldSplit(row.tags),
+                    tags: dictFieldSplit(tags[0]),
+                    termTags: tags.length > 1 ? dictFieldSplit(tags[1]) : [],
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
                     score: row.score,
@@ -93,10 +95,12 @@ class Database {
         const results = [];
         await this.db.terms.where('sequence').equals(sequence).each(row => {
             if (row.dictionary === mainDictionary) {
+                const tags = row.tags.split('\t');
                 results.push({
                     expression: row.expression,
                     reading: row.reading,
-                    tags: dictFieldSplit(row.tags),
+                    tags: dictFieldSplit(tags[0]),
+                    termTags: tags.length > 1 ? dictFieldSplit(tags[1]) : [],
                     rules: dictFieldSplit(row.rules),
                     glossary: row.glossary,
                     score: row.score,

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -30,7 +30,7 @@ class Database {
 
         this.db = new Dexie('dict');
         this.db.version(2).stores({
-            terms:        '++id,dictionary,expression,reading',
+            terms:        '++id,dictionary,expression,reading,sequence',
             kanji:        '++,dictionary,character',
             tagMeta:      '++,dictionary',
             dictionaries: '++,title,version'
@@ -73,12 +73,35 @@ class Database {
                     glossary: row.glossary,
                     score: row.score,
                     dictionary: row.dictionary,
-                    id: row.id
+                    id: row.id,
+                    sequence: row.sequence
                 });
             }
         });
 
         return results;
+    }
+
+    async findEntry(sequence) {
+        if (!this.db) {
+            throw 'Database not initialized';
+        }
+
+        const entry = [];
+        await this.db.terms.where('sequence').equals(sequence).each(row => {
+            entry.push({
+                expression: row.expression,
+                reading: row.reading,
+                tags: dictFieldSplit(row.tags),
+                rules: dictFieldSplit(row.rules),
+                glossary: row.glossary,
+                score: row.score,
+                dictionary: row.dictionary,
+                id: row.id
+            });
+        });
+
+        return entry;
     }
 
     async findTermMeta(term, titles) {

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -359,12 +359,13 @@ class Database {
             }
 
             const rows = [];
-            for (const [name, category, order, notes] of entries) {
+            for (const [name, category, order, notes, score] of entries) {
                 const row = dictTagSanitize({
                     name,
                     category,
                     order,
                     notes,
+                    score,
                     dictionary: summary.title
                 });
 
@@ -449,7 +450,7 @@ class Database {
             const bank = [];
             for (const name in index.tagMeta) {
                 const tag = index.tagMeta[name];
-                bank.push([name, tag.category, tag.order, tag.notes]);
+                bank.push([name, tag.category, tag.order, tag.notes, tag.score]);
             }
 
             tagDataLoaded(summary, bank, ++bankTotalCount, bankLoadedCount++);

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -368,7 +368,8 @@ async function dictFieldFormat(field, definition, mode, options) {
             merge: options.general.resultOutputMode === 'merge',
             modeTermKanji: mode === 'term-kanji',
             modeTermKana: mode === 'term-kana',
-            modeKanji: mode === 'kanji'
+            modeKanji: mode === 'kanji',
+            compactGlossaries: options.general.compactGlossaries
         };
 
         const html = await apiTemplateRender(options.anki.fieldTemplates, data, true);

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -124,6 +124,7 @@ function dictTermsCompressTags(definitions) {
             filterOutCategories.push('dictionary');
         } else {
             lastDictionary = dictionary;
+            lastPos = '';
         }
 
         if (lastPos === pos) {

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -112,11 +112,11 @@ function dictTermsUndupe(definitions) {
 
 function dictTermsCompressTags(definitions) {
     let lastDictionary = '';
-    let lastPos = '';
+    let lastPartOfSpeech = '';
 
     for (const definition of definitions) {
         const dictionary = JSON.stringify(definition.definitionTags.filter(tag => tag.category === 'dictionary').map(tag => tag.name).sort());
-        const pos = JSON.stringify(definition.definitionTags.filter(tag => tag.category === 'pos').map(tag => tag.name).sort());
+        const partOfSpeech = JSON.stringify(definition.definitionTags.filter(tag => tag.category === 'partOfSpeech').map(tag => tag.name).sort());
 
         const filterOutCategories = [];
 
@@ -124,13 +124,13 @@ function dictTermsCompressTags(definitions) {
             filterOutCategories.push('dictionary');
         } else {
             lastDictionary = dictionary;
-            lastPos = '';
+            lastPartOfSpeech = '';
         }
 
-        if (lastPos === pos) {
-            filterOutCategories.push('pos');
+        if (lastPartOfSpeech === partOfSpeech) {
+            filterOutCategories.push('partOfSpeech');
         } else {
-            lastPos = pos;
+            lastPartOfSpeech = partOfSpeech;
         }
 
         definition.definitionTags = definition.definitionTags.filter(tag => !filterOutCategories.includes(tag.category));

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -227,7 +227,6 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
 
         for (const tag of definition.tags) {
             if (dictIsJmdictTermTag(tag)) {
-                // TODO: expand tags
                 result.expressions.get(definition.expression).get(definition.reading).add(tag);
             } else {
                 definitionsByGloss[gloss].tags.add(tag);

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -89,7 +89,7 @@ function dictTermsSort(definitions, dictionaries=null) {
             return 1;
         }
 
-        return v2.expression.localeCompare(v1.expression);
+        return v2.expression.toString().localeCompare(v1.expression.toString());
     });
 }
 

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -144,10 +144,10 @@ function dictTermsGroup(definitions, dictionaries) {
     return dictTermsSort(results);
 }
 
-function dictTermsMergeBySequence(definitions) {
+function dictTermsMergeBySequence(definitions, mainDictionary) {
     const definitionsBySequence = {'-1': []};
     for (const definition of definitions) {
-        if (definition.sequence > 0) {
+        if (mainDictionary === definition.dictionary && definition.sequence > 0) {
             if (!definitionsBySequence[definition.sequence]) {
                 definitionsBySequence[definition.sequence] = {
                     reasons: definition.reasons,

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -196,7 +196,7 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
             }
         }
 
-        const gloss = JSON.stringify(definition.glossary);
+        const gloss = JSON.stringify(definition.glossary.concat(definition.dictionary));
         if (!definitionsByGloss[gloss]) {
             definitionsByGloss[gloss] = {
                 expression: new Set(),

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -229,7 +229,7 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
             definitionsByGloss[gloss] = {
                 expression: new Set(),
                 reading: new Set(),
-                definitionTags: new Set(),
+                definitionTags: [],
                 glossary: definition.glossary,
                 source: result.source,
                 reasons: [],
@@ -254,10 +254,8 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
         }
 
         for (const tag of definition.definitionTags) {
-            if (typeof tag === 'string') {
-                definitionsByGloss[gloss].definitionTags.add(tag);
-            } else if (tag.category && tag.category !== 'dictionary') {
-                definitionsByGloss[gloss].definitionTags.add(tag.name);
+            if (!definitionsByGloss[gloss].definitionTags.find(existingTag => existingTag.name === tag.name)) {
+                definitionsByGloss[gloss].definitionTags.push(tag);
             }
         }
 

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -207,7 +207,8 @@ async function dictFieldFormat(field, definition, mode, options) {
         const data = {
             marker,
             definition,
-            group: options.general.groupResults,
+            group: options.general.resultOutputMode === 'group',
+            merge: options.general.resultOutputMode === 'merge',
             modeTermKanji: mode === 'term-kanji',
             modeTermKana: mode === 'term-kana',
             modeKanji: mode === 'kanji'

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -175,7 +175,7 @@ function dictTermsGroup(definitions, dictionaries) {
 function dictTermsMergeBySequence(definitions, mainDictionary) {
     const definitionsBySequence = {'-1': []};
     for (const definition of definitions) {
-        if (mainDictionary === definition.dictionary && definition.sequence > 0) {
+        if (mainDictionary === definition.dictionary && definition.sequence >= 0) {
             if (!definitionsBySequence[definition.sequence]) {
                 definitionsBySequence[definition.sequence] = {
                     reasons: definition.reasons,

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -110,6 +110,32 @@ function dictTermsUndupe(definitions) {
     return definitionsUnique;
 }
 
+function dictTermsCompressTags(definitions) {
+    let lastDictionary = '';
+    let lastPos = '';
+
+    for (const definition of definitions) {
+        const dictionary = JSON.stringify(definition.tags.filter(tag => tag.category === 'dictionary').map(tag => tag.name).sort());
+        const pos = JSON.stringify(definition.tags.filter(tag => tag.category === 'pos').map(tag => tag.name).sort());
+
+        const filterOutCategories = [];
+
+        if (lastDictionary === dictionary) {
+            filterOutCategories.push('dictionary');
+        } else {
+            lastDictionary = dictionary;
+        }
+
+        if (lastPos === pos) {
+            filterOutCategories.push('pos');
+        } else {
+            lastPos = pos;
+        }
+
+        definition.tags = definition.tags.filter(tag => !filterOutCategories.includes(tag.category));
+    }
+}
+
 function dictTermsGroup(definitions, dictionaries) {
     const groups = {};
     for (const definition of definitions) {

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -228,8 +228,10 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
         for (const tag of definition.tags) {
             if (dictIsJmdictTermTag(tag)) {
                 result.expressions.get(definition.expression).get(definition.reading).add(tag);
-            } else {
+            } else if (typeof tag === 'string') {
                 definitionsByGloss[gloss].tags.add(tag);
+            } else if (tag.category && tag.category !== 'dictionary') {
+                definitionsByGloss[gloss].tags.add(tag.name);
             }
         }
     }

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -136,6 +136,7 @@ function dictTermsGroup(definitions, dictionaries) {
             expression: firstDef.expression,
             reading: firstDef.reading,
             reasons: firstDef.reasons,
+            termTags: groupDefs[0].termTags,
             score: groupDefs.reduce((p, v) => v.score > p ? v.score : p, Number.MIN_SAFE_INTEGER),
             source: firstDef.source
         });
@@ -226,13 +227,15 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
         }
 
         for (const tag of definition.tags) {
-            if (dictIsJmdictTermTag(tag)) {
-                result.expressions.get(definition.expression).get(definition.reading).add(tag);
-            } else if (typeof tag === 'string') {
+            if (typeof tag === 'string') {
                 definitionsByGloss[gloss].tags.add(tag);
             } else if (tag.category && tag.category !== 'dictionary') {
                 definitionsByGloss[gloss].tags.add(tag.name);
             }
+        }
+
+        for (const tag of definition.termTags) {
+            result.expressions.get(definition.expression).get(definition.reading).add(tag);
         }
     }
 
@@ -288,34 +291,12 @@ function dictTagsSort(tags) {
     });
 }
 
-function dictIsJmdictTermTag(tag) {
-    return [
-        'P',
-        'news',
-        'ichi',
-        'spec',
-        'gai',
-        'ik',
-        'iK',
-        'ok',
-        'oK',
-        'ek',
-        'eK',
-        'io',
-        'oik',
-        'ateji',
-        'gikun'
-    ].includes(tag);
-}
-
 function dictJmdictTermTagsRare(tags) {
     const rareTags = [
         'ik',
         'iK',
         'ok',
         'oK',
-        'ek',
-        'eK',
         'io',
         'oik'
     ];

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -293,6 +293,7 @@ function dictTagSanitize(tag) {
     tag.category = tag.category || 'default';
     tag.notes = tag.notes || '';
     tag.order = tag.order || 0;
+    tag.score = tag.score || 0;
     return tag;
 }
 
@@ -316,26 +317,6 @@ function dictTagsSort(tags) {
 
         return 0;
     });
-}
-
-function dictTermTagScore(tags) {
-    let score = 0;
-
-    const tagScores = {
-        'ik': -5,
-        'iK': -5,
-        'ok': -5,
-        'oK': -5,
-        'io': -5,
-        'oik': -5,
-        'P': 10
-    };
-
-    for (const tag of tags) {
-        score += tagScores[tag] || 0;
-    }
-
-    return score;
 }
 
 function dictFieldSplit(field) {

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -318,21 +318,24 @@ function dictTagsSort(tags) {
     });
 }
 
-function dictJmdictTermTagsRare(tags) {
-    const rareTags = [
-        'ik',
-        'iK',
-        'ok',
-        'oK',
-        'io',
-        'oik'
-    ];
+function dictTermTagScore(tags) {
+    let score = 0;
+
+    const tagScores = {
+        'ik': -5,
+        'iK': -5,
+        'ok': -5,
+        'oK': -5,
+        'io': -5,
+        'oik': -5,
+        'P': 10
+    };
+
     for (const tag of tags) {
-        if (rareTags.includes(tag)) {
-            return true;
-        }
+        score += tagScores[tag] || 0;
     }
-    return false;
+
+    return score;
 }
 
 function dictFieldSplit(field) {

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -115,8 +115,8 @@ function dictTermsCompressTags(definitions) {
     let lastPos = '';
 
     for (const definition of definitions) {
-        const dictionary = JSON.stringify(definition.tags.filter(tag => tag.category === 'dictionary').map(tag => tag.name).sort());
-        const pos = JSON.stringify(definition.tags.filter(tag => tag.category === 'pos').map(tag => tag.name).sort());
+        const dictionary = JSON.stringify(definition.definitionTags.filter(tag => tag.category === 'dictionary').map(tag => tag.name).sort());
+        const pos = JSON.stringify(definition.definitionTags.filter(tag => tag.category === 'pos').map(tag => tag.name).sort());
 
         const filterOutCategories = [];
 
@@ -133,7 +133,7 @@ function dictTermsCompressTags(definitions) {
             lastPos = pos;
         }
 
-        definition.tags = definition.tags.filter(tag => !filterOutCategories.includes(tag.category));
+        definition.definitionTags = definition.definitionTags.filter(tag => !filterOutCategories.includes(tag.category));
     }
 }
 
@@ -229,7 +229,7 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
             definitionsByGloss[gloss] = {
                 expression: new Set(),
                 reading: new Set(),
-                tags: new Set(),
+                definitionTags: new Set(),
                 glossary: definition.glossary,
                 source: result.source,
                 reasons: [],
@@ -253,11 +253,11 @@ function dictTermsMergeByGloss(result, definitions, appendTo, mergedIndices) {
             result.expressions.get(definition.expression).set(definition.reading, new Set());
         }
 
-        for (const tag of definition.tags) {
+        for (const tag of definition.definitionTags) {
             if (typeof tag === 'string') {
-                definitionsByGloss[gloss].tags.add(tag);
+                definitionsByGloss[gloss].definitionTags.add(tag);
             } else if (tag.category && tag.category !== 'dictionary') {
-                definitionsByGloss[gloss].tags.add(tag.name);
+                definitionsByGloss[gloss].definitionTags.add(tag.name);
             }
         }
 

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -71,16 +71,6 @@ function handlebarsKanjiLinks(options) {
     return result;
 }
 
-function handlebarsExpressions(options) {
-    const definition = options.fn(this);
-    return definition.expression;
-}
-
-function handlebarsReadings(options) {
-    const definition = options.fn(this);
-    return definition.reading;
-}
-
 function handlebarsMultiLine(options) {
     return options.fn(this).split('\n').join('<br>');
 }
@@ -93,8 +83,6 @@ function handlebarsRegisterHelpers() {
         Handlebars.registerHelper('furiganaPlain', handlebarsFuriganaPlain);
         Handlebars.registerHelper('kanjiLinks', handlebarsKanjiLinks);
         Handlebars.registerHelper('multiLine', handlebarsMultiLine);
-        Handlebars.registerHelper('expressions', handlebarsExpressions);
-        Handlebars.registerHelper('readings', handlebarsReadings);
     }
 }
 

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -75,6 +75,18 @@ function handlebarsMultiLine(options) {
     return options.fn(this).split('\n').join('<br>');
 }
 
+function handlebarsTermFrequencyColor(options) {
+    const termFrequency = options.fn(this);
+
+    if (termFrequency === 'popular') {
+        return '#0275d8';
+    } else if (termFrequency === 'rare') {
+        return '#999';
+    } else {
+        return 'inherit';
+    }
+}
+
 function handlebarsRegisterHelpers() {
     if (Handlebars.partials !== Handlebars.templates) {
         Handlebars.partials = Handlebars.templates;
@@ -83,6 +95,7 @@ function handlebarsRegisterHelpers() {
         Handlebars.registerHelper('furiganaPlain', handlebarsFuriganaPlain);
         Handlebars.registerHelper('kanjiLinks', handlebarsKanjiLinks);
         Handlebars.registerHelper('multiLine', handlebarsMultiLine);
+        Handlebars.registerHelper('termFrequencyColor', handlebarsTermFrequencyColor);
     }
 }
 

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -75,18 +75,6 @@ function handlebarsMultiLine(options) {
     return options.fn(this).split('\n').join('<br>');
 }
 
-function handlebarsTermFrequencyColor(options) {
-    const termFrequency = options.fn(this);
-
-    if (termFrequency === 'popular') {
-        return '#0275d8';
-    } else if (termFrequency === 'rare') {
-        return '#999';
-    } else {
-        return 'inherit';
-    }
-}
-
 function handlebarsRegisterHelpers() {
     if (Handlebars.partials !== Handlebars.templates) {
         Handlebars.partials = Handlebars.templates;
@@ -95,7 +83,6 @@ function handlebarsRegisterHelpers() {
         Handlebars.registerHelper('furiganaPlain', handlebarsFuriganaPlain);
         Handlebars.registerHelper('kanjiLinks', handlebarsKanjiLinks);
         Handlebars.registerHelper('multiLine', handlebarsMultiLine);
-        Handlebars.registerHelper('termFrequencyColor', handlebarsTermFrequencyColor);
     }
 }
 

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -71,6 +71,16 @@ function handlebarsKanjiLinks(options) {
     return result;
 }
 
+function handlebarsExpressions(options) {
+    const definition = options.fn(this);
+    return definition.expression;
+}
+
+function handlebarsReadings(options) {
+    const definition = options.fn(this);
+    return definition.reading;
+}
+
 function handlebarsMultiLine(options) {
     return options.fn(this).split('\n').join('<br>');
 }
@@ -83,6 +93,8 @@ function handlebarsRegisterHelpers() {
         Handlebars.registerHelper('furiganaPlain', handlebarsFuriganaPlain);
         Handlebars.registerHelper('kanjiLinks', handlebarsKanjiLinks);
         Handlebars.registerHelper('multiLine', handlebarsMultiLine);
+        Handlebars.registerHelper('expressions', handlebarsExpressions);
+        Handlebars.registerHelper('readings', handlebarsReadings);
     }
 }
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -154,6 +154,10 @@ function optionsSetDefaults(options) {
 
         dictionaries: {},
 
+        dictionary: {
+            main: ''
+        },
+
         anki: {
             enable: false,
             server: 'http://127.0.0.1:8765',

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -203,7 +203,8 @@ function optionsSetDefaults(options) {
             popupOffset: 10,
             showGuide: true,
             compactTags: false,
-            compactGlossaries: false
+            compactGlossaries: false,
+            mainDictionary: ''
         },
 
         scanning: {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -269,11 +269,15 @@ function optionsVersion(options) {
             }
             options.general.compactTags = false;
             options.general.compactGlossaries = false;
-            options.anki.fieldTemplates = '{{#if merge}}\n' +
-                                        optionsFieldTemplates() +
-                                        '\n{{else}}\n' +
-                                        options.anki.fieldTemplates +
-                                        '\n{{/if}}';
+            if (utilStringHashCode(options.anki.fieldTemplates) !== -1895236672) { // a3c8508031a1073629803d0616a2ee416cd3cccc
+                options.anki.fieldTemplates = '{{#if merge}}\n' +
+                                            optionsFieldTemplates() +
+                                            '\n{{else}}\n' +
+                                            options.anki.fieldTemplates +
+                                            '\n{{/if}}';
+            } else {
+                options.anki.fieldTemplates = optionsFieldTemplates();
+            }
         }
     ];
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -50,17 +50,17 @@ function optionsFieldTemplates() {
         {{~#if modeTermKana~}}
             {{~#each definition.reading~}}
                 {{{.}}}
-                {{~#unless @last}}, {{/unless~}}
+                {{~#unless @last}}、{{/unless~}}
             {{~else~}}
                 {{~#each definition.expression~}}
                     {{{.}}}
-                    {{~#unless @last}}, {{/unless~}}
+                    {{~#unless @last}}、{{/unless~}}
                 {{~/each~}}
             {{~/each~}}
         {{~else~}}
             {{~#each definition.expression~}}
                 {{{.}}}
-                {{~#unless @last}}, {{/unless~}}
+                {{~#unless @last}}、{{/unless~}}
             {{~/each~}}
         {{~/if~}}
     {{~else~}}
@@ -80,7 +80,7 @@ function optionsFieldTemplates() {
     {{~#if merge~}}
         {{~#each definition.expressions~}}
             {{~#furigana}}{{{.}}}{{/furigana~}}
-            {{~#unless @last}}, {{/unless~}}
+            {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}
         {{#furigana}}{{{definition}}}{{/furigana}}
@@ -91,7 +91,7 @@ function optionsFieldTemplates() {
     {{~#if merge~}}
         {{~#each definition.expressions~}}
             {{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}
-            {{~#unless @last}}, {{/unless~}}
+            {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}
         {{#furiganaPlain}}{{{definition}}}{{/furiganaPlain}}
@@ -143,7 +143,7 @@ function optionsFieldTemplates() {
         {{~#if merge~}}
             {{~#each definition.reading~}}
                 {{{.}}}
-                {{~#unless @last}}, {{/unless~}}
+                {{~#unless @last}}、{{/unless~}}
             {{~/each~}}
         {{~else~}}
             {{~definition.reading~}}

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -205,6 +205,13 @@ function optionsVersion(options) {
             } else {
                 options.scanning.modifier = 'none';
             }
+        },
+        () => {
+            if (options.general.groupResults) {
+                options.general.resultOutputMode = 'group';
+            } else {
+                options.general.resultOutputMode = 'split';
+            }
         }
     ];
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -269,6 +269,14 @@ function optionsVersion(options) {
             }
             options.general.compactTags = false;
             options.general.compactGlossaries = false;
+            if (options.anki.fieldTemplates !== optionsFieldTemplates()) {
+                options.anki.fieldTemplates = '{{#if merge}}\n' +
+                                            optionsFieldTemplates() +
+                                            '\n{{else}}\n' +
+                                            options.anki.fieldTemplates +
+                                            '\n{{/if}}';
+
+            }
         }
     ];
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -154,10 +154,6 @@ function optionsSetDefaults(options) {
 
         dictionaries: {},
 
-        dictionary: {
-            main: ''
-        },
-
         anki: {
             enable: false,
             server: 'http://127.0.0.1:8765',

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -141,7 +141,7 @@ function optionsSetDefaults(options) {
             popupOffset: 10,
             showGuide: true,
             compactTags: false,
-            tagLineBreak: false,
+            tagLineBreak: true,
             compactGlossaries: false
         },
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -277,14 +277,14 @@ function optionsVersion(options) {
             } else {
                 options.general.resultOutputMode = 'split';
             }
-            options.general.compactTags = false;
-            options.general.compactGlossaries = false;
             if (utilStringHashCode(options.anki.fieldTemplates) !== -805327496) { // a3c8508031a1073629803d0616a2ee416cd3cccc
-                options.anki.fieldTemplates = '{{#if merge}}\n' +
-                                            optionsFieldTemplates() +
-                                            '\n{{else}}\n' +
-                                            options.anki.fieldTemplates +
-                                            '\n{{/if}}';
+                options.anki.fieldTemplates = `
+{{#if merge}}
+${optionsFieldTemplates()}
+{{else}}
+${options.anki.fieldTemplates}
+{{/if}}
+`.trim();
             } else {
                 options.anki.fieldTemplates = optionsFieldTemplates();
             }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -90,7 +90,7 @@ function optionsFieldTemplates() {
 {{#*inline "furigana-plain"}}
     {{~#if merge~}}
         {{~#each definition.expressions~}}
-            {{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}
+            <span style="color: {{#termFrequencyColor}}{{termFrequency}}{{/termFrequencyColor}}">{{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}</span>
             {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -19,6 +19,15 @@
 
 function optionsFieldTemplates() {
     return `
+<style>
+.expression-popular {
+    color: #0275d8;
+}
+
+.expression-rare {
+    color: #999;
+}
+</style>
 {{#*inline "glossary-single"}}
     {{~#unless brief~}}
         {{~#if definitionTags~}}<i>({{#each definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
@@ -79,7 +88,7 @@ function optionsFieldTemplates() {
 {{#*inline "furigana"}}
     {{~#if merge~}}
         {{~#each definition.expressions~}}
-            <span style="color: {{#termFrequencyColor}}{{termFrequency}}{{/termFrequencyColor}}">{{~#furigana}}{{{.}}}{{/furigana~}}</span>
+            <span class="expression-{{termFrequency}}">{{~#furigana}}{{{.}}}{{/furigana~}}</span>
             {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}
@@ -90,7 +99,7 @@ function optionsFieldTemplates() {
 {{#*inline "furigana-plain"}}
     {{~#if merge~}}
         {{~#each definition.expressions~}}
-            <span style="color: {{#termFrequencyColor}}{{termFrequency}}{{/termFrequencyColor}}">{{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}</span>
+            <span class="expression-{{termFrequency}}">{{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}</span>
             {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -79,7 +79,7 @@ function optionsFieldTemplates() {
 {{#*inline "furigana"}}
     {{~#if merge~}}
         {{~#each definition.expressions~}}
-            {{~#furigana}}{{{.}}}{{/furigana~}}
+            <span style="color: {{#termFrequencyColor}}{{termFrequency}}{{/termFrequencyColor}}">{{~#furigana}}{{{.}}}{{/furigana~}}</span>
             {{~#unless @last}}、{{/unless~}}
         {{~/each~}}
     {{~else~}}

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -21,10 +21,15 @@ function optionsFieldTemplates() {
     return `
 {{#*inline "glossary-single"}}
     {{~#unless brief~}}
-        {{~#if tags~}}<i>({{#each tags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
+        {{~#if definitionTags~}}<i>({{#each definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
+        {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
     {{~/unless~}}
     {{~#if glossary.[1]~}}
-        <ul>{{#each glossary}}<li>{{#multiLine}}{{.}}{{/multiLine}}</li>{{/each}}</ul>
+        {{~#if compactGlossaries~}}
+            {{#each glossary}}{{#multiLine}}{{.}}{{/multiLine}}{{#unless @last}} | {{/unless}}{{/each}}
+        {{~else~}}
+            <ul>{{#each glossary}}<li>{{#multiLine}}{{.}}{{/multiLine}}</li>{{/each}}</ul>
+        {{~/if~}}
     {{~else~}}
         {{~#multiLine}}{{glossary.[0]}}{{/multiLine~}}
     {{~/if~}}
@@ -41,23 +46,56 @@ function optionsFieldTemplates() {
 {{/inline}}
 
 {{#*inline "expression"}}
-    {{~#if modeTermKana~}}
-        {{~#if definition.reading~}}
-            {{definition.reading}}
+    {{~#if merge~}}
+        {{~#if modeTermKana~}}
+            {{~#each definition.reading~}}
+                {{{.}}}
+                {{~#unless @last}}, {{/unless~}}
+            {{~else~}}
+                {{~#each definition.expression~}}
+                    {{{.}}}
+                    {{~#unless @last}}, {{/unless~}}
+                {{~/each~}}
+            {{~/each~}}
+        {{~else~}}
+            {{~#each definition.expression~}}
+                {{{.}}}
+                {{~#unless @last}}, {{/unless~}}
+            {{~/each~}}
+        {{~/if~}}
+    {{~else~}}
+        {{~#if modeTermKana~}}
+            {{~#if definition.reading~}}
+                {{definition.reading}}
+            {{~else~}}
+                {{definition.expression}}
+            {{~/if~}}
         {{~else~}}
             {{definition.expression}}
         {{~/if~}}
-    {{~else~}}
-        {{definition.expression}}
     {{~/if~}}
 {{/inline}}
 
 {{#*inline "furigana"}}
-    {{#furigana}}{{{definition}}}{{/furigana}}
+    {{~#if merge~}}
+        {{~#each definition.expressions~}}
+            {{~#furigana}}{{{.}}}{{/furigana~}}
+            {{~#unless @last}}, {{/unless~}}
+        {{~/each~}}
+    {{~else~}}
+        {{#furigana}}{{{definition}}}{{/furigana}}
+    {{~/if~}}
 {{/inline}}
 
 {{#*inline "furigana-plain"}}
-    {{#furiganaPlain}}{{{definition}}}{{/furiganaPlain}}
+    {{~#if merge~}}
+        {{~#each definition.expressions~}}
+            {{~#furiganaPlain}}{{{.}}}{{/furiganaPlain~}}
+            {{~#unless @last}}, {{/unless~}}
+        {{~/each~}}
+    {{~else~}}
+        {{#furiganaPlain}}{{{definition}}}{{/furiganaPlain}}
+    {{~/if~}}
 {{/inline}}
 
 {{#*inline "glossary"}}
@@ -71,12 +109,18 @@ function optionsFieldTemplates() {
     {{~else~}}
         {{~#if group~}}
             {{~#if definition.definitions.[1]~}}
-                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief}}</li>{{/each}}</ol>
+                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries}}</li>{{/each}}</ol>
             {{~else~}}
-                {{~> glossary-single definition.definitions.[0] brief=brief~}}
+                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries~}}
+            {{~/if~}}
+        {{~else if merge~}}
+            {{~#if definition.definitions.[1]~}}
+                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries}}</li>{{/each}}</ol>
+            {{~else~}}
+                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries~}}
             {{~/if~}}
         {{~else~}}
-            {{~> glossary-single definition brief=brief~}}
+            {{~> glossary-single definition brief=brief compactGlossaries=compactGlossaries~}}
         {{~/if~}}
     {{~/if~}}
     </div>
@@ -95,7 +139,16 @@ function optionsFieldTemplates() {
 {{/inline}}
 
 {{#*inline "reading"}}
-    {{~#unless modeTermKana}}{{definition.reading}}{{/unless~}}
+    {{~#unless modeTermKana~}}
+        {{~#if merge~}}
+            {{~#each definition.reading~}}
+                {{{.}}}
+                {{~#unless @last}}, {{/unless~}}
+            {{~/each~}}
+        {{~else~}}
+            {{~definition.reading~}}
+        {{~/if~}}
+    {{~/unless~}}
 {{/inline}}
 
 {{#*inline "sentence"}}
@@ -115,7 +168,7 @@ function optionsFieldTemplates() {
 {{/inline}}
 
 {{#*inline "tags"}}
-    {{~#each definition.tags}}{{name}}{{#unless @last}}, {{/unless}}{{/each~}}
+    {{~#each definition.definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each~}}
 {{/inline}}
 
 {{#*inline "url"}}

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -140,7 +140,9 @@ function optionsSetDefaults(options) {
             popupHeight: 250,
             popupOffset: 10,
             showGuide: true,
-            compactTags: false
+            compactTags: false,
+            tagLineBreak: false,
+            compactGlossaries: false
         },
 
         scanning: {
@@ -213,6 +215,9 @@ function optionsVersion(options) {
             } else {
                 options.general.resultOutputMode = 'split';
             }
+            options.general.compactTags = false;
+            options.general.tagLineBreak = true;
+            options.general.compactGlossaries = false;
         }
     ];
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -269,7 +269,7 @@ function optionsVersion(options) {
             }
             options.general.compactTags = false;
             options.general.compactGlossaries = false;
-            if (utilStringHashCode(options.anki.fieldTemplates) !== -1895236672) { // a3c8508031a1073629803d0616a2ee416cd3cccc
+            if (utilStringHashCode(options.anki.fieldTemplates) !== -805327496) { // a3c8508031a1073629803d0616a2ee416cd3cccc
                 options.anki.fieldTemplates = '{{#if merge}}\n' +
                                             optionsFieldTemplates() +
                                             '\n{{else}}\n' +

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -132,7 +132,7 @@ function optionsSetDefaults(options) {
             enable: true,
             audioSource: 'jpod101',
             audioVolume: 100,
-            groupResults: true,
+            resultOutputMode: 'group',
             debugInfo: false,
             maxResults: 32,
             showAdvanced: false,

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -141,7 +141,6 @@ function optionsSetDefaults(options) {
             popupOffset: 10,
             showGuide: true,
             compactTags: false,
-            tagLineBreak: true,
             compactGlossaries: false
         },
 
@@ -216,7 +215,6 @@ function optionsVersion(options) {
                 options.general.resultOutputMode = 'split';
             }
             options.general.compactTags = false;
-            options.general.tagLineBreak = true;
             options.general.compactGlossaries = false;
         }
     ];

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -269,14 +269,11 @@ function optionsVersion(options) {
             }
             options.general.compactTags = false;
             options.general.compactGlossaries = false;
-            if (options.anki.fieldTemplates !== optionsFieldTemplates()) {
-                options.anki.fieldTemplates = '{{#if merge}}\n' +
-                                            optionsFieldTemplates() +
-                                            '\n{{else}}\n' +
-                                            options.anki.fieldTemplates +
-                                            '\n{{/if}}';
-
-            }
+            options.anki.fieldTemplates = '{{#if merge}}\n' +
+                                        optionsFieldTemplates() +
+                                        '\n{{else}}\n' +
+                                        options.anki.fieldTemplates +
+                                        '\n{{/if}}';
         }
     ];
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -139,7 +139,8 @@ function optionsSetDefaults(options) {
             popupWidth: 400,
             popupHeight: 250,
             popupOffset: 10,
-            showGuide: true
+            showGuide: true,
+            compactTags: false
         },
 
         scanning: {

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -23,6 +23,8 @@ async function formRead() {
 
     optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
     optionsNew.general.compactTags = $('#compact-tags').prop('checked');
+    optionsNew.general.tagLineBreak = $('#tag-line-break').prop('checked');
+    optionsNew.general.compactGlossaries = $('#compact-glossaries').prop('checked');
     optionsNew.general.resultOutputMode = $('#result-output-mode').val();
     optionsNew.general.audioSource = $('#audio-playback-source').val();
     optionsNew.general.audioVolume = parseFloat($('#audio-playback-volume').val());
@@ -128,6 +130,8 @@ async function onReady() {
 
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
+    $('#tag-line-break').prop('checked', options.general.tagLineBreak);
+    $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
     $('#result-output-mode').val(options.general.resultOutputMode);
     $('#audio-playback-source').val(options.general.audioSource);
     $('#audio-playback-volume').val(options.general.audioVolume);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -111,7 +111,7 @@ async function formMainDictionaryOptionsPopulate(options) {
     titles = titles.filter(title => options.dictionaries[title].enabled);
     const formOptionsHtml = [];
     let mainDictionarySelected = false;
-    for (title of titles) {
+    for (const title of titles) {
         if (options.general.mainDictionary === title) {
             mainDictionarySelected = true;
         }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -22,9 +22,9 @@ async function formRead() {
     const optionsNew = $.extend(true, {}, optionsOld);
 
     optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
+    optionsNew.general.resultOutputMode = $('#result-output-mode').val();
     optionsNew.general.audioSource = $('#audio-playback-source').val();
     optionsNew.general.audioVolume = parseFloat($('#audio-playback-volume').val());
-    optionsNew.general.groupResults = $('#group-terms-results').prop('checked');
     optionsNew.general.debugInfo = $('#show-debug-info').prop('checked');
     optionsNew.general.showAdvanced = $('#show-advanced-options').prop('checked');
     optionsNew.general.maxResults = parseInt($('#max-displayed-results').val(), 10);
@@ -124,9 +124,9 @@ async function onReady() {
     const options = await optionsLoad();
 
     $('#show-usage-guide').prop('checked', options.general.showGuide);
+    $('#result-output-mode').val(options.general.resultOutputMode);
     $('#audio-playback-source').val(options.general.audioSource);
     $('#audio-playback-volume').val(options.general.audioVolume);
-    $('#group-terms-results').prop('checked', options.general.groupResults);
     $('#show-debug-info').prop('checked', options.general.debugInfo);
     $('#show-advanced-options').prop('checked', options.general.showAdvanced);
     $('#max-displayed-results').val(options.general.maxResults);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -22,6 +22,7 @@ async function formRead() {
     const optionsNew = $.extend(true, {}, optionsOld);
 
     optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
+    optionsNew.general.compactTags = $('#compact-tags').prop('checked');
     optionsNew.general.resultOutputMode = $('#result-output-mode').val();
     optionsNew.general.audioSource = $('#audio-playback-source').val();
     optionsNew.general.audioVolume = parseFloat($('#audio-playback-volume').val());
@@ -125,6 +126,7 @@ async function onReady() {
     const options = await optionsLoad();
 
     $('#show-usage-guide').prop('checked', options.general.showGuide);
+    $('#compact-tags').prop('checked', options.general.compactTags);
     $('#result-output-mode').val(options.general.resultOutputMode);
     $('#audio-playback-source').val(options.general.audioSource);
     $('#audio-playback-volume').val(options.general.audioVolume);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -61,9 +61,6 @@ async function formRead() {
         const priority = parseInt(dictionary.find('.dict-priority').val(), 10);
         const enabled = dictionary.find('.dict-enabled').prop('checked');
         const main = dictionary.find('.dict-main').prop('checked');
-        if (main) {
-            optionsNew.dictionary.main = title;
-        }
         optionsNew.dictionaries[title] = {priority, enabled, main};
     });
 
@@ -302,7 +299,6 @@ async function onDictionaryPurge(e) {
         await utilDatabasePurge();
         const options = await optionsLoad();
         options.dictionaries = {};
-        options.dictionary.main = '';
         await optionsSave(options);
 
         await dictionaryGroupsPopulate(options);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -62,7 +62,8 @@ async function formRead() {
         const priority = parseInt(dictionary.find('.dict-priority').val(), 10);
         const enabled = dictionary.find('.dict-enabled').prop('checked');
         const main = dictionary.find('.dict-main').prop('checked');
-        optionsNew.dictionaries[title] = {priority, enabled, main};
+        const allowSecondarySearches = dictionary.find('.dict-allow-secondary-searches').prop('checked');
+        optionsNew.dictionaries[title] = {priority, enabled, main, allowSecondarySearches};
     });
 
     return {optionsNew, optionsOld};
@@ -262,14 +263,15 @@ async function dictionaryGroupsPopulate(options) {
     }
 
     for (const dictRow of dictRowsSort(dictRows, options)) {
-        const dictOptions = options.dictionaries[dictRow.title] || {enabled: false, priority: 0, main: false};
+        const dictOptions = options.dictionaries[dictRow.title] || {enabled: false, priority: 0, main: false, allowSecondarySearches: false};
         const dictHtml = await apiTemplateRender('dictionary.html', {
             title: dictRow.title,
             version: dictRow.version,
             revision: dictRow.revision,
             priority: dictOptions.priority,
             enabled: dictOptions.enabled,
-            main: dictOptions.main
+            main: dictOptions.main,
+            allowSecondarySearches: dictOptions.allowSecondarySearches
         });
 
         dictGroups.append($(dictHtml));
@@ -277,7 +279,7 @@ async function dictionaryGroupsPopulate(options) {
 
     formUpdateVisibility(options);
 
-    $('.dict-enabled, .dict-priority').change(e => {
+    $('.dict-enabled, .dict-priority, .dict-allow-secondary-searches').change(e => {
         dictionaryGroupsSort();
         onFormOptionsChanged(e);
     });
@@ -329,7 +331,7 @@ async function onDictionaryImport(e) {
 
         const options = await optionsLoad();
         const summary = await utilDatabaseImport(e.target.files[0], updateProgress);
-        options.dictionaries[summary.title] = {enabled: true, priority: 0, main: false};
+        options.dictionaries[summary.title] = {enabled: true, priority: 0, main: false, allowSecondarySearches: false};
         await optionsSave(options);
 
         await dictionaryGroupsPopulate(options);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -23,7 +23,6 @@ async function formRead() {
 
     optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
     optionsNew.general.compactTags = $('#compact-tags').prop('checked');
-    optionsNew.general.tagLineBreak = $('#tag-line-break').prop('checked');
     optionsNew.general.compactGlossaries = $('#compact-glossaries').prop('checked');
     optionsNew.general.resultOutputMode = $('#result-output-mode').val();
     optionsNew.general.audioSource = $('#audio-playback-source').val();
@@ -130,7 +129,6 @@ async function onReady() {
 
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
-    $('#tag-line-break').prop('checked', options.general.tagLineBreak);
     $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
     $('#result-output-mode').val(options.general.resultOutputMode);
     $('#audio-playback-source').val(options.general.audioSource);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -122,7 +122,7 @@ async function formMainDictionaryOptionsPopulate(options) {
         options.general.mainDictionary = '';
     }
 
-    const notSelectedOptionHtml = `<option value=""${!mainDictionarySelected ? ' selected' : ''}>(Not selected)</option>`;
+    const notSelectedOptionHtml = `<option class="text-muted" value=""${!mainDictionarySelected ? ' selected' : ''}>Not selected</option>`;
 
     select.append($([notSelectedOptionHtml].concat(formOptionsHtml).join('')));
 }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -302,6 +302,7 @@ async function onDictionaryPurge(e) {
         await utilDatabasePurge();
         const options = await optionsLoad();
         options.dictionaries = {};
+        options.dictionary.main = '';
         await optionsSave(options);
 
         await dictionaryGroupsPopulate(options);

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -215,7 +215,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "<div "
-    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.tagLineBreak : depth0),{"name":"unless","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.compactGlossaries : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ">\n"
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.definitionTags : depth0),{"name":"each","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
@@ -438,12 +438,12 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1;
 
   return "            <li>"
-    + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1]),"tagLineBreak":(depths[1] != null ? depths[1].tagLineBreak : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
 },"58":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0),"tagLineBreak":(depth0 != null ? depth0.tagLineBreak : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+  return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
 },"60":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
@@ -451,7 +451,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 },"61":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0),"tagLineBreak":(depth0 != null ? depth0.tagLineBreak : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "        ";
 },"63":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
@@ -469,7 +469,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 
   return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(67, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1]),"tagLineBreak":(depths[1] != null ? depths[1].tagLineBreak : depths[1]),"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1]),"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
 },"67":function(container,depth0,helpers,partials,data) {
     return "<hr>";
 },"69":function(container,depth0,helpers,partials,data) {

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -265,85 +265,109 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1;
 
   return container.escapeExpression(container.lambda(((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["0"] : stack1), depth0));
-},"16":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "<div class=\"entry\" data-type=\"term\">\n    <div class=\"actions\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"unless","hash":{},"fn":container.program(19, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(21, data, 0),"inverse":container.program(28, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.program(34, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(36, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(34, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(43, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.program(49, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(52, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"17":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
 },"19":function(container,depth0,helpers,partials,data) {
-    return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
-},"21":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"22":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"20":function(container,depth0,helpers,partials,data) {
+    return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
+},"22":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1;
+
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(23, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"23":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
   "    <div class=\"expression\">\n        <span class=\"expression-"
     + container.escapeExpression(((helper = (helper = helpers.jmdictTermFrequency || (depth0 != null ? depth0.jmdictTermFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"jmdictTermFrequency","hash":{},"data":data}) : helper)))
     + "\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(24, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "</span>"
-    + ((stack1 = helpers.unless.call(alias1,(data && data.last),{"name":"unless","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return buffer + "</span><!--\n     --><div class=\"peek-wrapper\">"
+    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(27, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "<!--\n         --><span style=\"display: inline-block;\"></span><!--\n     --></div><!--\n     -->"
+    + ((stack1 = helpers.unless.call(alias1,(data && data.last),{"name":"unless","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    </div>\n";
-},"23":function(container,depth0,helpers,partials,data) {
+},"24":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
-  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.furigana) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { return stack1; }
   else { return ''; }
-},"24":function(container,depth0,helpers,partials,data) {
+},"25":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"26":function(container,depth0,helpers,partials,data) {
+},"27":function(container,depth0,helpers,partials,data) {
+    return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a><br>\n";
+},"29":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "            ";
+},"30":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<span class=\"label label-default tag-"
+    + alias4(((helper = (helper = helpers.category || (depth0 != null ? depth0.category : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"category","hash":{},"data":data}) : helper)))
+    + "\" title=\""
+    + alias4(((helper = (helper = helpers.notes || (depth0 != null ? depth0.notes : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"notes","hash":{},"data":data}) : helper)))
+    + "\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</span>\n";
+},"32":function(container,depth0,helpers,partials,data) {
     return "、";
-},"28":function(container,depth0,helpers,partials,data) {
+},"34":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <div class=\"expression\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</div>\n";
-},"30":function(container,depth0,helpers,partials,data) {
+},"36":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div class=\"reasons\">\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(31, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(37, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"31":function(container,depth0,helpers,partials,data) {
+},"37":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <span class=\"reasons\">"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</span> "
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(32, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(38, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n";
-},"32":function(container,depth0,helpers,partials,data) {
+},"38":function(container,depth0,helpers,partials,data) {
     return "&laquo;";
-},"34":function(container,depth0,helpers,partials,data) {
+},"40":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(41, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"35":function(container,depth0,helpers,partials,data) {
+},"41":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -351,61 +375,61 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"37":function(container,depth0,helpers,partials,data) {
+},"43":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(38, data, 0),"inverse":container.program(41, data, 0),"data":data})) != null ? stack1 : "");
-},"38":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(44, data, 0),"inverse":container.program(47, data, 0),"data":data})) != null ? stack1 : "");
+},"44":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(39, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(45, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </ol>\n";
-},"39":function(container,depth0,helpers,partials,data) {
+},"45":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <li>"
     + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
-},"41":function(container,depth0,helpers,partials,data) {
+},"47":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"43":function(container,depth0,helpers,partials,data) {
+},"49":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(44, data, 0),"data":data})) != null ? stack1 : "");
-},"44":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.program(50, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+},"50":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "        ";
-},"46":function(container,depth0,helpers,partials,data) {
+},"52":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <pre>";
-  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</pre>\n";
-},"48":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"54":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"49":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(55, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"55":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(50, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(56, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
     + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"50":function(container,depth0,helpers,partials,data) {
+},"56":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"52":function(container,depth0,helpers,partials,data) {
+},"58":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(48, data, 0, blockParams, depths),"inverse":container.program(52, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(54, data, 0, blockParams, depths),"inverse":container.program(58, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -209,15 +209,19 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.definitionTags : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(13, data, 0),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(11, data, 0),"inverse":container.program(17, data, 0),"data":data})) != null ? stack1 : "");
 },"2":function(container,depth0,helpers,partials,data) {
-    var stack1;
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return "<div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitionTags : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return "<div "
+    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.tagLineBreak : depth0),{"name":"unless","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ">\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.definitionTags : depth0),{"name":"each","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"3":function(container,depth0,helpers,partials,data) {
+    return "style=\"display: inline-block;\"";
+},"5":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "    <span class=\"label label-default tag-"
@@ -227,112 +231,120 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"5":function(container,depth0,helpers,partials,data) {
-    var stack1;
+},"7":function(container,depth0,helpers,partials,data) {
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return "<div>\n    ("
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.only : depth0),{"name":"each","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return "<div "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.compactGlossaries : depth0),{"name":"if","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ">\n    ("
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"each","hash":{},"fn":container.program(8, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    only)\n</div>\n";
-},"6":function(container,depth0,helpers,partials,data) {
+},"8":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "")
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(9, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n";
-},"7":function(container,depth0,helpers,partials,data) {
-    return ", ";
 },"9":function(container,depth0,helpers,partials,data) {
-    var stack1;
+    return ", ";
+},"11":function(container,depth0,helpers,partials,data) {
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return "<ul>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.glossary : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return "<ul "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.compactGlossaries : depth0),{"name":"if","hash":{},"fn":container.program(12, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ">\n"
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.glossary : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</ul>\n";
-},"10":function(container,depth0,helpers,partials,data) {
+},"12":function(container,depth0,helpers,partials,data) {
+    return "class=\"compact\"";
+},"14":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <li><span class=\"glossary-item\">";
-  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(15, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.multiLine) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</span></li>\n";
-},"11":function(container,depth0,helpers,partials,data) {
+},"15":function(container,depth0,helpers,partials,data) {
     return container.escapeExpression(container.lambda(depth0, depth0));
-},"13":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, buffer = 
-  "<div class=\"glossary-item\">";
-  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+},"17":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), buffer = 
+  "<div class=\"glossary-item "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.compactGlossaries : depth0),{"name":"if","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\">";
+  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(alias1,options) : helper));
   if (!helpers.multiLine) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</div>\n";
-},"14":function(container,depth0,helpers,partials,data) {
+},"18":function(container,depth0,helpers,partials,data) {
+    return "compact";
+},"20":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return container.escapeExpression(container.lambda(((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["0"] : stack1), depth0));
-},"16":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"22":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "<div class=\"entry\" data-type=\"term\">\n    <div class=\"actions\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"unless","hash":{},"fn":container.program(19, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(23, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"unless","hash":{},"fn":container.program(25, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.program(37, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(28, data, 0, blockParams, depths),"inverse":container.program(43, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(39, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(47, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(51, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.program(55, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(54, data, 0, blockParams, depths),"inverse":container.program(60, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(58, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(63, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
-},"17":function(container,depth0,helpers,partials,data) {
+},"23":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
-},"19":function(container,depth0,helpers,partials,data) {
+},"25":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"20":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"26":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
-},"22":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"28":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(23, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"23":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"29":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
   "    <div class=\"expression\">\n        <span class=\"expression-"
     + container.escapeExpression(((helper = (helper = helpers.jmdictTermFrequency || (depth0 != null ? depth0.jmdictTermFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"jmdictTermFrequency","hash":{},"data":data}) : helper)))
     + "\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(24, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(30, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</span><!--\n     --><div class=\"peek-wrapper\">"
-    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(27, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(33, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(38, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "<!--\n     --></div><!--\n     --><span class=\""
-    + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(41, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\">、</span><!--\n --></div>\n";
-},"24":function(container,depth0,helpers,partials,data) {
+},"30":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
-  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(31, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.furigana) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { return stack1; }
   else { return ''; }
-},"25":function(container,depth0,helpers,partials,data) {
+},"31":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"27":function(container,depth0,helpers,partials,data) {
+},"33":function(container,depth0,helpers,partials,data) {
     return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a>\n";
-},"29":function(container,depth0,helpers,partials,data) {
+},"35":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<div class=\"tags\">"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(36, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </div>\n";
-},"30":function(container,depth0,helpers,partials,data) {
+},"36":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "<span class=\"label label-default tag-"
@@ -342,13 +354,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"32":function(container,depth0,helpers,partials,data) {
+},"38":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<div class=\"frequencies\">"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(39, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </div>\n            ";
-},"33":function(container,depth0,helpers,partials,data) {
+},"39":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "<span class=\"label label-default tag-frequency\">"
@@ -356,38 +368,23 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"35":function(container,depth0,helpers,partials,data) {
+},"41":function(container,depth0,helpers,partials,data) {
     return "invisible";
-},"37":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, buffer = 
+},"43":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), buffer = 
   "    <div class=\"expression\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "</div>\n";
-},"39":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return "    <div class=\"reasons\">\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(40, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "    </div>\n";
-},"40":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return "        <span class=\"reasons\">"
-    + container.escapeExpression(container.lambda(depth0, depth0))
-    + "</span> "
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(41, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\n";
-},"41":function(container,depth0,helpers,partials,data) {
-    return "&laquo;";
-},"43":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.termTags : depth0),{"name":"each","hash":{},"fn":container.program(44, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "    </div>\n";
+  return buffer + "</div>\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(44, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"44":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "    <div style=\"display: inline-block;\">\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.termTags : depth0),{"name":"each","hash":{},"fn":container.program(45, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "    </div>\n";
+},"45":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-"
@@ -397,13 +394,29 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"46":function(container,depth0,helpers,partials,data) {
+},"47":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "    <div class=\"reasons\">\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(48, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "    </div>\n";
+},"48":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "        <span class=\"reasons\">"
+    + container.escapeExpression(container.lambda(depth0, depth0))
+    + "</span> "
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(49, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n";
+},"49":function(container,depth0,helpers,partials,data) {
+    return "&laquo;";
+},"51":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(47, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(52, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"47":function(container,depth0,helpers,partials,data) {
+},"52":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -411,67 +424,67 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"49":function(container,depth0,helpers,partials,data) {
+},"54":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(50, data, 0),"inverse":container.program(53, data, 0),"data":data})) != null ? stack1 : "");
-},"50":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(51, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "        </ol>\n";
-},"51":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return "            <li>"
-    + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
-    + "</li>\n";
-},"53":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(55, data, 0, blockParams, depths),"inverse":container.program(58, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"55":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.program(56, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
-},"56":function(container,depth0,helpers,partials,data) {
+  return "        <ol>\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(56, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "        </ol>\n";
+},"56":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
-    + "        ";
+  return "            <li>"
+    + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1]),"tagLineBreak":(depths[1] != null ? depths[1].tagLineBreak : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "</li>\n";
 },"58":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, buffer = 
-  "    <pre>";
-  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
-  if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</pre>\n";
+    var stack1;
+
+  return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0),"tagLineBreak":(depth0 != null ? depth0.tagLineBreak : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
 },"60":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(61, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"61":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(54, data, 0, blockParams, depths),"inverse":container.program(61, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+},"61":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(62, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","hash":{"compactGlossaries":(depth0 != null ? depth0.compactGlossaries : depth0),"tagLineBreak":(depth0 != null ? depth0.tagLineBreak : depth0)},"data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "        ";
+},"63":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, buffer = 
+  "    <pre>";
+  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(31, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</pre>\n";
+},"65":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1;
+
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(66, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"66":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1;
+
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(67, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"62":function(container,depth0,helpers,partials,data) {
+    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"compactGlossaries":(depths[1] != null ? depths[1].compactGlossaries : depths[1]),"tagLineBreak":(depths[1] != null ? depths[1].tagLineBreak : depths[1]),"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+},"67":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"64":function(container,depth0,helpers,partials,data) {
+},"69":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(60, data, 0, blockParams, depths),"inverse":container.program(64, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(65, data, 0, blockParams, depths),"inverse":container.program(69, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;
 
   fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"args":["definition"],"data":data}) || fn;
-  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(16, data, 0, blockParams, depths),"inverse":container.noop,"args":["term"],"data":data}) || fn;
+  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.noop,"args":["term"],"data":data}) || fn;
   return fn;
   }
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -218,7 +218,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.definitionTags : depth0),{"name":"each","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"3":function(container,depth0,helpers,partials,data) {
-    return "style=\"display: inline-block;\"";
+    return "class=\"compact-info\"";
 },"5":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -254,7 +254,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.glossary : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</ul>\n";
 },"12":function(container,depth0,helpers,partials,data) {
-    return "class=\"compact\"";
+    return "class=\"compact-glossary\"";
 },"14":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <li><span class=\"glossary-item\">";
@@ -274,7 +274,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</div>\n";
 },"18":function(container,depth0,helpers,partials,data) {
-    return "compact";
+    return "compact-glossary";
 },"20":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -272,15 +272,15 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers.unless.call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"unless","hash":{},"fn":container.program(19, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.program(34, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(22, data, 0, blockParams, depths),"inverse":container.program(37, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(36, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(39, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.program(49, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.program(52, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(52, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(55, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"17":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
@@ -305,8 +305,9 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   return buffer + "</span><!--\n     --><div class=\"peek-wrapper\">"
     + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(27, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "<!--\n         --><span style=\"display: inline-block;\"></span><!--\n     --></div><!--\n     --><span class=\""
-    + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "<!--\n     --></div><!--\n     --><span class=\""
+    + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\">、</span><!--\n --></div>\n";
 },"24":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
@@ -320,12 +321,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
 },"27":function(container,depth0,helpers,partials,data) {
-    return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a><br>\n";
+    return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a>\n";
 },"29":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "            ";
+  return "<div class=\"tags\">"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "            </div>\n";
 },"30":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -337,37 +339,51 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
 },"32":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "<div class=\"frequencies\">"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "            </div>\n            ";
+},"33":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<span class=\"label label-default tag-frequency\">"
+    + alias4(((helper = (helper = helpers.dictionary || (depth0 != null ? depth0.dictionary : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dictionary","hash":{},"data":data}) : helper)))
+    + ":"
+    + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
+    + "</span>\n";
+},"35":function(container,depth0,helpers,partials,data) {
     return "invisible";
-},"34":function(container,depth0,helpers,partials,data) {
+},"37":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <div class=\"expression\">";
   stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</div>\n";
-},"36":function(container,depth0,helpers,partials,data) {
+},"39":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div class=\"reasons\">\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(37, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(40, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"37":function(container,depth0,helpers,partials,data) {
+},"40":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <span class=\"reasons\">"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</span> "
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(38, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(41, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n";
-},"38":function(container,depth0,helpers,partials,data) {
+},"41":function(container,depth0,helpers,partials,data) {
     return "&laquo;";
-},"40":function(container,depth0,helpers,partials,data) {
+},"43":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(41, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(44, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"41":function(container,depth0,helpers,partials,data) {
+},"44":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -375,61 +391,61 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"43":function(container,depth0,helpers,partials,data) {
+},"46":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(44, data, 0),"inverse":container.program(47, data, 0),"data":data})) != null ? stack1 : "");
-},"44":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(47, data, 0),"inverse":container.program(50, data, 0),"data":data})) != null ? stack1 : "");
+},"47":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(45, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(48, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </ol>\n";
-},"45":function(container,depth0,helpers,partials,data) {
+},"48":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <li>"
     + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
-},"47":function(container,depth0,helpers,partials,data) {
+},"50":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"49":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"52":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.program(50, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
-},"50":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.program(53, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+},"53":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "        ";
-},"52":function(container,depth0,helpers,partials,data) {
+},"55":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <pre>";
   stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</pre>\n";
-},"54":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"57":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(55, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"55":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(58, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"58":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(56, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(59, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
     + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"56":function(container,depth0,helpers,partials,data) {
+},"59":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"58":function(container,depth0,helpers,partials,data) {
+},"61":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(54, data, 0, blockParams, depths),"inverse":container.program(58, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(57, data, 0, blockParams, depths),"inverse":container.program(61, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -276,11 +276,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(39, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.program(52, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.program(55, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(55, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(58, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"17":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
@@ -381,9 +383,25 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(44, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.termTags : depth0),{"name":"each","hash":{},"fn":container.program(44, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
 },"44":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "        <span class=\"label label-default tag-"
+    + alias4(((helper = (helper = helpers.category || (depth0 != null ? depth0.category : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"category","hash":{},"data":data}) : helper)))
+    + "\" title=\""
+    + alias4(((helper = (helper = helpers.notes || (depth0 != null ? depth0.notes : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"notes","hash":{},"data":data}) : helper)))
+    + "\">"
+    + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
+    + "</span>\n";
+},"46":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "    <div>\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(47, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "    </div>\n";
+},"47":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -391,61 +409,61 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"46":function(container,depth0,helpers,partials,data) {
+},"49":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(47, data, 0),"inverse":container.program(50, data, 0),"data":data})) != null ? stack1 : "");
-},"47":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(50, data, 0),"inverse":container.program(53, data, 0),"data":data})) != null ? stack1 : "");
+},"50":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(48, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(51, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </ol>\n";
-},"48":function(container,depth0,helpers,partials,data) {
+},"51":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <li>"
     + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
-},"50":function(container,depth0,helpers,partials,data) {
+},"53":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"52":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"55":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0, blockParams, depths),"inverse":container.program(53, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
-},"53":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.program(56, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+},"56":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "        ";
-},"55":function(container,depth0,helpers,partials,data) {
+},"58":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <pre>";
   stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</pre>\n";
-},"57":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"60":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(58, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"58":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(61, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"61":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(59, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(62, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
     + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"59":function(container,depth0,helpers,partials,data) {
+},"62":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"61":function(container,depth0,helpers,partials,data) {
+},"64":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(57, data, 0, blockParams, depths),"inverse":container.program(61, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(60, data, 0, blockParams, depths),"inverse":container.program(64, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -206,14 +206,14 @@ templates['model.html'] = template({"1":function(container,depth0,helpers,partia
 templates['terms.html'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.definitionTags : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(13, data, 0),"data":data})) != null ? stack1 : "");
 },"2":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitionTags : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"3":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -249,61 +249,85 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 
   return container.escapeExpression(container.lambda(((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["0"] : stack1), depth0));
 },"12":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), buffer = 
-  "<div class=\"entry\" data-type=\"term\">\n    <div class=\"actions\">\n"
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+
+  return "<div class=\"entry\" data-type=\"term\">\n    <div class=\"actions\">\n"
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n    <div class=\"expression\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(alias1,options) : helper));
-  if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(20, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.program(21, data, 0),"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n"
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(28, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(27, data, 0),"inverse":container.program(33, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(37, data, 0),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
 },"13":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
 },"15":function(container,depth0,helpers,partials,data) {
     return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
 },"17":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=helpers.blockHelperMissing, buffer = 
+  "    <div class=\"expression\">";
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  if (!helpers.kanjiLinks) { stack1 = alias4.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  buffer += "</div>\n    <div>";
+  stack1 = ((helper = (helper = helpers.readings || (depth0 != null ? depth0.readings : depth0)) != null ? helper : alias2),(options={"name":"readings","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
+  if (!helpers.readings) { stack1 = alias4.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</div>\n";
+},"18":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
-  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
-  if (!helpers.furigana) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  stack1 = ((helper = (helper = helpers.expressions || (depth0 != null ? depth0.expressions : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"expressions","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  if (!helpers.expressions) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { return stack1; }
   else { return ''; }
-},"18":function(container,depth0,helpers,partials,data) {
+},"19":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"20":function(container,depth0,helpers,partials,data) {
+},"21":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, buffer = 
+  "    <div class=\"expression\">";
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</div>\n";
+},"22":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options;
+
+  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  if (!helpers.furigana) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  if (stack1 != null) { return stack1; }
+  else { return ''; }
+},"24":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div class=\"reasons\">\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(21, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"21":function(container,depth0,helpers,partials,data) {
+},"25":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <span class=\"reasons\">"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</span> "
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n";
-},"22":function(container,depth0,helpers,partials,data) {
+},"26":function(container,depth0,helpers,partials,data) {
     return "&laquo;";
-},"24":function(container,depth0,helpers,partials,data) {
+},"28":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"25":function(container,depth0,helpers,partials,data) {
+},"29":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -311,56 +335,61 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"27":function(container,depth0,helpers,partials,data) {
+},"31":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(28, data, 0),"inverse":container.program(31, data, 0),"data":data})) != null ? stack1 : "");
-},"28":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(32, data, 0),"inverse":container.program(35, data, 0),"data":data})) != null ? stack1 : "");
+},"32":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </ol>\n";
-},"29":function(container,depth0,helpers,partials,data) {
+},"33":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <li>"
     + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
-},"31":function(container,depth0,helpers,partials,data) {
+},"35":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"33":function(container,depth0,helpers,partials,data) {
+},"37":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"35":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(38, data, 0),"data":data})) != null ? stack1 : "");
+},"38":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
+    + "        ";
+},"40":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <pre>";
-  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</pre>\n";
-},"37":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"42":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(38, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"38":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"43":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(39, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(44, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"39":function(container,depth0,helpers,partials,data) {
+    + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+},"44":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"41":function(container,depth0,helpers,partials,data) {
+},"46":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0, blockParams, depths),"inverse":container.program(41, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(42, data, 0, blockParams, depths),"inverse":container.program(46, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -13,7 +13,9 @@ templates['dictionary.html'] = template({"1":function(container,depth0,helpers,p
     + alias4(((helper = (helper = helpers.revision || (depth0 != null ? depth0.revision : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"revision","hash":{},"data":data}) : helper)))
     + "</small></h4>\n\n    <div class=\"checkbox\">\n        <label><input type=\"checkbox\" class=\"dict-enabled\" "
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.enabled : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "> Enable search</label>\n        <label><input type=\"radio\" class=\"dict-main\" "
+    + "> Enable search</label>\n    </div>\n    <div class=\"checkbox options-advanced\">\n        <label><input type=\"checkbox\" class=\"dict-allow-secondary-searches\" "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.allowSecondarySearches : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "> Allow secondary searches</label>\n    </div>\n    <div class=\"radio\">\n        <label><input type=\"radio\" class=\"dict-main\" "
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.main : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "> Set as main dictionary</label>\n    </div>\n    <div class=\"form-group options-advanced\">\n        <label for=\"dict-"
     + alias4(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"title","hash":{},"data":data}) : helper)))

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -345,13 +345,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 },"36":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
-  return "<span class=\"label label-default tag-"
+  return "                <span class=\"label label-default tag-"
     + alias4(((helper = (helper = helpers.category || (depth0 != null ? depth0.category : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"category","hash":{},"data":data}) : helper)))
     + "\" title=\""
     + alias4(((helper = (helper = helpers.notes || (depth0 != null ? depth0.notes : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"notes","hash":{},"data":data}) : helper)))
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</span>";
+    + "</span>\n";
 },"38":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -15,9 +15,7 @@ templates['dictionary.html'] = template({"1":function(container,depth0,helpers,p
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.enabled : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "> Enable search</label>\n    </div>\n    <div class=\"checkbox options-advanced\">\n        <label><input type=\"checkbox\" class=\"dict-allow-secondary-searches\" "
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.allowSecondarySearches : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "> Allow secondary searches</label>\n    </div>\n    <div class=\"radio\">\n        <label><input type=\"radio\" class=\"dict-main\" "
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.main : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "> Set as main dictionary</label>\n    </div>\n    <div class=\"form-group options-advanced\">\n        <label for=\"dict-"
+    + "> Allow secondary searches</label>\n    </div>\n    <div class=\"form-group options-advanced\">\n        <label for=\"dict-"
     + alias4(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"title","hash":{},"data":data}) : helper)))
     + "\">Result priority</label>\n        <input type=\"number\" value=\""
     + alias4(((helper = (helper = helpers.priority || (depth0 != null ? depth0.priority : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"priority","hash":{},"data":data}) : helper)))

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -296,7 +296,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "</span>\n        "
+  return buffer + "</span>"
     + ((stack1 = helpers.unless.call(alias1,(data && data.last),{"name":"unless","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    </div>\n";
 },"23":function(container,depth0,helpers,partials,data) {

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -313,7 +313,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 },"29":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
   "    <div class=\"expression\">\n        <span class=\"expression-"
-    + container.escapeExpression(((helper = (helper = helpers.jmdictTermFrequency || (depth0 != null ? depth0.jmdictTermFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"jmdictTermFrequency","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.termFrequency || (depth0 != null ? depth0.termFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"termFrequency","hash":{},"data":data}) : helper)))
     + "\">";
   stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(30, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -204,15 +204,30 @@ templates['model.html'] = template({"1":function(container,depth0,helpers,partia
 templates['terms.html'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.program(9, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(13, data, 0),"data":data})) != null ? stack1 : "");
 },"2":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return "<div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "</div>\n";
+  return "<div>\n    ("
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.only : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "    only)\n</div>\n";
 },"3":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n";
+},"4":function(container,depth0,helpers,partials,data) {
+    return ", ";
+},"6":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "<div>\n"
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "</div>\n";
+},"7":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "    <span class=\"label label-default tag-"
@@ -222,112 +237,111 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"5":function(container,depth0,helpers,partials,data) {
+},"9":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<ul>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.glossary : depth0),{"name":"each","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.glossary : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</ul>\n";
-},"6":function(container,depth0,helpers,partials,data) {
+},"10":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <li><span class=\"glossary-item\">";
-  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(11, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.multiLine) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</span></li>\n";
-},"7":function(container,depth0,helpers,partials,data) {
+},"11":function(container,depth0,helpers,partials,data) {
     return container.escapeExpression(container.lambda(depth0, depth0));
-},"9":function(container,depth0,helpers,partials,data) {
+},"13":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "<div class=\"glossary-item\">";
-  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.multiLine || (depth0 != null ? depth0.multiLine : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"multiLine","hash":{},"fn":container.program(14, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.multiLine) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</div>\n";
-},"10":function(container,depth0,helpers,partials,data) {
+},"14":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return container.escapeExpression(container.lambda(((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["0"] : stack1), depth0));
-},"12":function(container,depth0,helpers,partials,data) {
+},"16":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "<div class=\"entry\" data-type=\"term\">\n    <div class=\"actions\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(13, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(15, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.addable : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.playback : depth0),{"name":"if","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        <img src=\"/mixed/img/entry-current.png\" class=\"current\" title=\"Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)\" alt>\n    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(17, data, 0),"inverse":container.program(21, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(21, data, 0),"inverse":container.program(28, data, 0),"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.reasons : depth0),{"name":"if","hash":{},"fn":container.program(30, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(28, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(34, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n    <div class=\"glossary\">\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(37, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.grouped : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(43, data, 0),"data":data})) != null ? stack1 : "")
     + "    </div>\n\n"
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(40, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.debug : depth0),{"name":"if","hash":{},"fn":container.program(46, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
-},"13":function(container,depth0,helpers,partials,data) {
-    return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
-},"15":function(container,depth0,helpers,partials,data) {
-    return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
 },"17":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=helpers.blockHelperMissing, buffer = 
-  "    <div class=\"expression\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(18, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
-  if (!helpers.kanjiLinks) { stack1 = alias4.call(depth0,stack1,options)}
-  if (stack1 != null) { buffer += stack1; }
-  buffer += "</div>\n    <div>";
-  stack1 = ((helper = (helper = helpers.readings || (depth0 != null ? depth0.readings : depth0)) != null ? helper : alias2),(options={"name":"readings","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
-  if (!helpers.readings) { stack1 = alias4.call(depth0,stack1,options)}
-  if (stack1 != null) { buffer += stack1; }
-  return buffer + "</div>\n";
-},"18":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options;
-
-  stack1 = ((helper = (helper = helpers.expressions || (depth0 != null ? depth0.expressions : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"expressions","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
-  if (!helpers.expressions) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
-  if (stack1 != null) { return stack1; }
-  else { return ''; }
+    return "        <a href=\"#\" class=\"action-view-note pending disabled\"><img src=\"/mixed/img/view-note.png\" title=\"View added note (Alt + V)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kanji\"><img src=\"/mixed/img/add-term-kanji.png\" title=\"Add expression (Alt + E)\" alt></a>\n        <a href=\"#\" class=\"action-add-note pending disabled\" data-mode=\"term-kana\"><img src=\"/mixed/img/add-term-kana.png\" title=\"Add reading (Alt + R)\" alt></a>\n";
 },"19":function(container,depth0,helpers,partials,data) {
+    return "        <a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio (Alt + P)\" alt></a>\n";
+},"21":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
-},"21":function(container,depth0,helpers,partials,data) {
-    var stack1, helper, options, buffer = 
-  "    <div class=\"expression\">";
-  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(22, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"22":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
+  "    <div class=\"expression\">\n        <span class=\"expression-"
+    + container.escapeExpression(((helper = (helper = helpers.jmdictTermFrequency || (depth0 != null ? depth0.jmdictTermFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"jmdictTermFrequency","hash":{},"data":data}) : helper)))
+    + "\">";
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "</div>\n";
-},"22":function(container,depth0,helpers,partials,data) {
+  return buffer + "</span>\n        "
+    + ((stack1 = helpers.unless.call(alias1,(data && data.last),{"name":"unless","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n    </div>\n";
+},"23":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
-  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.furigana || (depth0 != null ? depth0.furigana : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"furigana","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.furigana) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { return stack1; }
   else { return ''; }
 },"24":function(container,depth0,helpers,partials,data) {
     var stack1;
 
+  return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
+},"26":function(container,depth0,helpers,partials,data) {
+    return "、";
+},"28":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, options, buffer = 
+  "    <div class=\"expression\">";
+  stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"kanjiLinks","hash":{},"fn":container.program(23, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
+  if (stack1 != null) { buffer += stack1; }
+  return buffer + "</div>\n";
+},"30":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
   return "    <div class=\"reasons\">\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(25, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.reasons : depth0),{"name":"each","hash":{},"fn":container.program(31, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"25":function(container,depth0,helpers,partials,data) {
+},"31":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <span class=\"reasons\">"
     + container.escapeExpression(container.lambda(depth0, depth0))
     + "</span> "
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(26, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(32, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n";
-},"26":function(container,depth0,helpers,partials,data) {
+},"32":function(container,depth0,helpers,partials,data) {
     return "&laquo;";
-},"28":function(container,depth0,helpers,partials,data) {
+},"34":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "    <div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(35, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "    </div>\n";
-},"29":function(container,depth0,helpers,partials,data) {
+},"35":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "        <span class=\"label label-default tag-frequency\">"
@@ -335,67 +349,67 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
     + "</span>\n";
-},"31":function(container,depth0,helpers,partials,data) {
+},"37":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(32, data, 0),"inverse":container.program(35, data, 0),"data":data})) != null ? stack1 : "");
-},"32":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(38, data, 0),"inverse":container.program(41, data, 0),"data":data})) != null ? stack1 : "");
+},"38":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "        <ol>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(33, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(39, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "        </ol>\n";
-},"33":function(container,depth0,helpers,partials,data) {
+},"39":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "            <li>"
     + ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "</li>\n";
-},"35":function(container,depth0,helpers,partials,data) {
+},"41":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,((stack1 = (depth0 != null ? depth0.definitions : depth0)) != null ? stack1["0"] : stack1),{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"37":function(container,depth0,helpers,partials,data) {
+},"43":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(31, data, 0),"inverse":container.program(38, data, 0),"data":data})) != null ? stack1 : "");
-},"38":function(container,depth0,helpers,partials,data) {
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.merged : depth0),{"name":"if","hash":{},"fn":container.program(37, data, 0),"inverse":container.program(44, data, 0),"data":data})) != null ? stack1 : "");
+},"44":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.definition,depth0,{"name":"definition","data":data,"indent":"        ","helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "")
     + "        ";
-},"40":function(container,depth0,helpers,partials,data) {
+},"46":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <pre>";
-  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(19, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
+  stack1 = ((helper = (helper = helpers.dumpObject || (depth0 != null ? depth0.dumpObject : depth0)) != null ? helper : helpers.helperMissing),(options={"name":"dumpObject","hash":{},"fn":container.program(24, data, 0),"inverse":container.noop,"data":data}),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),options) : helper));
   if (!helpers.dumpObject) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</pre>\n";
-},"42":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"48":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(43, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
-},"43":function(container,depth0,helpers,partials,data,blockParams,depths) {
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"each","hash":{},"fn":container.program(49, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"49":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(44, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.first),{"name":"unless","hash":{},"fn":container.program(50, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "\n"
     + ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"playback":(depths[1] != null ? depths[1].playback : depths[1]),"addable":(depths[1] != null ? depths[1].addable : depths[1]),"merged":(depths[1] != null ? depths[1].merged : depths[1]),"grouped":(depths[1] != null ? depths[1].grouped : depths[1]),"debug":(depths[1] != null ? depths[1].debug : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
-},"44":function(container,depth0,helpers,partials,data) {
+},"50":function(container,depth0,helpers,partials,data) {
     return "<hr>";
-},"46":function(container,depth0,helpers,partials,data) {
+},"52":function(container,depth0,helpers,partials,data) {
     return "<p class=\"note\">No results found.</p>\n";
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return "\n\n"
-    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(42, data, 0, blockParams, depths),"inverse":container.program(46, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
+    + ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.definitions : depth0),{"name":"if","hash":{},"fn":container.program(48, data, 0, blockParams, depths),"inverse":container.program(52, data, 0, blockParams, depths),"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;
 
   fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"args":["definition"],"data":data}) || fn;
-  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(12, data, 0, blockParams, depths),"inverse":container.noop,"args":["term"],"data":data}) || fn;
+  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(16, data, 0, blockParams, depths),"inverse":container.noop,"args":["term"],"data":data}) || fn;
   return fn;
   }
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -305,9 +305,9 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   return buffer + "</span><!--\n     --><div class=\"peek-wrapper\">"
     + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(27, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "<!--\n         --><span style=\"display: inline-block;\"></span><!--\n     --></div><!--\n     -->"
-    + ((stack1 = helpers.unless.call(alias1,(data && data.last),{"name":"unless","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\n    </div>\n";
+    + "<!--\n         --><span style=\"display: inline-block;\"></span><!--\n     --></div><!--\n     --><span class=\""
+    + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(32, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\">、</span><!--\n --></div>\n";
 },"24":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
@@ -337,7 +337,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
 },"32":function(container,depth0,helpers,partials,data) {
-    return "、";
+    return "invisible";
 },"34":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, buffer = 
   "    <div class=\"expression\">";

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -310,7 +310,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"29":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
-  "    <div class=\"expression\">\n        <span class=\"expression-"
+  "<div class=\"expression\"><!--\n     --><span class=\"expression-"
     + container.escapeExpression(((helper = (helper = helpers.termFrequency || (depth0 != null ? depth0.termFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"termFrequency","hash":{},"data":data}) : helper)))
     + "\">";
   stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(30, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
@@ -320,9 +320,9 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(33, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(38, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "<!--\n     --></div><!--\n     --><span class=\""
+    + "</div><!--\n     --><span class=\""
     + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(41, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\">、</span><!--\n --></div>\n";
+    + "\">、</span><!--\n --></div>";
 },"30":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 
@@ -335,13 +335,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 
   return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "");
 },"33":function(container,depth0,helpers,partials,data) {
-    return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a>\n";
+    return "<a href=\"#\" class=\"action-play-audio\"><img src=\"/mixed/img/play-audio.png\" title=\"Play audio\" alt></a>";
 },"35":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<div class=\"tags\">"
     + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.termTags : depth0),{"name":"each","hash":{},"fn":container.program(36, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "            </div>\n";
+    + "</div>";
 },"36":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -351,13 +351,13 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + alias4(((helper = (helper = helpers.notes || (depth0 != null ? depth0.notes : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"notes","hash":{},"data":data}) : helper)))
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
-    + "</span>\n";
+    + "</span>";
 },"38":function(container,depth0,helpers,partials,data) {
     var stack1;
 
   return "<div class=\"frequencies\">"
     + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.frequencies : depth0),{"name":"each","hash":{},"fn":container.program(39, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "            </div>\n            ";
+    + "</div>";
 },"39":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
@@ -365,7 +365,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + alias4(((helper = (helper = helpers.dictionary || (depth0 != null ? depth0.dictionary : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dictionary","hash":{},"data":data}) : helper)))
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
-    + "</span>\n";
+    + "</span>";
 },"41":function(container,depth0,helpers,partials,data) {
     return "invisible";
 },"43":function(container,depth0,helpers,partials,data) {

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -206,30 +206,16 @@ templates['model.html'] = template({"1":function(container,depth0,helpers,partia
 templates['terms.html'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
-  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.only : depth0),{"name":"if","hash":{},"fn":container.program(5, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,((stack1 = (depth0 != null ? depth0.glossary : depth0)) != null ? stack1["1"] : stack1),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(13, data, 0),"data":data})) != null ? stack1 : "");
 },"2":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return "<div>\n    ("
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.only : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "    only)\n</div>\n";
-},"3":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
-  return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "")
-    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(4, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\n";
-},"4":function(container,depth0,helpers,partials,data) {
-    return ", ";
-},"6":function(container,depth0,helpers,partials,data) {
-    var stack1;
-
   return "<div>\n"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(3, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "</div>\n";
-},"7":function(container,depth0,helpers,partials,data) {
+},"3":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
   return "    <span class=\"label label-default tag-"
@@ -239,6 +225,20 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     + "\">"
     + alias4(((helper = (helper = helpers.name || (depth0 != null ? depth0.name : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"name","hash":{},"data":data}) : helper)))
     + "</span>\n";
+},"5":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return "<div>\n    ("
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.only : depth0),{"name":"each","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "    only)\n</div>\n";
+},"6":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = container.lambda(depth0, depth0)) != null ? stack1 : "")
+    + ((stack1 = helpers.unless.call(depth0 != null ? depth0 : (container.nullContext || {}),(data && data.last),{"name":"unless","hash":{},"fn":container.program(7, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "\n";
+},"7":function(container,depth0,helpers,partials,data) {
+    return ", ";
 },"9":function(container,depth0,helpers,partials,data) {
     var stack1;
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -320,7 +320,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   if (stack1 != null) { buffer += stack1; }
   return buffer + "</span><!--\n     --><div class=\"peek-wrapper\">"
     + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(33, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.tags : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(38, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "<!--\n     --></div><!--\n     --><span class=\""
     + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(41, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
@@ -342,7 +342,7 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
     var stack1;
 
   return "<div class=\"tags\">"
-    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.tags : depth0),{"name":"each","hash":{},"fn":container.program(36, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.termTags : depth0),{"name":"each","hash":{},"fn":container.program(36, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "            </div>\n";
 },"36":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -13,7 +13,9 @@ templates['dictionary.html'] = template({"1":function(container,depth0,helpers,p
     + alias4(((helper = (helper = helpers.revision || (depth0 != null ? depth0.revision : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"revision","hash":{},"data":data}) : helper)))
     + "</small></h4>\n\n    <div class=\"checkbox\">\n        <label><input type=\"checkbox\" class=\"dict-enabled\" "
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.enabled : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "> Enable search</label>\n    </div>\n    <div class=\"form-group options-advanced\">\n        <label for=\"dict-"
+    + "> Enable search</label>\n        <label><input type=\"radio\" class=\"dict-main\" "
+    + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.main : depth0),{"name":"if","hash":{},"fn":container.program(1, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "> Set as main dictionary</label>\n    </div>\n    <div class=\"form-group options-advanced\">\n        <label for=\"dict-"
     + alias4(((helper = (helper = helpers.title || (depth0 != null ? depth0.title : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"title","hash":{},"data":data}) : helper)))
     + "\">Result priority</label>\n        <input type=\"number\" value=\""
     + alias4(((helper = (helper = helpers.priority || (depth0 != null ? depth0.priority : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"priority","hash":{},"data":data}) : helper)))

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -361,11 +361,11 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
 },"39":function(container,depth0,helpers,partials,data) {
     var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
 
-  return "<span class=\"label label-default tag-frequency\">"
+  return "                <span class=\"label label-default tag-frequency\">"
     + alias4(((helper = (helper = helpers.dictionary || (depth0 != null ? depth0.dictionary : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"dictionary","hash":{},"data":data}) : helper)))
     + ":"
     + alias4(((helper = (helper = helpers.frequency || (depth0 != null ? depth0.frequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"frequency","hash":{},"data":data}) : helper)))
-    + "</span>";
+    + "</span>\n";
 },"41":function(container,depth0,helpers,partials,data) {
     return "invisible";
 },"43":function(container,depth0,helpers,partials,data) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -67,7 +67,7 @@ class Translator {
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
         for (const sequence in definitionsBySequence) {
-            if (!(sequence > 0)) {
+            if (!(sequence >= 0)) {
                 continue;
             }
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -121,7 +121,7 @@ class Translator {
                             } else {
                                 return 'normal';
                             }
-                        })(dictTermTagScore(result.expressions.get(expression).get(reading)))
+                        })(tags.map(tag => tag.score).reduce((p, v) => p + v, 0))
                     });
                 }
             }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -49,10 +49,11 @@ class Translator {
     }
 
     async findTermsMerged(text, dictionaries, alphanumeric) {
+        const options = await apiOptionsGet();
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
 
-        const definitionsBySequence = dictTermsMergeBySequence(definitions);
+        const definitionsBySequence = dictTermsMergeBySequence(definitions, options.dictionary.main);
 
         const definitionsMerged = dictTermsGroup(definitionsBySequence['-1'], dictionaries);
         for (const sequence in definitionsBySequence) {
@@ -62,7 +63,7 @@ class Translator {
 
             const result = definitionsBySequence[sequence];
 
-            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence));
+            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence), options.dictionary.main);
             const definitionsByGloss = dictTermsMergeByGloss(result, rawDefinitionsBySequence);
 
             // postprocess glossaries

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -50,10 +50,11 @@ class Translator {
 
     async findTermsMerged(text, dictionaries, alphanumeric) {
         const options = await apiOptionsGet();
+        const mainDictionary = Object.keys(options.dictionaries).filter(dict => options.dictionaries[dict].main).concat([''])[0];
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
 
-        const definitionsBySequence = dictTermsMergeBySequence(definitions, options.dictionary.main);
+        const definitionsBySequence = dictTermsMergeBySequence(definitions, mainDictionary);
 
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
@@ -64,7 +65,7 @@ class Translator {
 
             const result = definitionsBySequence[sequence];
 
-            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence), options.dictionary.main);
+            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence), mainDictionary);
             const definitionsByGloss = dictTermsMergeByGloss(result, rawDefinitionsBySequence);
             dictTermsMergeByGloss(result, definitionsBySequence['-1'], definitionsByGloss, mergedByTermIndices);
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -48,6 +48,18 @@ class Translator {
         return {length, definitions: definitionsGrouped};
     }
 
+    async findTermsMerged(text, dictionaries, alphanumeric) {
+        const titles = Object.keys(dictionaries);
+        const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
+
+        const definitionsMerged = dictTermsGroup(definitions, dictionaries);
+        // for (const definition of definitionsMerged) {
+        //     await this.buildTermFrequencies(definition, titles);
+        // }
+
+        return {length, definitions: definitionsMerged};
+    }
+
     async findTermsSplit(text, dictionaries, alphanumeric) {
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
@@ -90,7 +102,8 @@ class Translator {
                     expression: definition.expression,
                     reading: definition.reading,
                     glossary: definition.glossary,
-                    tags: dictTagsSort(tags)
+                    tags: dictTagsSort(tags),
+                    sequence: definition.sequence
                 });
             }
         }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -37,12 +37,19 @@ class Translator {
     }
 
     async findTermsGrouped(text, dictionaries, alphanumeric) {
+        const options = await apiOptionsGet();
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
 
         const definitionsGrouped = dictTermsGroup(definitions, dictionaries);
         for (const definition of definitionsGrouped) {
             await this.buildTermFrequencies(definition, titles);
+        }
+
+        if (options.general.compactTags) {
+            for (const definition of definitionsGrouped) {
+                dictTermsCompressTags(definition.definitions);
+            }
         }
 
         return {length, definitions: definitionsGrouped};
@@ -118,6 +125,12 @@ class Translator {
 
         for (const definition of definitionsMerged) {
             await this.buildTermFrequencies(definition, titles);
+        }
+
+        if (options.general.compactTags) {
+            for (const definition of definitionsMerged) {
+                dictTermsCompressTags(definition.definitions);
+            }
         }
 
         return {length, definitions: dictTermsSort(definitionsMerged)};

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -66,7 +66,7 @@ class Translator {
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
         for (const sequence in definitionsBySequence) {
-            if (!(sequence >= 0)) {
+            if (sequence < 0) {
                 continue;
             }
 
@@ -83,7 +83,7 @@ class Translator {
             const definitionsByGloss = dictTermsMergeByGloss(result, rawDefinitionsBySequence);
 
             const secondarySearchResults = [];
-            if (secondarySearchTitles.length) {
+            if (secondarySearchTitles.length > 0) {
                 for (const expression of result.expressions.keys()) {
                     if (expression === text) {
                         continue;

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -128,8 +128,9 @@ class Translator {
 
             result.expressions = expressions;
 
-            // result.expression = Array.from(result.expression).join(', ');
-            // result.reading = Array.from(result.reading).join(', ');
+            result.expression = Array.from(result.expression);
+            result.reading = Array.from(result.reading);
+
             definitionsMerged.push(result);
         }
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -79,9 +79,9 @@ class Translator {
             for (const gloss in definitionsByGloss) {
                 const definition = definitionsByGloss[gloss];
 
-                const tags = await this.expandTags(definition.tags, definition.dictionary);
+                const tags = await this.expandTags(definition.definitionTags, definition.dictionary);
                 tags.push(dictTagBuildSource(definition.dictionary));
-                definition.tags = dictTagsSort(tags);
+                definition.definitionTags = dictTagsSort(tags);
 
                 result.definitions.push(definition);
             }
@@ -166,8 +166,8 @@ class Translator {
         let definitions = [];
         for (const deinflection of deinflections) {
             for (const definition of deinflection.definitions) {
-                const tags = await this.expandTags(definition.tags, definition.dictionary);
-                tags.push(dictTagBuildSource(definition.dictionary));
+                const definitionTags = await this.expandTags(definition.definitionTags, definition.dictionary);
+                definitionTags.push(dictTagBuildSource(definition.dictionary));
                 const termTags = await this.expandTags(definition.termTags, definition.dictionary);
 
                 definitions.push({
@@ -179,7 +179,7 @@ class Translator {
                     expression: definition.expression,
                     reading: definition.reading,
                     glossary: definition.glossary,
-                    tags: dictTagsSort(tags),
+                    definitionTags: dictTagsSort(definitionTags),
                     termTags: dictTagsSort(termTags),
                     sequence: definition.sequence
                 });

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -57,12 +57,11 @@ class Translator {
 
     async findTermsMerged(text, dictionaries, alphanumeric) {
         const options = await apiOptionsGet();
-        const mainDictionary = Object.keys(options.dictionaries).filter(dict => options.dictionaries[dict].main).concat([''])[0];
         const secondarySearchTitles = Object.keys(options.dictionaries).filter(dict => options.dictionaries[dict].allowSecondarySearches);
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
 
-        const definitionsBySequence = dictTermsMergeBySequence(definitions, mainDictionary);
+        const definitionsBySequence = dictTermsMergeBySequence(definitions, options.general.mainDictionary);
 
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
@@ -73,7 +72,7 @@ class Translator {
 
             const result = definitionsBySequence[sequence];
 
-            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence), mainDictionary);
+            const rawDefinitionsBySequence = await this.database.findTermsBySequence(Number(sequence), options.general.mainDictionary);
             const definitionsByGloss = dictTermsMergeByGloss(result, rawDefinitionsBySequence);
 
             const secondarySearchResults = [];

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -154,6 +154,7 @@ class Translator {
             for (const definition of deinflection.definitions) {
                 const tags = await this.expandTags(definition.tags, definition.dictionary);
                 tags.push(dictTagBuildSource(definition.dictionary));
+                const termTags = await this.expandTags(definition.termTags, definition.dictionary);
 
                 definitions.push({
                     source: deinflection.source,
@@ -165,6 +166,7 @@ class Translator {
                     reading: definition.reading,
                     glossary: definition.glossary,
                     tags: dictTagsSort(tags),
+                    termTags: dictTagsSort(termTags),
                     sequence: definition.sequence
                 });
             }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -84,9 +84,11 @@ class Translator {
             const expressions = [];
             for (const expression of result.expressions.keys()) {
                 for (const reading of result.expressions.get(expression).keys()) {
+                    const tags = await this.expandTags(result.expressions.get(expression).get(reading), result.dictionary);
                     expressions.push({
                         expression: expression,
                         reading: reading,
+                        tags: dictTagsSort(tags),
                         jmdictTermFrequency: (tags => {
                             if (tags.has('P')) {
                                 return 'popular';
@@ -109,6 +111,7 @@ class Translator {
 
         const strayDefinitions = definitionsBySequence['-1'].filter((definition, index) => !mergedByTermIndices.has(index));
         for (const groupedDefinition of dictTermsGroup(strayDefinitions, dictionaries)) {
+            groupedDefinition.expressions = [{expression: groupedDefinition.expression, reading: groupedDefinition.reading}];
             definitionsMerged.push(groupedDefinition);
         }
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -113,15 +113,15 @@ class Translator {
                         expression: expression,
                         reading: reading,
                         termTags: dictTagsSort(tags),
-                        jmdictTermFrequency: (tags => {
-                            if (tags.has('P')) {
+                        termFrequency: (score => {
+                            if (score > 0) {
                                 return 'popular';
-                            } else if (dictJmdictTermTagsRare(tags)) {
+                            } else if (score < 0) {
                                 return 'rare';
                             } else {
                                 return 'normal';
                             }
-                        })(result.expressions.get(expression).get(reading))
+                        })(dictTermTagScore(result.expressions.get(expression).get(reading)))
                     });
                 }
             }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -112,7 +112,7 @@ class Translator {
                     expressions.push({
                         expression: expression,
                         reading: reading,
-                        tags: dictTagsSort(tags),
+                        termTags: dictTagsSort(tags),
                         jmdictTermFrequency: (tags => {
                             if (tags.has('P')) {
                                 return 'popular';

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -52,6 +52,21 @@ function utilSetDifference(setA, setB) {
     );
 }
 
+function utilStringHashCode(string) {
+    let hashCode = 0;
+
+    if (string.length === 0) {
+        return hashCode;
+    }
+
+    for (let i = 0, charCode = string.charCodeAt(i); i < string.length; i++) {
+        hashCode = ((hashCode << 5) - hashCode) + charCode;
+        hashCode |= 0;
+    }
+
+    return hashCode;
+}
+
 function utilBackend() {
     return chrome.extension.getBackgroundPage().yomichan_backend;
 }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -26,6 +26,32 @@ function utilIsolate(data) {
     return JSON.parse(JSON.stringify(data));
 }
 
+function utilSetEqual(setA, setB) {
+    if (setA.size !== setB.size) {
+        return false;
+    }
+
+    for (const value of setA) {
+        if (!setB.has(value)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function utilSetIntersection(setA, setB) {
+    return new Set(
+        [...setA].filter(value => setB.has(value))
+    );
+}
+
+function utilSetDifference(setA, setB) {
+    return new Set(
+        [...setA].filter(value => !setB.has(value))
+    );
+}
+
 function utilBackend() {
     return chrome.extension.getBackgroundPage().yomichan_backend;
 }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -59,7 +59,7 @@ function utilStringHashCode(string) {
         return hashCode;
     }
 
-    for (let i = 0, charCode = string.charCodeAt(i); i < string.length; i++) {
+    for (let i = 0, charCode = string.charCodeAt(i); i < string.length; charCode = string.charCodeAt(++i)) {
         hashCode = ((hashCode << 5) - hashCode) + charCode;
         hashCode |= 0;
     }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -87,6 +87,10 @@ function utilDatabaseGetTitles() {
     return utilBackend().translator.database.getTitles();
 }
 
+function utilDatabaseGetTitlesWithSequences() {
+    return utilBackend().translator.database.getTitlesWithSequences();
+}
+
 function utilDatabasePurge() {
     return utilBackend().translator.database.purge();
 }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -55,10 +55,6 @@ function utilSetDifference(setA, setB) {
 function utilStringHashCode(string) {
     let hashCode = 0;
 
-    if (string.length === 0) {
-        return hashCode;
-    }
-
     for (let i = 0, charCode = string.charCodeAt(i); i < string.length; charCode = string.charCodeAt(++i)) {
         hashCode = ((hashCode << 5) - hashCode) + charCode;
         hashCode |= 0;

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -36,6 +36,10 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="compact-tags"> Compact tags</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-advanced-options"> Show advanced options</label>
                 </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -40,10 +40,6 @@
                 </div>
 
                 <div class="checkbox">
-                    <label><input type="checkbox" id="tag-line-break"> Line break after tags</label>
-                </div>
-
-                <div class="checkbox">
                     <label><input type="checkbox" id="compact-glossaries"> Compact glossaries</label>
                 </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -60,11 +60,6 @@
                     </select>
                 </div>
 
-                <div class="form-group options-merge">
-                    <label for="main-dictionary">Main dictionary</label>
-                    <select class="form-control" id="main-dictionary"></select>
-                </div>
-
                 <div class="form-group">
                     <label for="audio-playback-source">Audio playback source</label>
                     <select class="form-control" id="audio-playback-source">
@@ -143,6 +138,11 @@
                 <div>
                     <img src="/mixed/img/spinner.gif" class="pull-right" id="dict-spinner" alt>
                     <h3>Dictionaries</h3>
+                </div>
+
+                <div class="form-group options-merge">
+                    <label for="main-dictionary">Main dictionary</label>
+                    <select class="form-control" id="main-dictionary"></select>
                 </div>
 
                 <p class="help-block">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -40,6 +40,14 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="tag-line-break"> Line break after tags</label>
+                </div>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="compact-glossaries"> Compact glossaries</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-advanced-options"> Show advanced options</label>
                 </div>
 
@@ -48,9 +56,9 @@
                 </div>
 
                 <div class="form-group">
-                    <label for="result-output-mode">Result output mode</label>
+                    <label for="result-output-mode">Result grouping</label>
                     <select class="form-control" id="result-output-mode">
-                        <option value="group">Group results by written form and reading</option>
+                        <option value="group">Group results by term-reading pairs</option>
                         <option value="merge">Group results by main dictionary entry ID (experimental)</option>
                         <option value="split">Split definitions to their own results</option>
                     </select>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -60,6 +60,11 @@
                     </select>
                 </div>
 
+                <div class="form-group options-merge">
+                    <label for="main-dictionary">Main dictionary</label>
+                    <select class="form-control" id="main-dictionary"></select>
+                </div>
+
                 <div class="form-group">
                     <label for="audio-playback-source">Audio playback source</label>
                     <select class="form-control" id="audio-playback-source">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -36,15 +36,20 @@
                 </div>
 
                 <div class="checkbox">
-                    <label><input type="checkbox" id="group-terms-results"> Group term results</label>
-                </div>
-
-                <div class="checkbox">
                     <label><input type="checkbox" id="show-advanced-options"> Show advanced options</label>
                 </div>
 
                 <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="show-debug-info"> Show debug information</label>
+                </div>
+
+                <div class="form-group">
+                    <label for="result-output-mode">Result output mode</label>
+                    <select class="form-control" id="result-output-mode">
+                        <option value="group">Group results by written form and reading</option>
+                        <option value="merge">Group results by main dictionary entry ID (experimental)</option>
+                        <option value="split">Split definitions to their own results</option>
+                    </select>
                 </div>
 
                 <div class="form-group">

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -92,6 +92,10 @@ hr {
     background-color: #5cb85c;
 }
 
+.tag-pos {
+    background-color: #565656;
+}
+
 .actions .disabled {
     pointer-events: none;
     cursor: default;

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -146,6 +146,24 @@ hr {
     visibility: hidden;
 }
 
+.expression .peek-wrapper .action-play-audio {
+    position: absolute;
+    left: 0px;
+    bottom: 10px;
+}
+
+.expression .peek-wrapper .tags {
+    position: absolute;
+    left: 0px;
+    bottom: -10px;
+}
+
+.expression .peek-wrapper .frequencies {
+    position: absolute;
+    left: 0px;
+    bottom: -30px;
+}
+
 .expression:hover .peek-wrapper {
     visibility: visible;
 }

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -124,6 +124,14 @@ hr {
     text-decoration: none;
 }
 
+.expression-popular, .expression-popular a {
+    color: #0275d8;
+}
+
+.expression-rare, .expression-rare a {
+    color: #999;
+}
+
 .reasons {
     color: #777;
     display: inline-block;

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -181,12 +181,30 @@ hr {
     padding-left: 1.4em;
 }
 
+.glossary ul.compact {
+    display: inline;
+    list-style: none;
+    padding-left: 0px;
+}
+
+.glossary .compact li {
+    display: inline;
+}
+
+.glossary .compact li:not(:first-child):before {
+    content: " | ";
+}
+
 .glossary li {
     color: #777;
 }
 
 .glossary-item {
     color: #000;
+}
+
+div.glossary-item.compact {
+    display: inline;
 }
 
 .glyph {

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -177,21 +177,25 @@ hr {
     display: inline-block;
 }
 
+.compact-info {
+    display: inline-block;
+}
+
 .glossary ol, .glossary ul {
     padding-left: 1.4em;
 }
 
-.glossary ul.compact {
+.glossary ul.compact-glossary {
     display: inline;
     list-style: none;
     padding-left: 0px;
 }
 
-.glossary .compact li {
+.glossary .compact-glossary li {
     display: inline;
 }
 
-.glossary .compact li:not(:first-child):before {
+.glossary .compact-glossary li:not(:first-child):before {
     content: " | ";
 }
 
@@ -203,7 +207,7 @@ hr {
     color: #000;
 }
 
-div.glossary-item.compact {
+div.glossary-item.compact-glossary {
     display: inline;
 }
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -118,18 +118,32 @@ hr {
     font-size: 24px;
 }
 
-.expression a {
+.expression .kanji-link {
     border-bottom: 1px #777 dashed;
     color: #333;
     text-decoration: none;
 }
 
-.expression-popular, .expression-popular a {
+.expression-popular, .expression-popular .kanji-link {
     color: #0275d8;
 }
 
-.expression-rare, .expression-rare a {
+.expression-rare, .expression-rare .kanji-link {
     color: #999;
+}
+
+.expression .peek-wrapper {
+    font-size: 14px;
+    white-space: nowrap;
+    display: inline-block;
+    position: relative;
+    width: 0px;
+    height: 0px;
+    visibility: hidden;
+}
+
+.expression:hover .peek-wrapper {
+    visibility: visible;
 }
 
 .reasons {

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -92,7 +92,7 @@ hr {
     background-color: #5cb85c;
 }
 
-.tag-pos {
+.tag-partOfSpeech {
     background-color: #565656;
 }
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -46,6 +46,10 @@ hr {
     display: none;
 }
 
+.invisible {
+    visibility: hidden;
+}
+
 
 /*
  * Entries

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -239,6 +239,8 @@ class Display {
                 grouped: options.general.resultOutputMode === 'group',
                 merged: options.general.resultOutputMode === 'merge',
                 playback: options.general.audioSource !== 'disabled',
+                tagLineBreak: options.general.tagLineBreak,
+                compactGlossaries: options.general.compactGlossaries,
                 debug: options.general.debugInfo
             };
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -185,7 +185,7 @@ class Display {
             80: /* p */ () => {
                 if (e.altKey) {
                     if ($('.entry').eq(this.index).data('type') === 'term') {
-                        this.audioPlay(this.definitions[this.index], -1);
+                        this.audioPlay(this.definitions[this.index], this.options.general.resultOutputMode === 'merge' ? 0 : -1);
                     }
 
                     return true;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -234,7 +234,8 @@ class Display {
             const params = {
                 definitions,
                 addable: options.anki.enable,
-                grouped: options.general.groupResults,
+                grouped: options.general.resultOutputMode === 'group',
+                merged: options.general.resultOutputMode === 'merge',
                 playback: options.general.audioSource !== 'disabled',
                 debug: options.general.debugInfo
             };

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -71,8 +71,10 @@ class Display {
 
     onAudioPlay(e) {
         e.preventDefault();
-        const index = Display.entryIndexFind($(e.currentTarget));
-        this.audioPlay(this.definitions[index]);
+        const link = $(e.currentTarget);
+        const definitionIndex = Display.entryIndexFind(link);
+        const expressionIndex = $(e.currentTarget).closest('.entry').find('.expression .action-play-audio').index(link);
+        this.audioPlay(this.definitions[definitionIndex], expressionIndex);
     }
 
     onNoteAdd(e) {
@@ -380,11 +382,11 @@ class Display {
         }
     }
 
-    async audioPlay(definition) {
+    async audioPlay(definition, expressionIndex) {
         try {
             this.spinner.show();
 
-            let url = await apiAudioGetUrl(definition, this.options.general.audioSource);
+            let url = await apiAudioGetUrl(expressionIndex === -1 ? definition : definition.expressions[expressionIndex], this.options.general.audioSource);
             if (!url) {
                 url = '/mixed/mp3/button.mp3';
             }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -239,7 +239,6 @@ class Display {
                 grouped: options.general.resultOutputMode === 'group',
                 merged: options.general.resultOutputMode === 'merge',
                 playback: options.general.audioSource !== 'disabled',
-                tagLineBreak: options.general.tagLineBreak,
                 compactGlossaries: options.general.compactGlossaries,
                 debug: options.general.debugInfo
             };

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -73,7 +73,7 @@ class Display {
         e.preventDefault();
         const link = $(e.currentTarget);
         const definitionIndex = Display.entryIndexFind(link);
-        const expressionIndex = $(e.currentTarget).closest('.entry').find('.expression .action-play-audio').index(link);
+        const expressionIndex = link.closest('.entry').find('.expression .action-play-audio').index(link);
         this.audioPlay(this.definitions[definitionIndex], expressionIndex);
     }
 
@@ -185,7 +185,7 @@ class Display {
             80: /* p */ () => {
                 if (e.altKey) {
                     if ($('.entry').eq(this.index).data('type') === 'term') {
-                        this.audioPlay(this.definitions[this.index]);
+                        this.audioPlay(this.definitions[this.index], -1);
                     }
 
                     return true;

--- a/tmpl/dictionary.html
+++ b/tmpl/dictionary.html
@@ -3,6 +3,11 @@
 
     <div class="checkbox">
         <label><input type="checkbox" class="dict-enabled" {{#if enabled}}checked{{/if}}> Enable search</label>
+    </div>
+    <div class="checkbox options-advanced">
+        <label><input type="checkbox" class="dict-allow-secondary-searches" {{#if allowSecondarySearches}}checked{{/if}}> Allow secondary searches</label>
+    </div>
+    <div class="radio">
         <label><input type="radio" class="dict-main" {{#if main}}checked{{/if}}> Set as main dictionary</label>
     </div>
     <div class="form-group options-advanced">

--- a/tmpl/dictionary.html
+++ b/tmpl/dictionary.html
@@ -7,9 +7,6 @@
     <div class="checkbox options-advanced">
         <label><input type="checkbox" class="dict-allow-secondary-searches" {{#if allowSecondarySearches}}checked{{/if}}> Allow secondary searches</label>
     </div>
-    <div class="radio">
-        <label><input type="radio" class="dict-main" {{#if main}}checked{{/if}}> Set as main dictionary</label>
-    </div>
     <div class="form-group options-advanced">
         <label for="dict-{{title}}">Result priority</label>
         <input type="number" value="{{priority}}" id="dict-{{title}}" class="form-control dict-priority">

--- a/tmpl/dictionary.html
+++ b/tmpl/dictionary.html
@@ -3,6 +3,7 @@
 
     <div class="checkbox">
         <label><input type="checkbox" class="dict-enabled" {{#if enabled}}checked{{/if}}> Enable search</label>
+        <label><input type="radio" class="dict-main" {{#if main}}checked{{/if}}> Set as main dictionary</label>
     </div>
     <div class="form-group options-advanced">
         <label for="dict-{{title}}">Result priority</label>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -48,14 +48,22 @@
         <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
      --><div class="peek-wrapper">
             {{~#if ../playback~}}
-            <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a><br>
+            <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a>
             {{/if}}
             {{~#if tags~}}
+            <div class="tags">
                 {{~#each tags~}}
                 <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
                 {{/each}}
+            </div>
+            {{/if}}
+            {{~#if frequencies~}}
+            <div class="frequencies">
+                {{~#each frequencies~}}
+                <span class="label label-default tag-frequency">{{dictionary}}:{{frequency}}</span>
+                {{/each}}
+            </div>
             {{/if}}<!--
-         --><span style="display: inline-block;"></span><!--
      --></div><!--
      --><span class="{{#if @last}}invisible{{/if}}">、</span><!--
  --></div>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -31,7 +31,12 @@
         <img src="/mixed/img/entry-current.png" class="current" title="Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)" alt>
     </div>
 
+    {{#if merged}}
+    <div class="expression">{{#kanjiLinks}}{{#expressions}}{{{.}}}{{/expressions}}{{/kanjiLinks}}</div>
+    <div>{{#readings}}{{{.}}}{{/readings}}</div>
+    {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>
+    {{/if}}
 
     {{#if reasons}}
     <div class="reasons">
@@ -60,6 +65,16 @@
         {{else}}
         {{> definition definitions.[0]}}
         {{/if}}
+        {{else if merged}}
+        {{#if definitions.[1]}}
+        <ol>
+            {{#each definitions}}
+            <li>{{> definition}}</li>
+            {{/each}}
+        </ol>
+        {{else}}
+        {{> definition definitions.[0]}}
+        {{/if}}
         {{else}}
         {{> definition}}
         {{/if}}
@@ -74,7 +89,7 @@
 {{#if definitions}}
 {{#each definitions}}
 {{#unless @first}}<hr>{{/unless}}
-{{> term debug=../debug grouped=../grouped addable=../addable playback=../playback}}
+{{> term debug=../debug grouped=../grouped merged=../merged addable=../addable playback=../playback}}
 {{/each}}
 {{else}}
 <p class="note">No results found.</p>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -80,6 +80,14 @@
     </div>
     {{/if}}
 
+    {{#if termTags}}
+    <div>
+        {{#each termTags}}
+        <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
+        {{/each}}
+    </div>
+    {{/if}}
+
     {{#if frequencies}}
     <div>
         {{#each frequencies}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,7 +1,7 @@
 {{#*inline "definition"}}
-{{#if tags}}
+{{#if definitionTags}}
 <div>
-    {{#each tags}}
+    {{#each definitionTags}}
     <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
     {{/each}}
 </div>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -59,9 +59,9 @@
             {{~/if~}}
             {{~#if frequencies~}}
             <div class="frequencies">
-                {{~#each frequencies~}}
+                {{~#each frequencies}}
                 <span class="label label-default tag-frequency">{{dictionary}}:{{frequency}}</span>
-                {{~/each~}}
+                {{/each~}}
             </div>
             {{~/if~}}
         </div><!--

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,13 +1,13 @@
 {{#*inline "definition"}}
 {{#if definitionTags}}
-<div {{#if compactGlossaries}}style="display: inline-block;"{{/if}}>
+<div {{#if compactGlossaries}}class="compact-info"{{/if}}>
     {{#each definitionTags}}
     <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
     {{/each}}
 </div>
 {{/if}}
 {{#if only}}
-<div {{#if compactGlossaries}}style="display: inline-block;"{{/if}}>
+<div {{#if compactGlossaries}}class="compact-info"{{/if}}>
     (
     {{~#each only~}}
     {{{.}}}{{#unless @last}}, {{/unless}}
@@ -16,13 +16,13 @@
 </div>
 {{/if}}
 {{#if glossary.[1]}}
-<ul {{#if compactGlossaries}}class="compact"{{/if}}>
+<ul {{#if compactGlossaries}}class="compact-glossary"{{/if}}>
     {{#each glossary}}
     <li><span class="glossary-item">{{#multiLine}}{{.}}{{/multiLine}}</span></li>
     {{/each}}
 </ul>
 {{else}}
-<div class="glossary-item {{#if compactGlossaries}}compact{{/if}}">{{#multiLine}}{{glossary.[0]}}{{/multiLine}}</div>
+<div class="glossary-item {{#if compactGlossaries}}compact-glossary{{/if}}">{{#multiLine}}{{glossary.[0]}}{{/multiLine}}</div>
 {{/if}}
 {{/inline}}
 

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -52,9 +52,9 @@
             {{~/if~}}
             {{~#if termTags~}}
             <div class="tags">
-                {{~#each termTags~}}
+                {{~#each termTags}}
                 <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
-                {{~/each~}}
+                {{/each~}}
             </div>
             {{~/if~}}
             {{~#if frequencies~}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -43,8 +43,7 @@
     {{#if merged}}
     {{#each expressions}}
     <div class="expression">
-        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span>
-        {{#unless @last}}、{{/unless}}
+        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span>{{#unless @last}}、{{/unless}}
     </div>
     {{/each}}
     {{else}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,13 +1,13 @@
 {{#*inline "definition"}}
 {{#if definitionTags}}
-<div>
+<div {{#unless tagLineBreak}}style="display: inline-block;"{{/unless}}>
     {{#each definitionTags}}
     <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
     {{/each}}
 </div>
 {{/if}}
 {{#if only}}
-<div>
+<div {{#if compactGlossaries}}style="display: inline-block;"{{/if}}>
     (
     {{~#each only~}}
     {{{.}}}{{#unless @last}}, {{/unless}}
@@ -16,13 +16,13 @@
 </div>
 {{/if}}
 {{#if glossary.[1]}}
-<ul>
+<ul {{#if compactGlossaries}}class="compact"{{/if}}>
     {{#each glossary}}
     <li><span class="glossary-item">{{#multiLine}}{{.}}{{/multiLine}}</span></li>
     {{/each}}
 </ul>
 {{else}}
-<div class="glossary-item">{{#multiLine}}{{glossary.[0]}}{{/multiLine}}</div>
+<div class="glossary-item {{#if compactGlossaries}}compact{{/if}}">{{#multiLine}}{{glossary.[0]}}{{/multiLine}}</div>
 {{/if}}
 {{/inline}}
 
@@ -70,20 +70,19 @@
     {{/each}}
     {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>
+    {{#if termTags}}
+    <div style="display: inline-block;">
+        {{#each termTags}}
+        <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
+        {{/each}}
+    </div>
+    {{/if}}
     {{/if}}
 
     {{#if reasons}}
     <div class="reasons">
         {{#each reasons}}
         <span class="reasons">{{.}}</span> {{#unless @last}}&laquo;{{/unless}}
-        {{/each}}
-    </div>
-    {{/if}}
-
-    {{#if termTags}}
-    <div>
-        {{#each termTags}}
-        <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
         {{/each}}
     </div>
     {{/if}}
@@ -101,24 +100,24 @@
         {{#if definitions.[1]}}
         <ol>
             {{#each definitions}}
-            <li>{{> definition}}</li>
+            <li>{{> definition tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}</li>
             {{/each}}
         </ol>
         {{else}}
-        {{> definition definitions.[0]}}
+        {{> definition definitions.[0] tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
         {{/if}}
         {{else if merged}}
         {{#if definitions.[1]}}
         <ol>
             {{#each definitions}}
-            <li>{{> definition}}</li>
+            <li>{{> definition tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}</li>
             {{/each}}
         </ol>
         {{else}}
-        {{> definition definitions.[0]}}
+        {{> definition definitions.[0] tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
         {{/if}}
         {{else}}
-        {{> definition}}
+        {{> definition tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
         {{/if}}
     </div>
 
@@ -131,7 +130,7 @@
 {{#if definitions}}
 {{#each definitions}}
 {{#unless @first}}<hr>{{/unless}}
-{{> term debug=../debug grouped=../grouped merged=../merged addable=../addable playback=../playback}}
+{{> term debug=../debug grouped=../grouped merged=../merged addable=../addable playback=../playback tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}
 {{/each}}
 {{else}}
 <p class="note">No results found.</p>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -57,8 +57,8 @@
             {{/if}}<!--
          --><span style="display: inline-block;"></span><!--
      --></div><!--
-     -->{{~#unless @last~}}、{{/unless}}
-    </div>
+     --><span class="{{#if @last}}invisible{{/if}}">、</span><!--
+ --></div>
     {{/each}}
     {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -43,31 +43,31 @@
     </div>
 
     {{#if merged}}
-    {{#each expressions}}
-    <div class="expression">
-        <span class="expression-{{termFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
+    {{~#each expressions~}}
+    <div class="expression"><!--
+     --><span class="expression-{{termFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
      --><div class="peek-wrapper">
             {{~#if ../playback~}}
             <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a>
-            {{/if}}
+            {{~/if~}}
             {{~#if termTags~}}
             <div class="tags">
                 {{~#each termTags~}}
                 <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
-                {{/each}}
+                {{~/each~}}
             </div>
-            {{/if}}
+            {{~/if~}}
             {{~#if frequencies~}}
             <div class="frequencies">
                 {{~#each frequencies~}}
                 <span class="label label-default tag-frequency">{{dictionary}}:{{frequency}}</span>
-                {{/each}}
+                {{~/each~}}
             </div>
-            {{/if}}<!--
-     --></div><!--
+            {{~/if~}}
+        </div><!--
      --><span class="{{#if @last}}invisible{{/if}}">、</span><!--
  --></div>
-    {{/each}}
+    {{~/each~}}
     {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>
     {{#if termTags}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -45,7 +45,7 @@
     {{#if merged}}
     {{#each expressions}}
     <div class="expression">
-        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
+        <span class="expression-{{termFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
      --><div class="peek-wrapper">
             {{~#if ../playback~}}
             <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,4 +1,13 @@
 {{#*inline "definition"}}
+{{#if only}}
+<div>
+    (
+    {{~#each only~}}
+    {{{.}}}{{#unless @last}}, {{/unless}}
+    {{/each}}
+    only)
+</div>
+{{/if}}
 {{#if tags}}
 <div>
     {{#each tags}}
@@ -32,8 +41,12 @@
     </div>
 
     {{#if merged}}
-    <div class="expression">{{#kanjiLinks}}{{#expressions}}{{{.}}}{{/expressions}}{{/kanjiLinks}}</div>
-    <div>{{#readings}}{{{.}}}{{/readings}}</div>
+    {{#each expressions}}
+    <div class="expression">
+        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span>
+        {{#unless @last}}、{{/unless}}
+    </div>
+    {{/each}}
     {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>
     {{/if}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,4 +1,11 @@
 {{#*inline "definition"}}
+{{#if tags}}
+<div>
+    {{#each tags}}
+    <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
+    {{/each}}
+</div>
+{{/if}}
 {{#if only}}
 <div>
     (
@@ -6,13 +13,6 @@
     {{{.}}}{{#unless @last}}, {{/unless}}
     {{/each}}
     only)
-</div>
-{{/if}}
-{{#if tags}}
-<div>
-    {{#each tags}}
-    <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
-    {{/each}}
 </div>
 {{/if}}
 {{#if glossary.[1]}}

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -1,6 +1,6 @@
 {{#*inline "definition"}}
 {{#if definitionTags}}
-<div {{#unless tagLineBreak}}style="display: inline-block;"{{/unless}}>
+<div {{#if compactGlossaries}}style="display: inline-block;"{{/if}}>
     {{#each definitionTags}}
     <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
     {{/each}}
@@ -100,24 +100,24 @@
         {{#if definitions.[1]}}
         <ol>
             {{#each definitions}}
-            <li>{{> definition tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}</li>
+            <li>{{> definition compactGlossaries=../compactGlossaries}}</li>
             {{/each}}
         </ol>
         {{else}}
-        {{> definition definitions.[0] tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
+        {{> definition definitions.[0] compactGlossaries=compactGlossaries}}
         {{/if}}
         {{else if merged}}
         {{#if definitions.[1]}}
         <ol>
             {{#each definitions}}
-            <li>{{> definition tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}</li>
+            <li>{{> definition compactGlossaries=../compactGlossaries}}</li>
             {{/each}}
         </ol>
         {{else}}
-        {{> definition definitions.[0] tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
+        {{> definition definitions.[0] compactGlossaries=compactGlossaries}}
         {{/if}}
         {{else}}
-        {{> definition tagLineBreak=tagLineBreak compactGlossaries=compactGlossaries}}
+        {{> definition compactGlossaries=compactGlossaries}}
         {{/if}}
     </div>
 
@@ -130,7 +130,7 @@
 {{#if definitions}}
 {{#each definitions}}
 {{#unless @first}}<hr>{{/unless}}
-{{> term debug=../debug grouped=../grouped merged=../merged addable=../addable playback=../playback tagLineBreak=../tagLineBreak compactGlossaries=../compactGlossaries}}
+{{> term debug=../debug grouped=../grouped merged=../merged addable=../addable playback=../playback compactGlossaries=../compactGlossaries}}
 {{/each}}
 {{else}}
 <p class="note">No results found.</p>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -50,9 +50,9 @@
             {{~#if ../playback~}}
             <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a>
             {{/if}}
-            {{~#if tags~}}
+            {{~#if termTags~}}
             <div class="tags">
-                {{~#each tags~}}
+                {{~#each termTags~}}
                 <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
                 {{/each}}
             </div>

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -34,16 +34,30 @@
         <a href="#" class="action-add-note pending disabled" data-mode="term-kanji"><img src="/mixed/img/add-term-kanji.png" title="Add expression (Alt + E)" alt></a>
         <a href="#" class="action-add-note pending disabled" data-mode="term-kana"><img src="/mixed/img/add-term-kana.png" title="Add reading (Alt + R)" alt></a>
         {{/if}}
+        {{#unless merged}}
         {{#if playback}}
         <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio (Alt + P)" alt></a>
         {{/if}}
+        {{/unless}}
         <img src="/mixed/img/entry-current.png" class="current" title="Current entry (Alt + Up/Down/Home/End/PgUp/PgDn)" alt>
     </div>
 
     {{#if merged}}
     {{#each expressions}}
     <div class="expression">
-        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span>{{#unless @last}}、{{/unless}}
+        <span class="expression-{{jmdictTermFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><!--
+     --><div class="peek-wrapper">
+            {{~#if ../playback~}}
+            <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a><br>
+            {{/if}}
+            {{~#if tags~}}
+                {{~#each tags~}}
+                <span class="label label-default tag-{{category}}" title="{{notes}}">{{name}}</span>
+                {{/each}}
+            {{/if}}<!--
+         --><span style="display: inline-block;"></span><!--
+     --></div><!--
+     -->{{~#unless @last~}}、{{/unless}}
     </div>
     {{/each}}
     {{else}}


### PR DESCRIPTION
I can't find anything major to change or implement, so I'm opening this pull request. Some minor things below:

- I'm not sure if `compactTags` and `compactGlossaries` should be on by default for [new users](https://github.com/siikamiika/yomichan/blob/feature-merge-similar-results/ext/bg/js/options.js#L196). They will be off for [existing users](https://github.com/siikamiika/yomichan/blob/feature-merge-similar-results/ext/bg/js/options.js#L270).

- I tested on a Windows Firefox that `utilStringHashCode` gives the same hash for the first revision of the field templates (it could have messed up with `\r\n` after `formRead`). Can we trust this or should the string be normalized before hashing?