### PR TITLE
Add support for touch input

### DIFF
--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -190,6 +190,7 @@ function optionsSetDefaults(options) {
             debugInfo: false,
             maxResults: 32,
             showAdvanced: false,
+            popupDisplayMode: 'default',
             popupWidth: 400,
             popupHeight: 250,
             popupOffset: 10,

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -201,6 +201,7 @@ function optionsSetDefaults(options) {
 
         scanning: {
             middleMouse: true,
+            touchInputEnabled: true,
             selectText: true,
             alphanumeric: true,
             autoHideResults: false,

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -36,6 +36,7 @@ async function formRead() {
     optionsNew.general.popupOffset = parseInt($('#popup-offset').val(), 10);
 
     optionsNew.scanning.middleMouse = $('#middle-mouse-button-scan').prop('checked');
+    optionsNew.scanning.touchInputEnabled = $('#touch-input-enabled').prop('checked');
     optionsNew.scanning.selectText = $('#select-matched-text').prop('checked');
     optionsNew.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
     optionsNew.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
@@ -166,6 +167,7 @@ async function onReady() {
     $('#popup-offset').val(options.general.popupOffset);
 
     $('#middle-mouse-button-scan').prop('checked', options.scanning.middleMouse);
+    $('#touch-input-enabled').prop('checked', options.scanning.touchInputEnabled);
     $('#select-matched-text').prop('checked', options.scanning.selectText);
     $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
     $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -31,6 +31,7 @@ async function formRead() {
     optionsNew.general.debugInfo = $('#show-debug-info').prop('checked');
     optionsNew.general.showAdvanced = $('#show-advanced-options').prop('checked');
     optionsNew.general.maxResults = parseInt($('#max-displayed-results').val(), 10);
+    optionsNew.general.popupDisplayMode = $('#popup-display-mode').val();
     optionsNew.general.popupWidth = parseInt($('#popup-width').val(), 10);
     optionsNew.general.popupHeight = parseInt($('#popup-height').val(), 10);
     optionsNew.general.popupOffset = parseInt($('#popup-offset').val(), 10);
@@ -162,6 +163,7 @@ async function onReady() {
     $('#show-debug-info').prop('checked', options.general.debugInfo);
     $('#show-advanced-options').prop('checked', options.general.showAdvanced);
     $('#max-displayed-results').val(options.general.maxResults);
+    $('#popup-display-mode').val(options.general.popupDisplayMode);
     $('#popup-width').val(options.general.popupWidth);
     $('#popup-height').val(options.general.popupHeight);
     $('#popup-offset').val(options.general.popupOffset);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -74,6 +74,14 @@
                     </select>
                 </div>
 
+                <div class="form-group">
+                    <label for="popup-display-mode">Popup display mode</label>
+                    <select class="form-control" id="popup-display-mode">
+                        <option value="default">Default</option>
+                        <option value="full-width">Full width</option>
+                    </select>
+                </div>
+
                 <div class="form-group options-advanced">
                     <label for="audio-playback-volume">Audio playback volume (percent)</label>
                     <input type="number" min="0" max="100" id="audio-playback-volume" class="form-control">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -106,6 +106,10 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="touch-input-enabled"> Touch input enabled</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="select-matched-text"> Select matched text</label>
                 </div>
 

--- a/ext/fg/css/client.css
+++ b/ext/fg/css/client.css
@@ -27,3 +27,25 @@ iframe#yomichan-float {
     visibility: hidden;
     z-index: 2147483647;
 }
+
+iframe#yomichan-float.yomichan-float-full-width {
+    border-left: none;
+    border-right: none;
+    left: 0 !important;
+    right: 0 !important;
+    width: 100% !important;
+    box-sizing: border-box;
+    resize: none;
+}
+
+iframe#yomichan-float.yomichan-float-full-width:not(.yomichan-float-above) {
+    border-bottom: none;
+    top: auto !important;
+    bottom: 0 !important;
+}
+
+iframe#yomichan-float.yomichan-float-full-width.yomichan-float-above {
+    border-top: none;
+    top: 0 !important;
+    bottom: auto !important;
+}

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -92,7 +92,19 @@ function docRangeFromPoint(point) {
 
     if(imposter !== null) imposter.style.zIndex = -2147483646;
 
-    const rect = range.getClientRects()[0];
+    let rects;
+    try {
+        rects = range.getClientRects();
+    }
+    catch (e) {
+        return;
+    }
+
+    if (rects.length === 0) {
+        return;
+    }
+
+    const rect = rects[0];
     if (point.y > rect.bottom + 2) {
         return;
     }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -85,20 +85,18 @@ function docRangeFromPoint(point) {
                 range.setEnd(position.offsetNode, position.offset);
                 return range;
             }
+            return null;
         };
     }
 
     const range = document.caretRangeFromPoint(point.x, point.y);
+    if (range === null) {
+        return;
+    }
 
     if(imposter !== null) imposter.style.zIndex = -2147483646;
 
-    let rects;
-    try {
-        rects = range.getClientRects();
-    }
-    catch (e) {
-        return;
-    }
+    const rects = range.getClientRects();
 
     if (rects.length === 0) {
         return;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -96,7 +96,7 @@ class Frontend {
 
         const search = async () => {
             try {
-                await this.searchAt({x: e.clientX, y: e.clientY}, Frontend.SearchType.Mouse);
+                await this.searchAt({x: e.clientX, y: e.clientY}, 'mouse');
             } catch (e) {
                 this.onError(e);
             }
@@ -203,7 +203,7 @@ class Frontend {
         }
 
         const touch = touches[index];
-        this.searchFromTouch(touch.clientX, touch.clientY, Frontend.SearchType.TouchMove);
+        this.searchFromTouch(touch.clientX, touch.clientY, 'touchMove');
 
         e.preventDefault(); // Disable scroll
     }
@@ -218,7 +218,7 @@ class Frontend {
     }
 
     onAfterSearch(newRange, type, searched, success) {
-        if (type === Frontend.SearchType.Mouse) {
+        if (type === 'mouse') {
             return;
         }
 
@@ -228,7 +228,7 @@ class Frontend {
             return;
         }
 
-        if (type === Frontend.SearchType.TouchStart && newRange !== null) {
+        if (type === 'touchStart' && newRange !== null) {
             this.scrollPrevent = true;
         }
 
@@ -377,7 +377,7 @@ class Frontend {
     }
 
     getIndexOfTouch(touchList, identifier) {
-        for (let i = 0, ii = touchList.length; i < ii; ++i) {
+        for (let i in touchList) {
             let t = touchList[i];
             if (t.identifier === identifier) {
                 return i;
@@ -388,8 +388,7 @@ class Frontend {
 
     excludeTouches(touchList, excludeTouchList) {
         const result = [];
-        for (let i = 0, ii = touchList.length; i < ii; ++i) {
-            let r = result[i];
+        for (let r of touchList) {
             if (this.getIndexOfTouch(excludeTouchList, r.identifier) < 0) {
                 result.push(r);
             }
@@ -416,7 +415,7 @@ class Frontend {
             this.setMouseDownPrevent(false, false);
             this.setClickPrevent(false);
 
-            this.searchFromTouch(touch.clientX, touch.clientY, Frontend.SearchType.TouchStart);
+            this.searchFromTouch(touch.clientX, touch.clientY, 'touchStart');
         }
     }
 
@@ -443,11 +442,9 @@ class Frontend {
             return;
         }
 
-        const pos = {x: x, y: y};
-
         const search = async () => {
             try {
-                await this.searchAt(pos, type);
+                await this.searchAt({x, y}, type);
             } catch (e) {
                 this.onError(e);
             }
@@ -456,12 +453,6 @@ class Frontend {
         search();
     }
 }
-
-Frontend.SearchType = {
-    Mouse: 0,
-    TouchStart: 1,
-    TouchMove: 2
-};
 
 window.yomichan_frontend = new Frontend();
 window.yomichan_frontend.prepare();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -62,6 +62,7 @@ class Popup {
             }
         }
 
+        let above = false;
         let y = 0;
         let height = Math.max(containerHeight, options.general.popupHeight);
         const yBelow = elementRect.bottom + options.general.popupOffset;
@@ -75,11 +76,14 @@ class Popup {
             } else {
                 height = Math.max(height - overflowAbove, 0);
                 y = Math.max(yAbove - height, 0);
+                above = true;
             }
         } else {
             y = yBelow;
         }
 
+        this.container.classList.toggle('yomichan-float-full-width', options.general.popupDisplayMode === 'full-width');
+        this.container.classList.toggle('yomichan-float-above', above);
         this.container.style.left = `${x}px`;
         this.container.style.top = `${y}px`;
         this.container.style.width = `${width}px`;

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -27,6 +27,10 @@
     }],
     "minimum_chrome_version": "57.0.0.0",
     "options_page": "bg/settings.html",
+    "options_ui": {
+        "page": "bg/settings.html",
+        "open_in_tab": true
+    },
     "permissions": [
         "<all_urls>",
         "storage",


### PR DESCRIPTION
* Text can now be touched to bring up the dictionary popup.
* Feature can be enabled or disabled through settings (enabled by default).
* When touch input is disabled, touch events will not be hooked.
* An option to allow the dictionary popup be fixed to the bottom or top of the page has also been added. This mode may be less intrusive when physically touching a screen and moving along the text.
* Touch inputs can be tested without a touchscreen in Chrome by using the touchscreen device simulation mode.