### PR TITLE
Fix docRangeFromPoint sometimes not returning results

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -97,18 +97,10 @@ function docRangeFromPoint(point) {
     if(imposter !== null) imposter.style.zIndex = -2147483646;
 
     const rects = range.getClientRects();
-
-    if (rects.length === 0) {
-        return;
-    }
-
-    const rect = rects[0];
-    if (point.y > rect.bottom + 2) {
-        return;
-    }
-
-    if (range) {
-        return new TextSourceRange(range);
+    for (const rect of rects) {
+        if (point.y <= rect.bottom + 2) {
+            return new TextSourceRange(range);
+        }
     }
 }
 


### PR DESCRIPTION
If range.getClientRects() has more than 1 result, it is possible that nothing will be returned when hovering over a valid target.

Example page exhibiting the bug:
```html
<!DOCTYPE html>
<html>
<body>
<div style="font-size: 20px; width: 300px; font-family: Arial; margin: 0 auto;">
私も台所から便所紙を投げつけて応戦した。
</div>
</body>
</html>
```

The word wrap should appear as such:
```
私も台所から便所紙を投げつけて
応戦した。 
```

Hovering over 応戦 can result in no results being detected because ```range.getClientRects()``` is returning 2 results rather than the usual 1.

The change which causes this issue seems to have been introduced sometime after v1.5.1, since that version does not have this issue (guessing [this](https://github.com/FooSoft/yomichan/commit/0cc5566886f34f781072c1b0ae9ce85a12295a7e#diff-8dcb9a0ea4375b3bf7ed569620281840R95)).