### PR TITLE
Don't process touchmove events if they can't be canceled

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -192,7 +192,7 @@ class Frontend {
     }
 
     onTouchMove(e) {
-        if (!this.scrollPrevent || this.primaryTouchIdentifier === null) {
+        if (!this.scrollPrevent || !e.cancelable || this.primaryTouchIdentifier === null) {
             return;
         }
 


### PR DESCRIPTION
If the event cannot be canceled, the browser will continue to scroll while looking up results, which makes it very difficult to control where the lookup cursor is.

Chrome also logs error messages that this is invalid:
```
[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false, for example because scrolling is in progress and cannot be interrupted.
```