### PR TITLE
Don't scan when touching the current selection

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -172,7 +172,12 @@ class Frontend {
             return;
         }
 
-        this.setPrimaryTouch(this.getPrimaryTouch(e.changedTouches));
+        let touch = this.getPrimaryTouch(e.changedTouches);
+        if (this.selectionContainsPoint(window.getSelection(), touch.clientX, touch.clientY)) {
+            touch = null;
+        }
+
+        this.setPrimaryTouch(touch);
     }
 
     onTouchEnd(e) {
@@ -451,6 +456,18 @@ class Frontend {
         };
 
         search();
+    }
+
+    selectionContainsPoint(selection, x, y) {
+        for (let i = 0; i < selection.rangeCount; ++i) {
+            const range = selection.getRangeAt(i);
+            for (const rect of range.getClientRects()) {
+                if (x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -290,7 +290,8 @@ class Frontend {
             if (!hideResults && (!this.textSourceLast || !this.textSourceLast.equals(textSource))) {
                 searched = true;
                 this.pendingLookup = true;
-                hideResults = !await this.searchTerms(textSource) && !await this.searchKanji(textSource);
+                const focus = (type === 'mouse');
+                hideResults = !await this.searchTerms(textSource, focus) && !await this.searchKanji(textSource, focus);
                 success = true;
             }
         } catch (e) {
@@ -313,7 +314,7 @@ class Frontend {
         }
     }
 
-    async searchTerms(textSource) {
+    async searchTerms(textSource, focus) {
         textSource.setEndOffset(this.options.scanning.length);
 
         const {definitions, length} = await apiTermsFind(textSource.text());
@@ -329,7 +330,7 @@ class Frontend {
             textSource.getRect(),
             definitions,
             this.options,
-            {sentence, url}
+            {sentence, url, focus}
         );
 
         this.textSourceLast = textSource;
@@ -340,7 +341,7 @@ class Frontend {
         return true;
     }
 
-    async searchKanji(textSource) {
+    async searchKanji(textSource, focus) {
         textSource.setEndOffset(1);
 
         const definitions = await apiKanjiFind(textSource.text());
@@ -354,7 +355,7 @@ class Frontend {
             textSource.getRect(),
             definitions,
             this.options,
-            {sentence, url}
+            {sentence, url, focus}
         );
 
         this.textSourceLast = textSource;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -269,7 +269,9 @@ class Display {
 
     async termsShow(definitions, options, context) {
         try {
-            window.focus();
+            if (context && context.focus) {
+                window.focus();
+            }
 
             this.definitions = definitions;
             this.options = options;
@@ -321,7 +323,9 @@ class Display {
 
     async kanjiShow(definitions, options, context) {
         try {
-            window.focus();
+            if (context && context.focus) {
+                window.focus();
+            }
 
             this.definitions = definitions;
             this.options = options;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -269,7 +269,7 @@ class Display {
 
     async termsShow(definitions, options, context) {
         try {
-            if (context && context.focus) {
+            if (!context || context.focus !== false) {
                 window.focus();
             }
 
@@ -323,7 +323,7 @@ class Display {
 
     async kanjiShow(definitions, options, context) {
         try {
-            if (context && context.focus) {
+            if (!context || context.focus !== false) {
                 window.focus();
             }
 


### PR DESCRIPTION
It is sometimes desirable to try to act on the current text selection without performing another scan. For example: a long-press on the selected word to open the context menu.