### PR TITLE
Suppress messages about unchecked runtime.lastError

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -57,9 +57,10 @@ class Backend {
             this.anki = new AnkiNull();
         }
 
+        const callback = () => this.checkLastError(chrome.runtime.lastError);
         chrome.tabs.query({}, tabs => {
             for (const tab of tabs) {
-                chrome.tabs.sendMessage(tab.id, {action: 'optionsSet', params: options}, () => null);
+                chrome.tabs.sendMessage(tab.id, {action: 'optionsSet', params: options}, callback);
             }
         });
     }
@@ -146,6 +147,10 @@ class Backend {
         if (typeof chrome.browserAction.setBadgeText === 'function') {
             chrome.browserAction.setBadgeText({text});
         }
+    }
+
+    checkLastError(e) {
+        // NOP
     }
 }
 


### PR DESCRIPTION
Suppresses messages produced by both Chrome and Firefox when attempting to send a message to a tab which Yomichan is not running on. This most consistently occurs when attempting to send the ```'optionsSet'``` message to all tabs upon extension installation or editing the settings page.

The messages are harmless, but somewhat annoying to have them appear when debugging.

Chrome error message:
```
Unchecked runtime.lastError: Could not establish connection. Receiving end does not exist.
```

Firefox error message:
```
Unchecked lastError value: Error: Could not establish connection. Receiving end does not exist.
```