### PR TITLE
return focus to site after hiding popup

### DIFF
--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -106,6 +106,7 @@ class Popup {
 
     hide() {
         this.container.style.visibility = 'hidden';
+        this.container.blur();
     }
 
     isVisible() {


### PR DESCRIPTION
When "Automatically hide results" is checked and empty part of the website is scanned, the popup hides. However, iframe#yomichan-float still has focus and prevents the site from being used normally with keyboard.

This PR fixes the issue by blurring the popup iframe each time its `hide` method is called.