### PR TITLE
Add option to play audio automatically

### DIFF
--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -185,6 +185,7 @@ function optionsSetDefaults(options) {
             enable: true,
             audioSource: 'jpod101',
             audioVolume: 100,
+            autoPlayAudio: false,
             resultOutputMode: 'group',
             debugInfo: false,
             maxResults: 32,

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -24,6 +24,7 @@ async function formRead() {
     optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
     optionsNew.general.compactTags = $('#compact-tags').prop('checked');
     optionsNew.general.compactGlossaries = $('#compact-glossaries').prop('checked');
+    optionsNew.general.autoPlayAudio = $('#auto-play-audio').prop('checked');
     optionsNew.general.resultOutputMode = $('#result-output-mode').val();
     optionsNew.general.audioSource = $('#audio-playback-source').val();
     optionsNew.general.audioVolume = parseFloat($('#audio-playback-volume').val());
@@ -153,6 +154,7 @@ async function onReady() {
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
     $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
+    $('#auto-play-audio').prop('checked', options.general.autoPlayAudio);
     $('#result-output-mode').val(options.general.resultOutputMode);
     $('#audio-playback-source').val(options.general.audioSource);
     $('#audio-playback-volume').val(options.general.audioVolume);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -44,6 +44,10 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="auto-play-audio"> Play audio automatically</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-advanced-options"> Show advanced options</label>
                 </div>
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -20,6 +20,8 @@
 class DisplayFloat extends Display {
     constructor() {
         super($('#spinner'), $('#definitions'));
+        this.autoPlayAudioTimer = null;
+
         $(window).on('message', utilAsync(this.onMessage.bind(this)));
     }
 
@@ -54,6 +56,10 @@ class DisplayFloat extends Display {
                 this.kanjiShow(definitions, options, context);
             },
 
+            clearAutoPlayTimer: () => {
+                this.clearAutoPlayTimer();
+            },
+
             orphaned: () => {
                 this.onOrphaned();
             }
@@ -81,6 +87,18 @@ class DisplayFloat extends Display {
             e.preventDefault();
         } else {
             super.onKeyDown(e);
+        }
+    }
+
+    autoPlayAudio() {
+        this.clearAutoPlayTimer();
+        this.autoPlayAudioTimer = window.setTimeout(() => super.autoPlayAudio(), 400);
+    }
+
+    clearAutoPlayTimer() {
+        if (this.autoPlayAudioTimer) {
+            window.clearTimeout(this.autoPlayAudioTimer);
+            this.autoPlayAudioTimer = null;
         }
     }
 }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -254,6 +254,7 @@ class Frontend {
     searchClear() {
         docImposterDestroy();
         this.popup.hide();
+        this.popup.clearAutoPlayTimer()
 
         if (this.options.scanning.selectText && this.textSourceLast) {
             this.textSourceLast.deselect();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -125,6 +125,12 @@ class Popup {
         this.invokeApi('kanjiShow', {definitions, options, context});
     }
 
+    clearAutoPlayTimer() {
+        if (this.injected) {
+            this.invokeApi('clearAutoPlayTimer');
+        }
+    }
+
     invokeApi(action, params={}) {
         this.container.contentWindow.postMessage({action, params}, '*');
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -185,8 +185,7 @@ class Display {
             80: /* p */ () => {
                 if (e.altKey) {
                     if ($('.entry').eq(this.index).data('type') === 'term') {
-                        const expressionIndex = this.options.general.resultOutputMode === 'merge' ? 0 : -1;
-                        this.audioPlay(this.definitions[this.index], expressionIndex);
+                        this.audioPlay(this.definitions[this.index], this.firstExpressionIndex);
                     }
 
                     return true;
@@ -258,6 +257,10 @@ class Display {
             this.container.html(content);
             this.entryScrollIntoView(context && context.index || 0);
 
+            if (this.options.general.autoPlayAudio && this.options.general.audioSource !== 'disabled') {
+                this.autoPlayAudio();
+            }
+
             $('.action-add-note').click(this.onNoteAdd.bind(this));
             $('.action-view-note').click(this.onNoteView.bind(this));
             $('.action-play-audio').click(this.onAudioPlay.bind(this));
@@ -307,6 +310,10 @@ class Display {
         } catch (e) {
             this.onError(e);
         }
+    }
+
+    autoPlayAudio() {
+        this.audioPlay(this.definitions[0], this.firstExpressionIndex);
     }
 
     async adderButtonUpdate(modes, sequence) {
@@ -420,6 +427,10 @@ class Display {
         } finally {
             this.spinner.hide();
         }
+    }
+
+    get firstExpressionIndex() {
+        return this.options.general.resultOutputMode === 'merge' ? 0 : -1;
     }
 
     static clozeBuild(sentence, source) {


### PR DESCRIPTION
Adds an option to play the audio of the first term automatically when a popup opens and when a search is performed. This was the only feature I missed from Rikaisama other than the pitch accent information. Personally I always want to play the audio of the word I'm checking, and ALT+P is awkward to press with only your left hand.