### PR TITLE
merged mode: remove whitespace between expressions

### DIFF
--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -314,19 +314,19 @@ templates['terms.html'] = template({"1":function(container,depth0,helpers,partia
   return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.expressions : depth0),{"name":"each","hash":{},"fn":container.program(29, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"29":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", buffer = 
-  "<div class=\"expression\">\n        <span class=\"expression-"
+  "<div class=\"expression\"><span class=\"expression-"
     + container.escapeExpression(((helper = (helper = helpers.termFrequency || (depth0 != null ? depth0.termFrequency : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"termFrequency","hash":{},"data":data}) : helper)))
     + "\">";
   stack1 = ((helper = (helper = helpers.kanjiLinks || (depth0 != null ? depth0.kanjiLinks : depth0)) != null ? helper : alias2),(options={"name":"kanjiLinks","hash":{},"fn":container.program(30, data, 0, blockParams, depths),"inverse":container.noop,"data":data}),(typeof helper === alias3 ? helper.call(alias1,options) : helper));
   if (!helpers.kanjiLinks) { stack1 = helpers.blockHelperMissing.call(depth0,stack1,options)}
   if (stack1 != null) { buffer += stack1; }
-  return buffer + "</span>\n        <div class=\"peek-wrapper\">"
+  return buffer + "</span><div class=\"peek-wrapper\">"
     + ((stack1 = helpers["if"].call(alias1,(depths[1] != null ? depths[1].playback : depths[1]),{"name":"if","hash":{},"fn":container.program(33, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.termTags : depth0),{"name":"if","hash":{},"fn":container.program(35, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.frequencies : depth0),{"name":"if","hash":{},"fn":container.program(38, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "</div>\n        <span class=\""
+    + "</div><span class=\""
     + ((stack1 = helpers["if"].call(alias1,(data && data.last),{"name":"if","hash":{},"fn":container.program(41, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "")
-    + "\">、</span>\n    </div>";
+    + "\">、</span></div>";
 },"30":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options;
 

--- a/tmpl/terms.html
+++ b/tmpl/terms.html
@@ -44,9 +44,7 @@
 
     {{#if merged}}
     {{~#each expressions~}}
-    <div class="expression">
-        <span class="expression-{{termFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span>
-        <div class="peek-wrapper">
+    <div class="expression"><span class="expression-{{termFrequency}}">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</span><div class="peek-wrapper">
             {{~#if ../playback~}}
             <a href="#" class="action-play-audio"><img src="/mixed/img/play-audio.png" title="Play audio" alt></a>
             {{~/if~}}
@@ -64,9 +62,7 @@
                 {{/each~}}
             </div>
             {{~/if~}}
-        </div>
-        <span class="{{#if @last}}invisible{{/if}}">、</span>
-    </div>
+    </div><span class="{{#if @last}}invisible{{/if}}">、</span></div>
     {{~/each~}}
     {{else}}
     <div class="expression">{{#kanjiLinks}}{{#furigana}}{{{.}}}{{/furigana}}{{/kanjiLinks}}</div>


### PR DESCRIPTION
The CSS way would have required editing markup for other modes, too (`.expression` `font-size` to `0px` and `.expression *` `font-size` to `24px` or something similar but that would make https://github.com/FooSoft/yomichan/blob/dcef7ce3774a3dcc8e7bee0bc17398251523451e/tmpl/terms.html#L72 invisible)

Another stupid hack:
```html
<e1>...</e1
><e2>...</e2>
```