### PR TITLE
Add support for mobile Firefox

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
     </head>
     <body>
         <script src="/mixed/lib/dexie.min.js"></script>

--- a/ext/bg/context.html
+++ b/ext/bg/context.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap-toggle/bootstrap-toggle.min.css">

--- a/ext/bg/guide.html
+++ b/ext/bg/guide.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>Welcome to Yomichan!</title>
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -28,7 +28,9 @@ class Backend {
         await this.translator.prepare();
         await apiOptionsSet(await optionsLoad());
 
-        chrome.commands.onCommand.addListener(this.onCommand.bind(this));
+        if (chrome.commands !== null && typeof chrome.commands === 'object') {
+            chrome.commands.onCommand.addListener(this.onCommand.bind(this));
+        }
         chrome.runtime.onMessage.addListener(this.onMessage.bind(this));
 
         if (this.options.general.showGuide) {
@@ -40,13 +42,13 @@ class Backend {
         this.options = utilIsolate(options);
 
         if (!options.general.enable) {
-            chrome.browserAction.setBadgeBackgroundColor({color: '#555555'});
-            chrome.browserAction.setBadgeText({text: 'off'});
+            this.setExtensionBadgeBackgroundColor('#555555');
+            this.setExtensionBadgeText('off');
         } else if (!dictConfigured(options)) {
-            chrome.browserAction.setBadgeBackgroundColor({color: '#f0ad4e'});
-            chrome.browserAction.setBadgeText({text: '!'});
+            this.setExtensionBadgeBackgroundColor('#f0ad4e');
+            this.setExtensionBadgeText('!');
         } else {
-            chrome.browserAction.setBadgeText({text: ''});
+            this.setExtensionBadgeText('');
         }
 
         if (options.anki.enable) {
@@ -124,6 +126,18 @@ class Backend {
         }
 
         return true;
+    }
+
+    setExtensionBadgeBackgroundColor(color) {
+        if (typeof chrome.browserAction.setBadgeBackgroundColor === 'function') {
+            chrome.browserAction.setBadgeBackgroundColor({color});
+        }
+    }
+    
+    setExtensionBadgeText(text) {
+        if (typeof chrome.browserAction.setBadgeText === 'function') {
+            chrome.browserAction.setBadgeText({text});
+        }
     }
 }
 

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -87,6 +87,6 @@ function utilDatabasePurge() {
     return utilBackend().translator.database.purge();
 }
 
-function utilDatabaseImport(data, progress) {
-    return utilBackend().translator.database.importDictionary(data, progress);
+function utilDatabaseImport(data, progress, exceptions) {
+    return utilBackend().translator.database.importDictionary(data, progress, exceptions);
 }

--- a/ext/bg/legal.html
+++ b/ext/bg/legal.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>Yomichan Legal</title>
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>Yomichan Search</title>
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -9,7 +9,7 @@
         <style>
             #anki-spinner, #anki-general, #anki-error,
             #dict-spinner, #dict-error, #dict-warning, #dict-purge, #dict-import-progress,
-            #debug, .options-advanced {
+            #debug, .options-advanced, .storage-hidden, #storage-spinner {
                 display: none;
             }
 
@@ -28,6 +28,17 @@
 
             .bottom-links {
                 padding-bottom: 1em;
+            }
+
+            [data-show-for-browser] {
+                display: none;
+            }
+
+            [data-browser=edge] [data-show-for-browser~=edge],
+            [data-browser=chrome] [data-show-for-browser~=chrome],
+            [data-browser=firefox] [data-show-for-browser~=firefox],
+            [data-browser=firefox-mobile] [data-show-for-browser~=firefox-mobile] {
+                display: initial;
             }
         </style>
     </head>
@@ -194,6 +205,40 @@
                         for use with this extension and to learn about importing proprietary EPWING dictionaries.
                     </p>
                     <input type="file" id="dict-file">
+                </div>
+            </div>
+
+            <div id="storage-info" class="storage-hidden">
+                <div>
+                    <img src="/mixed/img/spinner.gif" class="pull-right" id="storage-spinner" />
+                    <h3>Storage</h3>
+                </div>
+
+                <div id="storage-use" class="storage-hidden">
+                    <p class="help-block">
+                        Yomichan is using approximately <strong id="storage-usage"></strong> of <strong id="storage-quota"></strong>.
+                    </p>
+                </div>
+
+                <div id="storage-error" class="storage-hidden">
+                    <p class="help-block">
+                        Could not detect how much storage Yomichan is using.
+                    </p>
+                    <div data-show-for-browser="firefox firefox-mobile"><div class="alert alert-danger options-advanced">
+                        On Firefox and Firefox for Android, the storage information feature may be hidden behind a browser flag.
+
+                        If you would like to enable this flag, open <a href="about:config" target="_blank">about:config</a> and search for the
+                        <strong>dom.storageManager.enabled</strong> option. If this option has a value of <strong>false</strong>, toggling it to
+                        <strong>true</strong> may allow storage information to be calculated.
+                    </div></div>
+                </div>
+
+                <div data-show-for-browser="firefox-mobile"><div class="alert alert-warning">
+                    If you are using Firefox for Android, you will have to make sure you have enough free space on your device to install dictionaries.
+                </div></div>
+
+                <div>
+                    <input type="button" value="Refresh" id="storage-refresh" />
                 </div>
             </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -25,6 +25,10 @@
                 overflow-x: hidden;
                 white-space: pre;
             }
+
+            .bottom-links {
+                padding-bottom: 1em;
+            }
         </style>
     </head>
     <body>
@@ -311,8 +315,8 @@
 
             <pre id="debug"></pre>
 
-            <div class="pull-right">
-                <small><a href="https://foosoft.net/projects/yomichan/" target="_blank">Homepage</a> &bull; <a href="legal.html">Legal</a></small>
+            <div class="pull-right bottom-links">
+                <small><a href="search.html">Search</a> &bull; <a href="https://foosoft.net/projects/yomichan/" target="_blank">Homepage</a> &bull; <a href="legal.html">Legal</a></small>
             </div>
         </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title>Yomichan Options</title>
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" type="text/css" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -2,6 +2,7 @@
 <html lang="en">
     <head>
         <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
         <title></title>
         <link rel="stylesheet" href="/mixed/lib/bootstrap/css/bootstrap.min.css">
         <link rel="stylesheet" href="/mixed/lib/bootstrap/css/bootstrap-theme.min.css">

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -256,7 +256,7 @@ class Frontend {
     }
 
     onError(error) {
-        window.alert(`Error: ${error.toString ? error.toString() : error}`);
+        console.log(error);
     }
 
     popupTimerSet(callback) {

--- a/ext/fg/js/util.js
+++ b/ext/fg/js/util.js
@@ -26,11 +26,15 @@ function utilAsync(func) {
 function utilInvoke(action, params={}) {
     return new Promise((resolve, reject) => {
         try {
-            chrome.runtime.sendMessage({action, params}, ({result, error}) => {
-                if (error) {
-                    reject(error);
+            chrome.runtime.sendMessage({action, params}, (response) => {
+                if (response !== null && typeof response === 'object') {
+                    if (response.error) {
+                        reject(response.error);
+                    } else {
+                        resolve(response.result);
+                    }
                 } else {
-                    resolve(result);
+                    reject(`Unexpected response of type ${typeof response}`);
                 }
             });
         } catch (e) {


### PR DESCRIPTION
Mobile Firefox supports addons, and I had added touch support in a previous pull request, so it seemed logical to add this.

Changes:
* HTML pages now look correct for devices with different display scaling values.
* Added a search link to the settings page since it cannot be accessed otherwise on mobile Firefox.
* Fixed some extension commands which are not supported on mobile Firefox.
  * Extension badges and custom commands.
* Added storage usage information to the settings page.
  * Interestingly, Firefox for Android's databases seem to take up about 3x the storage space as desktop Firefox, so adding a dictionary takes 3x as much space.
* Slightly changed how database dictionary insertion is handled in order to not leave the database in a completely unusable state.
  * If adding a dictionary fails while importing, the database will remain full but none of the added content will be usable. This change allows the added content to be used.