### PR TITLE
fix scanning start of line on Firefox

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -102,6 +102,10 @@ function docRangeFromPoint(point) {
             return new TextSourceRange(range);
         }
     }
+
+    if (navigator.userAgent.match(/Firefox/)) {
+        return new TextSourceRange(range);
+    }
 }
 
 function docSentenceExtract(source, extent) {


### PR DESCRIPTION
On many sites, for example Twitter (posts), Yomichan doesn't match any
text from the beginning of the line unless you move the mouse cursor to
the top left corner of the word that starts from the beginning of the
line.

Apparently there were some problems related to the imposter and there
was commit 0cc5566 adding a fix for it, but this seemed to cause
problems and 542cdb2 was added to fix that. It didn't handle all of the
cases, though, so this commit is letting everything through on Firefox.