### PR TITLE
Recursive popups

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -15,6 +15,7 @@
         <script src="/bg/js/anki.js"></script>
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/audio.js"></script>
+        <script src="/bg/js/backend-api-forwarder.js"></script>
         <script src="/bg/js/database.js"></script>
         <script src="/bg/js/deinflector.js"></script>
         <script src="/bg/js/dictionary.js"></script>

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -205,3 +205,8 @@ function apiForward(action, params, sender) {
         chrome.tabs.sendMessage(tabId, {action, params}, (response) => resolve(response));
     });
 }
+
+function apiFrameInformationGet(sender) {
+    const frameId = sender.frameId;
+    return Promise.resolve({frameId});
+}

--- a/ext/bg/js/backend-api-forwarder.js
+++ b/ext/bg/js/backend-api-forwarder.js
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class BackendApiForwarder {
+    constructor() {
+        chrome.runtime.onConnect.addListener(this.onConnect.bind(this));
+    }
+
+    onConnect(port) {
+        if (port.name !== 'backend-api-forwarder') { return; }
+
+        let tabId;
+        if (!(
+            port.sender &&
+            port.sender.tab &&
+            (typeof (tabId = port.sender.tab.id)) === 'number'
+        )) {
+            port.disconnect();
+            return;
+        }
+
+        const forwardPort = chrome.tabs.connect(tabId, {name: 'frontend-api-receiver'});
+
+        port.onMessage.addListener(message => forwardPort.postMessage(message));
+        forwardPort.onMessage.addListener(message => port.postMessage(message));
+        port.onDisconnect.addListener(() => forwardPort.disconnect());
+        forwardPort.onDisconnect.addListener(() => port.disconnect());
+    }
+}

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -22,6 +22,8 @@ class Backend {
         this.translator = new Translator();
         this.anki = new AnkiNull();
         this.options = null;
+
+        this.apiForwarder = new BackendApiForwarder();
     }
 
     async prepare() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -127,6 +127,10 @@ class Backend {
 
             forward: ({action, params}) => {
                 forward(apiForward(action, params, sender), callback);
+            },
+
+            frameInformationGet: () => {
+                forward(apiFrameInformationGet(sender), callback);
             }
         };
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -221,6 +221,7 @@ function optionsSetDefaults(options) {
             modifier: 'shift',
             deepDomScan: false,
             popupNestingMaxDepth: 0,
+            enableOnPopupExpressions: false,
             enableOnSearchPage: true
         },
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -219,7 +219,8 @@ function optionsSetDefaults(options) {
             delay: 20,
             length: 10,
             modifier: 'shift',
-            deepDomScan: false
+            deepDomScan: false,
+            popupNestingMaxDepth: 0
         },
 
         dictionaries: {},

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -220,7 +220,8 @@ function optionsSetDefaults(options) {
             length: 10,
             modifier: 'shift',
             deepDomScan: false,
-            popupNestingMaxDepth: 0
+            popupNestingMaxDepth: 0,
+            enableOnSearchPage: true
         },
 
         dictionaries: {},

--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -25,8 +25,8 @@ async function searchFrontendSetup() {
         '/fg/js/api.js',
         '/fg/js/frontend-api-receiver.js',
         '/fg/js/popup.js',
-        '/fg/js/popup-proxy-host.js',
         '/fg/js/util.js',
+        '/fg/js/popup-proxy-host.js',
         '/fg/js/frontend.js'
     ];
     for (const src of scriptSrcs) {

--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+async function searchFrontendSetup() {
+    const options = await apiOptionsGet();
+    if (!options.scanning.enableOnSearchPage) { return; }
+
+    const scriptSrcs = [
+        '/fg/js/api.js',
+        '/fg/js/frontend-api-receiver.js',
+        '/fg/js/popup.js',
+        '/fg/js/popup-proxy-host.js',
+        '/fg/js/util.js',
+        '/fg/js/frontend.js'
+    ];
+    for (const src of scriptSrcs) {
+        const script = document.createElement('script');
+        script.async = false;
+        script.src = src;
+        document.body.appendChild(script);
+    }
+
+    const styleSrcs = [
+        '/fg/css/client.css'
+    ];
+    for (const src of styleSrcs) {
+        const style = document.createElement('link');
+        style.rel = 'stylesheet';
+        style.type = 'text/css';
+        style.href = src;
+        document.head.appendChild(style);
+    }
+}
+
+searchFrontendSetup();

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -48,6 +48,7 @@ async function formRead() {
     optionsNew.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
     optionsNew.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
     optionsNew.scanning.deepDomScan = $('#deep-dom-scan').prop('checked');
+    optionsNew.scanning.enableOnPopupExpressions = $('#enable-scanning-of-popup-expressions').prop('checked');
     optionsNew.scanning.enableOnSearchPage = $('#enable-scanning-on-search-page').prop('checked');
     optionsNew.scanning.delay = parseInt($('#scan-delay').val(), 10);
     optionsNew.scanning.length = parseInt($('#scan-length').val(), 10);
@@ -191,6 +192,7 @@ async function onReady() {
     $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
     $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);
     $('#deep-dom-scan').prop('checked', options.scanning.deepDomScan);
+    $('#enable-scanning-of-popup-expressions').prop('checked', options.scanning.enableOnPopupExpressions);
     $('#enable-scanning-on-search-page').prop('checked', options.scanning.enableOnSearchPage);
     $('#scan-delay').val(options.scanning.delay);
     $('#scan-length').val(options.scanning.length);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -48,6 +48,7 @@ async function formRead() {
     optionsNew.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
     optionsNew.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
     optionsNew.scanning.deepDomScan = $('#deep-dom-scan').prop('checked');
+    optionsNew.scanning.enableOnSearchPage = $('#enable-scanning-on-search-page').prop('checked');
     optionsNew.scanning.delay = parseInt($('#scan-delay').val(), 10);
     optionsNew.scanning.length = parseInt($('#scan-length').val(), 10);
     optionsNew.scanning.modifier = $('#scan-modifier-key').val();
@@ -190,6 +191,7 @@ async function onReady() {
     $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
     $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);
     $('#deep-dom-scan').prop('checked', options.scanning.deepDomScan);
+    $('#enable-scanning-on-search-page').prop('checked', options.scanning.enableOnSearchPage);
     $('#scan-delay').val(options.scanning.delay);
     $('#scan-length').val(options.scanning.length);
     $('#scan-modifier-key').val(options.scanning.modifier);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -51,6 +51,7 @@ async function formRead() {
     optionsNew.scanning.delay = parseInt($('#scan-delay').val(), 10);
     optionsNew.scanning.length = parseInt($('#scan-length').val(), 10);
     optionsNew.scanning.modifier = $('#scan-modifier-key').val();
+    optionsNew.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
 
     optionsNew.anki.enable = $('#anki-enable').prop('checked');
     optionsNew.anki.tags = $('#card-tags').val().split(/[,; ]+/);
@@ -192,6 +193,7 @@ async function onReady() {
     $('#scan-delay').val(options.scanning.delay);
     $('#scan-length').val(options.scanning.length);
     $('#scan-modifier-key').val(options.scanning.modifier);
+    $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
 
     $('#dict-purge-link').click(utilAsync(onDictionaryPurge));
     $('#dict-file').change(utilAsync(onDictionaryImport));

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -51,5 +51,6 @@
         <script src="/mixed/js/japanese.js"></script>
 
         <script src="/bg/js/search.js"></script>
+        <script src="/bg/js/search-frontend.js"></script>
     </body>
 </html>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -192,6 +192,10 @@
                     <label><input type="checkbox" id="auto-hide-results"> Automatically hide results</label>
                 </div>
 
+                <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="enable-scanning-of-popup-expressions"> Enable scanning of popup expressions</label>
+                </div>
+
                 <div class="checkbox">
                     <label><input type="checkbox" id="enable-scanning-on-search-page"> Enable scanning on search page</label>
                 </div>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -192,6 +192,10 @@
                     <label><input type="checkbox" id="auto-hide-results"> Automatically hide results</label>
                 </div>
 
+                <div class="checkbox">
+                    <label><input type="checkbox" id="enable-scanning-on-search-page"> Enable scanning on search page</label>
+                </div>
+
                 <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="deep-dom-scan"> Deep DOM scan</label>
                 </div>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -215,6 +215,11 @@
                         <option value="shift">Shift</option>
                     </select>
                 </div>
+
+                <div class="form-group options-advanced">
+                    <label for="popup-nesting-max-depth">Maximum nested popup depth</label>
+                    <input type="number" min="0" id="popup-nesting-max-depth" class="form-control">
+                </div>
             </div>
 
             <div>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -44,10 +44,6 @@
 
         <script src="/fg/js/float.js"></script>
 
-        <!-- TODO : Make these conditional based on options -->
-        <script src="/fg/js/frontend-api-sender.js"></script>
-        <script src="/fg/js/popup.js"></script>
-        <script src="/fg/js/popup-proxy.js"></script>
-        <script src="/fg/js/frontend.js"></script>
+        <script src="/fg/js/popup-nested.js"></script>
     </body>
 </html>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -43,5 +43,11 @@
         <script src="/mixed/js/display.js"></script>
 
         <script src="/fg/js/float.js"></script>
+
+        <!-- TODO : Make these conditional based on options -->
+        <script src="/fg/js/frontend-api-sender.js"></script>
+        <script src="/fg/js/popup.js"></script>
+        <script src="/fg/js/popup-proxy.js"></script>
+        <script src="/fg/js/frontend.js"></script>
     </body>
 </html>

--- a/ext/fg/js/api.js
+++ b/ext/fg/js/api.js
@@ -64,3 +64,7 @@ function apiScreenshotGet(options) {
 function apiForward(action, params) {
     return utilInvoke('forward', {action, params});
 }
+
+function apiFrameInformationGet() {
+    return utilInvoke('frameInformationGet');
+}

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -72,6 +72,10 @@ class DisplayFloat extends Display {
                 if (css) {
                     this.setStyle(css);
                 }
+            },
+
+            popupNestedInitialize: ({id, depth, parentFrameId}) => {
+                popupNestedInitialize(id, depth, parentFrameId);
             }
         };
 

--- a/ext/fg/js/frontend-api-receiver.js
+++ b/ext/fg/js/frontend-api-receiver.js
@@ -31,7 +31,7 @@ class FrontendApiReceiver {
         port.onMessage.addListener(this.onMessage.bind(this, port));
     }
 
-    onMessage(port, {id, action, params, target}) {
+    onMessage(port, {id, action, params, target, senderId}) {
         if (
             target !== this.source ||
             !this.handlers.hasOwnProperty(action)
@@ -39,24 +39,24 @@ class FrontendApiReceiver {
             return;
         }
 
-        this.sendAck(port, id);
+        this.sendAck(port, id, senderId);
 
         const handler = this.handlers[action];
         handler(params).then(
             result => {
-                this.sendResult(port, id, {result});
+                this.sendResult(port, id, senderId, {result});
             },
             e => {
                 const error = typeof e.toString === 'function' ? e.toString() : e;
-                this.sendResult(port, id, {error});
+                this.sendResult(port, id, senderId, {error});
             });
     }
 
-    sendAck(port, id) {
-        port.postMessage({type: 'ack', id});
+    sendAck(port, id, senderId) {
+        port.postMessage({type: 'ack', id, senderId});
     }
 
-    sendResult(port, id, data) {
-        port.postMessage({type: 'result', id, data});
+    sendResult(port, id, senderId, data) {
+        port.postMessage({type: 'result', id, senderId, data});
     }
 }

--- a/ext/fg/js/frontend-api-receiver.js
+++ b/ext/fg/js/frontend-api-receiver.js
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class FrontendApiReceiver {
+    constructor(source='', handlers={}) {
+        this.source = source;
+        this.handlers = handlers;
+
+        chrome.runtime.onConnect.addListener(this.onConnect.bind(this));
+    }
+
+    onConnect(port) {
+        if (port.name !== 'frontend-api-receiver') { return; }
+
+        port.onMessage.addListener(this.onMessage.bind(this, port));
+    }
+
+    onMessage(port, {id, action, params, target}) {
+        if (
+            target !== this.source ||
+            !this.handlers.hasOwnProperty(action)
+        ) {
+            return;
+        }
+
+        this.sendAck(port, id);
+
+        const handler = this.handlers[action];
+        handler(params).then(
+            result => {
+                this.sendResult(port, id, {result});
+            },
+            e => {
+                const error = typeof e.toString === 'function' ? e.toString() : e;
+                this.sendResult(port, id, {error});
+            });
+    }
+
+    sendAck(port, id) {
+        port.postMessage({type: 'ack', id});
+    }
+
+    sendResult(port, id, data) {
+        port.postMessage({type: 'result', id, data});
+    }
+}

--- a/ext/fg/js/frontend-api-sender.js
+++ b/ext/fg/js/frontend-api-sender.js
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class FrontendApiSender {
+    constructor() {
+        this.ackTimeout = 3000; // 3 seconds
+        this.responseTimeout = 10000; // 10 seconds
+        this.callbacks = {};
+        this.disconnected = false;
+        this.nextId = 0;
+
+        this.port = chrome.runtime.connect(null, {name: 'backend-api-forwarder'});
+        this.port.onDisconnect.addListener(this.onDisconnect.bind(this));
+        this.port.onMessage.addListener(this.onMessage.bind(this));
+    }
+
+    invoke(action, params, target) {
+        if (this.disconnected) {
+            return Promise.reject('Disconnected');
+        }
+
+        const id = `${this.nextId}`;
+        ++this.nextId;
+
+        return new Promise((resolve, reject) => {
+            const info = {id, resolve, reject, ack: false, timer: null};
+            this.callbacks[id] = info;
+            info.timer = setTimeout(() => this.onError(id, 'Timeout (ack)'), this.ackTimeout);
+
+            this.port.postMessage({id, action, params, target});
+        });
+    }
+
+    onMessage({type, id, data}) {
+        switch (type) {
+            case 'ack':
+                this.onAck(id);
+                break;
+            case 'result':
+                this.onResult(id, data);
+                break;
+        }
+    }
+
+    onDisconnect() {
+        this.disconnected = true;
+
+        const ids = Object.keys(this.callbacks);
+        for (const id of ids) {
+            this.onError(id, 'Disconnected');
+        }
+    }
+
+    onAck(id) {
+        if (!this.callbacks.hasOwnProperty(id)) {
+            console.warn(`ID ${id} not found`);
+            return;
+        }
+
+        const info = this.callbacks[id];
+        if (info.ack) {
+            console.warn(`Request ${id} already ack'd`);
+            return;
+        }
+
+        info.ack = true;
+        clearTimeout(info.timer);
+        info.timer = setTimeout(() => this.onError(id, 'Timeout (response)'), this.responseTimeout);
+    }
+
+    onResult(id, data) {
+        if (!this.callbacks.hasOwnProperty(id)) {
+            console.warn(`ID ${id} not found`);
+            return;
+        }
+
+        const info = this.callbacks[id];
+        if (!info.ack) {
+            console.warn(`Request ${id} not ack'd`);
+            return;
+        }
+
+        delete this.callbacks[id];
+        clearTimeout(info.timer);
+        info.timer = null;
+
+        if (typeof data.error === 'string') {
+            info.reject(data.error);
+        } else {
+            info.resolve(data.result);
+        }
+    }
+
+    onError(id, reason) {
+        if (!this.callbacks.hasOwnProperty(id)) { return; }
+        const info = this.callbacks[id];
+        delete this.callbacks[id];
+        info.timer = null;
+        info.reject(reason);
+    }
+
+    static generateId(length) {
+        let id = '';
+        for (let i = 0; i < length; ++i) {
+            id += Math.floor(Math.random() * 256).toString(16).padStart(2, '0');
+        }
+        return id;
+    }
+}

--- a/ext/fg/js/frontend-api-sender.js
+++ b/ext/fg/js/frontend-api-sender.js
@@ -19,6 +19,7 @@
 
 class FrontendApiSender {
     constructor() {
+        this.senderId = FrontendApiSender.generateId(16);
         this.ackTimeout = 3000; // 3 seconds
         this.responseTimeout = 10000; // 10 seconds
         this.callbacks = {};
@@ -43,11 +44,12 @@ class FrontendApiSender {
             this.callbacks[id] = info;
             info.timer = setTimeout(() => this.onError(id, 'Timeout (ack)'), this.ackTimeout);
 
-            this.port.postMessage({id, action, params, target});
+            this.port.postMessage({id, action, params, target, senderId: this.senderId});
         });
     }
 
-    onMessage({type, id, data}) {
+    onMessage({type, id, data, senderId}) {
+        if (senderId !== this.senderId) { return; }
         switch (type) {
             case 'ack':
                 this.onAck(id);
@@ -69,7 +71,7 @@ class FrontendApiSender {
 
     onAck(id) {
         if (!this.callbacks.hasOwnProperty(id)) {
-            console.warn(`ID ${id} not found`);
+            console.warn(`ID ${id} not found for ack`);
             return;
         }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -56,6 +56,7 @@ class Frontend {
             window.addEventListener('mousedown', this.onMouseDown.bind(this));
             window.addEventListener('mousemove', this.onMouseMove.bind(this));
             window.addEventListener('mouseover', this.onMouseOver.bind(this));
+            window.addEventListener('mouseout', this.onMouseOut.bind(this));
             window.addEventListener('mouseup', this.onMouseUp.bind(this));
             window.addEventListener('resize', this.onResize.bind(this));
 
@@ -147,6 +148,10 @@ class Frontend {
         } else if (e.which === 2) {
             this.mouseDownMiddle = false;
         }
+    }
+
+    onMouseOut(e) {
+        this.popupTimerClear();
     }
 
     onFrameMessage(e) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -37,23 +37,9 @@ class Frontend {
     }
 
     static create() {
-        const floatUrl = chrome.extension.getURL('/fg/float.html');
-        const currentUrl = location.href.replace(/[\?#][\w\W]*$/, "");
-        const isNested = (currentUrl === floatUrl);
-
-        let id = null;
-        let parentFrameId = null;
-        if (isNested) {
-            let match = /[&?]id=([^&]*?)(?:&|$)/.exec(location.href);
-            if (match !== null) {
-                id = match[1];
-            }
-
-            match = /[&?]parent=(\d+)(?:&|$)/.exec(location.href);
-            if (match !== null) {
-                parentFrameId = parseInt(match[1], 10);
-            }
-        }
+        const initializationData = window.frontendInitializationData;
+        const isNested = (initializationData !== null && typeof initializationData === 'object');
+        const {id, parentFrameId} = initializationData || {};
 
         const popup = isNested ? new PopupProxy(id, parentFrameId) : PopupProxyHost.instance.createPopup(null);
         const frontend = new Frontend(popup);

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -515,57 +515,13 @@ class Frontend {
 
         length = textSource.text().length;
         while (textSource.range && length > 0) {
-            const nodes = Frontend.getNodesInRange(textSource.range);
-            if (Frontend.isValidScanningNodeList(nodes, this.ignoreNodes)) {
+            const nodes = TextSourceRange.getNodesInRange(textSource.range);
+            if (!TextSourceRange.anyNodeMatchesSelector(nodes, this.ignoreNodes)) {
                 break;
             }
             --length;
             textSource.setEndOffset(length);
         }
-    }
-
-    static getNodesInRange(range) {
-        const end = range.endContainer;
-        const nodes = [];
-        for (let node = range.startContainer; node !== null; node = Frontend.getNextNode(node)) {
-            nodes.push(node);
-            if (node === end) { break; }
-        }
-        return nodes;
-    }
-
-    static getNextNode(node) {
-        let next = node.firstChild;
-        if (next === null) {
-            while (true) {
-                next = node.nextSibling;
-                if (next !== null) { break; }
-
-                next = node.parentNode;
-                if (node === null) { break; }
-
-                node = next;
-            }
-        }
-        return next;
-    }
-
-    static isValidScanningNodeList(nodeList, selector) {
-        for (const node of nodeList) {
-            if (!Frontend.isValidScanningNode(node, selector)) {
-                return false;
-            }
-        }
-        return true;
-    }
-
-    static isValidScanningNode(node, selector) {
-        for (; node !== null; node = node.parentNode) {
-            if (node.nodeType === Node.ELEMENT_NODE) {
-                return !node.matches(selector);
-            }
-        }
-        return true;
     }
 }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -297,10 +297,7 @@ class Frontend {
     }
 
     async searchAt(point, type) {
-        if (
-            this.pendingLookup ||
-            await this.popup.containsPoint(point)
-        ) {
+        if (this.pendingLookup || await this.popup.containsPoint(point)) {
             return;
         }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -294,7 +294,7 @@ class Frontend {
     async searchAt(point, type) {
         if (
             this.pendingLookup ||
-            (this.popup.containsPointIsAsync() ? await this.popup.containsPointAsync(point) : this.popup.containsPoint(point))
+            await this.popup.containsPoint(point)
         ) {
             return;
         }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -42,14 +42,20 @@ class Frontend {
         const isNested = (currentUrl === floatUrl);
 
         let id = null;
+        let parentFrameId = null;
         if (isNested) {
-            const match = /[&?]id=([^&]*?)(?:&|$)/.exec(location.href);
+            let match = /[&?]id=([^&]*?)(?:&|$)/.exec(location.href);
             if (match !== null) {
                 id = match[1];
             }
+
+            match = /[&?]parent=(\d+)(?:&|$)/.exec(location.href);
+            if (match !== null) {
+                parentFrameId = parseInt(match[1], 10);
+            }
         }
 
-        const popup = isNested ? new PopupProxy(id) : PopupProxyHost.instance.createPopup();
+        const popup = isNested ? new PopupProxy(id, parentFrameId) : PopupProxyHost.instance.createPopup(null);
         const frontend = new Frontend(popup);
         frontend.prepare();
         return frontend;

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -17,19 +17,22 @@
  */
 
 
-async function popupNestedSetup() {
+let popupNestedInitialized = false;
+
+async function popupNestedInitialize(id, depth, parentFrameId) {
+    if (popupNestedInitialized) {
+        return;
+    }
+    popupNestedInitialized = true;
+
     const options = await apiOptionsGet();
     const popupNestingMaxDepth = options.scanning.popupNestingMaxDepth;
-
-    let depth = null;
-    const match = /[&?]depth=([^&]*?)(?:&|$)/.exec(location.href);
-    if (match !== null) {
-        depth = parseInt(match[1], 10);
-    }
 
     if (!(typeof popupNestingMaxDepth === 'number' && typeof depth === 'number' && depth < popupNestingMaxDepth)) {
         return;
     }
+
+    window.frontendInitializationData = {id, depth, parentFrameId};
 
     const scriptSrcs = [
         '/fg/js/frontend-api-sender.js',
@@ -44,5 +47,3 @@ async function popupNestedSetup() {
         document.body.appendChild(script);
     }
 }
-
-popupNestedSetup();

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -32,7 +32,9 @@ async function popupNestedInitialize(id, depth, parentFrameId) {
         return;
     }
 
-    window.frontendInitializationData = {id, depth, parentFrameId};
+    const ignoreNodes = options.scanning.enableOnPopupExpressions ? [] : [ '.expression', '.expression *' ];
+
+    window.frontendInitializationData = {id, depth, parentFrameId, ignoreNodes};
 
     const scriptSrcs = [
         '/fg/js/frontend-api-sender.js',

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+async function popupNestedSetup() {
+    const options = await apiOptionsGet();
+    const popupNestingMaxDepth = options.scanning.popupNestingMaxDepth;
+
+    let depth = null;
+    const match = /[&?]depth=([^&]*?)(?:&|$)/.exec(location.href);
+    if (match !== null) {
+        depth = parseInt(match[1], 10);
+    }
+
+    if (!(typeof popupNestingMaxDepth === 'number' && typeof depth === 'number' && depth < popupNestingMaxDepth)) {
+        return;
+    }
+
+    const scriptSrcs = [
+        '/fg/js/frontend-api-sender.js',
+        '/fg/js/popup.js',
+        '/fg/js/popup-proxy.js',
+        '/fg/js/frontend.js'
+    ];
+    for (const src of scriptSrcs) {
+        const script = document.createElement('script');
+        script.async = false;
+        script.src = src;
+        document.body.appendChild(script);
+    }
+}
+
+popupNestedSetup();

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -57,7 +57,7 @@ class PopupProxyHost {
         const popup = new Popup(id, depth, this.frameIdPromise);
         if (parent !== null) {
             popup.parent = parent;
-            parent.children.push(popup);
+            parent.child = popup;
         }
         this.popups[id] = popup;
         return popup;

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class PopupProxyHost {
+    constructor() {
+        this.popups = {};
+        this.nextId = 0;
+        this.apiReceiver = new FrontendApiReceiver('popup-proxy-host', {
+            createNestedPopup: ({parentId}) => this.createNestedPopup(parentId),
+            show: ({id, elementRect, options}) => this.show(id, elementRect, options),
+            showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
+            hide: ({id}) => this.hide(id),
+            setVisible: ({id, visible}) => this.setVisible(id, visible),
+            containsPoint: ({id, point}) => this.containsPoint(id, point),
+            termsShow: ({id, elementRect, definitions, options, context}) => this.termsShow(id, elementRect, definitions, options, context),
+            kanjiShow: ({id, elementRect, definitions, options, context}) => this.kanjiShow(id, elementRect, definitions, options, context),
+            clearAutoPlayTimer: ({id}) => this.clearAutoPlayTimer(id)
+        });
+    }
+
+    createPopup(parentId) {
+        const parent = (typeof parentId === 'string' && this.popups.hasOwnProperty(parentId) ? this.popups[parentId] : null);
+        const id = `${this.nextId}`;
+        ++this.nextId;
+        const popup = new Popup(id);
+        if (parent !== null) {
+            popup.parent = parent;
+            parent.children.push(popup);
+        }
+        this.popups[id] = popup;
+        return popup;
+    }
+
+    async createNestedPopup(parentId) {
+        return this.createPopup(parentId).id;
+    }
+
+    getPopup(id) {
+        if (!this.popups.hasOwnProperty(id)) {
+            throw 'Invalid popup ID';
+        }
+
+        return this.popups[id];
+    }
+
+    jsonRectToDOMRect(popup, jsonRect) {
+        let x = jsonRect.x;
+        let y = jsonRect.y;
+        if (popup.parent !== null) {
+            const popupRect = popup.parent.container.getBoundingClientRect();
+            x += popupRect.x;
+            y += popupRect.y;
+        }
+        return new DOMRect(x, y, jsonRect.width, jsonRect.height);
+    }
+
+    async show(id, elementRect, options) {
+        const popup = this.getPopup(id);
+        elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        return await popup.show(elementRect, options);
+    }
+
+    async showOrphaned(id, elementRect, options) {
+        const popup = this.getPopup(id);
+        elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        return await popup.showOrphaned(elementRect, options);
+    }
+
+    async hide(id) {
+        const popup = this.getPopup(id);
+        return popup.hide();
+    }
+
+    async setVisible(id, visible) {
+        const popup = this.getPopup(id);
+        return popup.setVisible(visible);
+    }
+
+    async containsPoint(id, point) {
+        const popup = this.getPopup(id);
+        return popup.containsPointIsAsync() ? await popup.containsPointAsync(point) : popup.containsPoint(point);
+    }
+
+    async termsShow(id, elementRect, definitions, options, context) {
+        const popup = this.getPopup(id);
+        elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        return await popup.termsShow(elementRect, definitions, options, context);
+    }
+
+    async kanjiShow(id, elementRect, definitions, options, context) {
+        const popup = this.getPopup(id);
+        elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        return await popup.kanjiShow(elementRect, definitions, options, context);
+    }
+
+    async clearAutoPlayTimer(id) {
+        const popup = this.getPopup(id);
+        return popup.clearAutoPlayTimer();
+    }
+}
+
+PopupProxyHost.instance = new PopupProxyHost();

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -36,9 +36,10 @@ class PopupProxyHost {
 
     createPopup(parentId) {
         const parent = (typeof parentId === 'string' && this.popups.hasOwnProperty(parentId) ? this.popups[parentId] : null);
+        const depth = (parent !== null ? parent.depth + 1 : 0);
         const id = `${this.nextId}`;
         ++this.nextId;
-        const popup = new Popup(id);
+        const popup = new Popup(id, depth);
         if (parent !== null) {
             popup.parent = parent;
             parent.children.push(popup);

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -110,7 +110,7 @@ class PopupProxyHost {
 
     async containsPoint(id, point) {
         const popup = this.getPopup(id);
-        return popup.containsPointIsAsync() ? await popup.containsPointAsync(point) : popup.containsPoint(point);
+        return await popup.containsPoint(point);
     }
 
     async termsShow(id, elementRect, definitions, options, context) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -1,0 +1,116 @@
+/*
+ * Copyright (C) 2019 Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class PopupProxy {
+    constructor(parentId) {
+        this.parentId = parentId;
+        this.id = null;
+        this.idPromise = null;
+        this.parent = null;
+        this.children = [];
+
+        this.container = null;
+
+        this.apiSender = new FrontendApiSender();
+    }
+
+    getPopupId() {
+        if (this.idPromise === null) {
+            this.idPromise = this.getPopupIdAsync();
+        }
+        return this.idPromise;
+    }
+
+    async getPopupIdAsync() {
+        const id = await this.invokeHostApi('createNestedPopup', {parentId: this.parentId});
+        this.id = id;
+        return id;
+    }
+
+    async show(elementRect, options) {
+        const id = await this.getPopupId();
+        elementRect = PopupProxy.DOMRectToJson(elementRect);
+        return await this.invokeHostApi('show', {id, elementRect, options});
+    }
+
+    async showOrphaned(elementRect, options) {
+        const id = await this.getPopupId();
+        elementRect = PopupProxy.DOMRectToJson(elementRect);
+        return await this.invokeHostApi('showOrphaned', {id, elementRect, options});
+    }
+
+    async hide() {
+        if (this.id === null) {
+            return;
+        }
+        return await this.invokeHostApi('hide', {id: this.id});
+    }
+
+    async setVisible(visible) {
+        const id = await this.getPopupId();
+        return await this.invokeHostApi('setVisible', {id, visible});
+    }
+
+    containsPoint() {
+        throw 'Non-async function not supported';
+    }
+
+    async containsPointAsync(point) {
+        if (this.id === null) {
+            return false;
+        }
+        return await this.invokeHostApi('containsPoint', {id: this.id, point});
+    }
+
+    containsPointIsAsync() {
+        return true;
+    }
+
+    async termsShow(elementRect, definitions, options, context) {
+        const id = await this.getPopupId();
+        elementRect = PopupProxy.DOMRectToJson(elementRect);
+        return await this.invokeHostApi('termsShow', {id, elementRect, definitions, options, context});
+    }
+
+    async kanjiShow(elementRect, definitions, options, context) {
+        const id = await this.getPopupId();
+        elementRect = PopupProxy.DOMRectToJson(elementRect);
+        return await this.invokeHostApi('kanjiShow', {id, elementRect, definitions, options, context});
+    }
+
+    async clearAutoPlayTimer() {
+        if (this.id === null) {
+            return;
+        }
+        return await this.invokeHostApi('clearAutoPlayTimer', {id: this.id});
+    }
+
+    invokeHostApi(action, params={}) {
+        return this.apiSender.invoke(action, params, 'popup-proxy-host');
+    }
+
+    static DOMRectToJson(domRect) {
+        return {
+            x: domRect.x,
+            y: domRect.y,
+            width: domRect.width,
+            height: domRect.height
+        };
+    }
+}

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -24,7 +24,7 @@ class PopupProxy {
         this.id = null;
         this.idPromise = null;
         this.parent = null;
-        this.children = [];
+        this.child = null;
         this.depth = 0;
 
         this.container = null;

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -69,19 +69,11 @@ class PopupProxy {
         return await this.invokeHostApi('setVisible', {id, visible});
     }
 
-    containsPoint() {
-        throw 'Non-async function not supported';
-    }
-
-    async containsPointAsync(point) {
+    async containsPoint(point) {
         if (this.id === null) {
             return false;
         }
         return await this.invokeHostApi('containsPoint', {id: this.id, point});
-    }
-
-    containsPointIsAsync() {
-        return true;
     }
 
     async termsShow(elementRect, definitions, options, context) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -18,12 +18,14 @@
 
 
 class PopupProxy {
-    constructor(parentId) {
+    constructor(parentId, parentFrameId) {
         this.parentId = parentId;
+        this.parentFrameId = parentFrameId;
         this.id = null;
         this.idPromise = null;
         this.parent = null;
         this.children = [];
+        this.depth = 0;
 
         this.container = null;
 
@@ -102,7 +104,10 @@ class PopupProxy {
     }
 
     invokeHostApi(action, params={}) {
-        return this.apiSender.invoke(action, params, 'popup-proxy-host');
+        if (typeof this.parentFrameId !== 'number') {
+            return Promise.reject('Invalid frame');
+        }
+        return this.apiSender.invoke(action, params, `popup-proxy-host#${this.parentFrameId}`);
     }
 
     static DOMRectToJson(domRect) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -207,7 +207,7 @@ class Popup {
 
     hide() {
         this.hideContainer();
-        this.container.blur();
+        this.focusParent();
         this.hideChildren();
     }
 
@@ -245,6 +245,14 @@ class Popup {
             this.container.style.setProperty('display', '');
         } else {
             this.container.style.setProperty('display', 'none', 'important');
+        }
+    }
+
+    focusParent() {
+        if (this.parent && this.parent.container) {
+            this.parent.container.focus();
+        } else {
+            this.container.blur();
         }
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -29,6 +29,7 @@ class Popup {
         this.container.id = 'yomichan-float';
         this.container.addEventListener('mousedown', e => e.stopPropagation());
         this.container.addEventListener('scroll', e => e.stopPropagation());
+        this.container.setAttribute('src', chrome.extension.getURL('/fg/float.html'));
         this.container.style.width = '0px';
         this.container.style.height = '0px';
         this.injectPromise = null;
@@ -53,9 +54,13 @@ class Popup {
         }
 
         return new Promise((resolve) => {
-            const parent = (typeof this.frameId === 'number' ? this.frameId : '');
-            this.container.setAttribute('src', chrome.extension.getURL(`/fg/float.html?id=${this.id}&depth=${this.depth}&parent=${parent}`));
+            const parentFrameId = (typeof this.frameId === 'number' ? this.frameId : null);
             this.container.addEventListener('load', () => {
+                this.invokeApi('popupNestedInitialize', {
+                    id: this.id,
+                    depth: this.depth,
+                    parentFrameId
+                });
                 this.invokeApi('setOptions', {
                     general: {
                         customPopupCss: options.general.customPopupCss

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -18,15 +18,16 @@
 
 
 class Popup {
-    constructor(id) {
+    constructor(id, depth) {
         this.id = id;
+        this.depth = depth;
         this.parent = null;
         this.children = [];
         this.container = document.createElement('iframe');
         this.container.id = 'yomichan-float';
         this.container.addEventListener('mousedown', e => e.stopPropagation());
         this.container.addEventListener('scroll', e => e.stopPropagation());
-        this.container.setAttribute('src', chrome.extension.getURL(`/fg/float.html?id=${id}`));
+        this.container.setAttribute('src', chrome.extension.getURL(`/fg/float.html?id=${id}&depth=${depth}`));
         this.container.style.width = '0px';
         this.container.style.height = '0px';
         this.injected = null;

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -251,26 +251,13 @@ class Popup {
         }
     }
 
-    async containsPoint(point) {
-        if (!this.isVisible()) {
-            return false;
+    async containsPoint({x, y}) {
+        for (let popup = this; popup !== null && popup.isVisible(); popup = popup.child) {
+            const rect = popup.container.getBoundingClientRect();
+            if (x >= rect.left && y >= rect.top && x < rect.right && y < rect.bottom) {
+                return true;
+            }
         }
-
-        const rect = this.container.getBoundingClientRect();
-        const contained =
-            point.x >= rect.left &&
-            point.y >= rect.top &&
-            point.x < rect.right &&
-            point.y < rect.bottom;
-
-        return contained;
-    }
-
-    async containsPointAsync(point) {
-        return containsPoint(point);
-    }
-
-    containsPointIsAsync() {
         return false;
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -206,9 +206,9 @@ class Popup {
     }
 
     hide() {
+        this.hideChildren();
         this.hideContainer();
         this.focusParent();
-        this.hideChildren();
     }
 
     hideChildren() {
@@ -221,7 +221,7 @@ class Popup {
             const target = targets.shift();
             if (target.isContainerHidden()) { continue; }
 
-            target.hideContainer();
+            target.hide();
             for (const child of target.children) {
                 targets.push(child);
             }
@@ -249,10 +249,9 @@ class Popup {
     }
 
     focusParent() {
+        this.container.blur();
         if (this.parent && this.parent.container) {
             this.parent.container.focus();
-        } else {
-            this.container.blur();
         }
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -248,7 +248,7 @@ class Popup {
         }
     }
 
-    containsPoint(point) {
+    async containsPoint(point) {
         if (!this.isVisible()) {
             return false;
         }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -239,9 +239,15 @@ class Popup {
     }
 
     focusParent() {
-        this.container.blur();
         if (this.parent && this.parent.container) {
-            this.parent.container.focus();
+            // Chrome doesn't like focusing iframe without contentWindow.
+            this.parent.container.contentWindow.focus();
+        } else {
+            // Firefox doesn't like focusing window without first blurring the iframe.
+            // this.container.contentWindow.blur() doesn't work on Firefox for some reason.
+            this.container.blur();
+            // This is needed for Chrome.
+            window.focus();
         }
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -24,7 +24,7 @@ class Popup {
         this.frameIdPromise = frameIdPromise;
         this.frameId = null;
         this.parent = null;
-        this.children = [];
+        this.child = null;
         this.container = document.createElement('iframe');
         this.container.id = 'yomichan-float';
         this.container.addEventListener('mousedown', e => e.stopPropagation());
@@ -212,19 +212,9 @@ class Popup {
     }
 
     hideChildren() {
-        if (this.children.length === 0) {
-            return;
-        }
-
-        const targets = this.children.slice(0);
-        while (targets.length > 0) {
-            const target = targets.shift();
-            if (target.isContainerHidden()) { continue; }
-
-            target.hide();
-            for (const child of target.children) {
-                targets.push(child);
-            }
+        // recursively hides all children
+        if (this.child && !this.child.isContainerHidden()) {
+            this.child.hide();
         }
     }
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -232,6 +232,50 @@ class TextSourceRange {
         const writingMode = style.writingMode;
         return typeof writingMode === 'string' ? writingMode : 'horizontal-tb';
     }
+
+    static getNodesInRange(range) {
+        const end = range.endContainer;
+        const nodes = [];
+        for (let node = range.startContainer; node !== null; node = TextSourceRange.getNextNode(node)) {
+            nodes.push(node);
+            if (node === end) { break; }
+        }
+        return nodes;
+    }
+
+    static getNextNode(node) {
+        let next = node.firstChild;
+        if (next === null) {
+            while (true) {
+                next = node.nextSibling;
+                if (next !== null) { break; }
+
+                next = node.parentNode;
+                if (node === null) { break; }
+
+                node = next;
+            }
+        }
+        return next;
+    }
+
+    static anyNodeMatchesSelector(nodeList, selector) {
+        for (const node of nodeList) {
+            if (TextSourceRange.nodeMatchesSelector(node, selector)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static nodeMatchesSelector(node, selector) {
+        for (; node !== null; node = node.parentNode) {
+            if (node.nodeType === Node.ELEMENT_NODE) {
+                return node.matches(selector);
+            }
+        }
+        return false;
+    }
 }
 
 

--- a/ext/fg/js/util.js
+++ b/ext/fg/js/util.js
@@ -24,9 +24,10 @@ function utilAsync(func) {
 }
 
 function utilInvoke(action, params={}) {
+    const data = {action, params};
     return new Promise((resolve, reject) => {
         try {
-            chrome.runtime.sendMessage({action, params}, (response) => {
+            chrome.runtime.sendMessage(data, (response) => {
                 utilCheckLastError(chrome.runtime.lastError);
                 if (response !== null && typeof response === 'object') {
                     if (response.error) {
@@ -35,7 +36,8 @@ function utilInvoke(action, params={}) {
                         resolve(response.result);
                     }
                 } else {
-                    reject(`Unexpected response of type ${typeof response}`);
+                    const message = response === null ? 'Unexpected null response' : `Unexpected response of type ${typeof response}`;
+                    reject(`${message} (${JSON.stringify(data)})`);
                 }
             });
         } catch (e) {

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -21,7 +21,9 @@
             "mixed/js/extension.js",
             "fg/js/api.js",
             "fg/js/document.js",
+            "fg/js/frontend-api-receiver.js",
             "fg/js/popup.js",
+            "fg/js/popup-proxy-host.js",
             "fg/js/source.js",
             "fg/js/util.js",
             "fg/js/frontend.js"

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -23,9 +23,9 @@
             "fg/js/document.js",
             "fg/js/frontend-api-receiver.js",
             "fg/js/popup.js",
-            "fg/js/popup-proxy-host.js",
             "fg/js/source.js",
             "fg/js/util.js",
+            "fg/js/popup-proxy-host.js",
             "fg/js/frontend.js"
         ],
         "css": ["fg/css/client.css"],


### PR DESCRIPTION
Allows content of popups to be scanned in the same way that standard webpages are, creating multiple popups to be created in the parent frame.


The concept here is not all that complicated, although it did require some infrastructure to overcome some of the restrictions of browser extensions.
* A PopupProxy class is used inside of ```/fg/float.html```. The public API of this class is the same as the standard Popup class.
* Messages must be passed from the PopupProxy class to the parent frame, and this frame is ultimately where the real Popup is created. Since the popup is created here and not recursively inside of ```/fg/float.html```, there is no need to worry the popup not fitting or getting too small.
* PopupProxyHost is in charge of forwarding API calls to the real Popup.
* New settings to control whether recursive popups and popups on the search page are enabled. The Javascript code is only loaded on-demand if these options are enabled.


Browser limitations:
* Firefox has a more limited subset of APIs available to [content scripts](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Content_scripts) than Chrome. This includes not having access to [chrome.tabs](https://developer.chrome.com/extensions/tabs) APIs.
* Messages must be able to be passed from the ```/fg/float.html``` frame to the parent frame, and this only seems to be possible by forwarding through the backend as a middle-man.
* The callback feature of the message passing systems ([runtime.sendMessage](https://developer.chrome.com/apps/runtime#method-sendMessage) and [tabs.sendMessage](https://developer.chrome.com/extensions/tabs#method-sendMessage)) does not work if sending another message before invoking ```sendResponse``` because the channel will be closed. Therefore, the [runtime.connect](https://developer.chrome.com/apps/runtime#method-connect) and [tabs.connect](https://developer.chrome.com/extensions/tabs#method-connect) APIs had to be used instead. This is why BackendApiForwarder, FrontendApiReceiver, and FrontendApiSender exist.
* The ```.connect``` calls need to be handled by exactly one window, so some unique IDs/```frameId```s are used to filter this. ```<iframe>```s will otherwise cause issues.


Other:
* Seems to work reliably on Chrome Dev 78 and Firefox Developer Edition 69. Also works on Firefox for Android Beta 68, but the message passing system seems to get flooded a lot easier, which can lead to some timeouts.
* There are some new files added for this, and for the most part, the copyright notice was was just copied from existing files.
* Inspired from a [comment](https://github.com/FooSoft/yomichan/pull/172#issuecomment-517975972) by @odehjoseph in #172 (and a few other issues), I mostly made this to see if it was possible. There's a non-trivial amount of complexity added, so feel free to decline the PR if it doesn't seem beneficial.


Example image:
![image](https://user-images.githubusercontent.com/11037431/63235978-fad0e880-c209-11e9-942a-0772a907d127.png)