### PR TITLE
Add support for Edge browser

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -10,6 +10,8 @@
         <script src="/mixed/lib/jszip.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
+        <script src="/mixed/js/extension.js"></script>
+
         <script src="/bg/js/anki.js"></script>
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/audio.js"></script>

--- a/ext/bg/context.html
+++ b/ext/bg/context.html
@@ -32,6 +32,8 @@
         <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/bootstrap-toggle/bootstrap-toggle.min.js"></script>
 
+        <script src="/mixed/js/extension.js"></script>
+
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/options.js"></script>
         <script src="/bg/js/util.js"></script>

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -25,7 +25,7 @@ class DisplaySearch extends Display {
         this.query = $('#query').on('input', this.onSearchInput.bind(this));
         this.intro = $('#intro');
 
-        this.dependencies = {...this.dependencies, ...{docRangeFromPoint, docSentenceExtract}};
+        this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
         window.wanakana.bind(this.query.get(0));
     }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -116,7 +116,7 @@ async function formMainDictionaryOptionsPopulate(options) {
     select.append($('<option class="text-muted" value="">Not selected</option>'));
 
     let mainDictionary = '';
-    for (const dictRow of await utilDatabaseSummarize()) {
+    for (const dictRow of toIterable(await utilDatabaseSummarize())) {
         if (dictRow.sequenced) {
             select.append($(`<option value="${dictRow.title}">${dictRow.title}</option>`));
             if (dictRow.title === options.general.mainDictionary) {
@@ -314,12 +314,12 @@ async function dictionaryGroupsPopulate(options) {
     const dictGroups = $('#dict-groups').empty();
     const dictWarning = $('#dict-warning').hide();
 
-    const dictRows = await utilDatabaseSummarize();
+    const dictRows = toIterable(await utilDatabaseSummarize());
     if (dictRows.length === 0) {
         dictWarning.show();
     }
 
-    for (const dictRow of dictRowsSort(dictRows, options)) {
+    for (const dictRow of toIterable(dictRowsSort(dictRows, options))) {
         const dictOptions = options.dictionaries[dictRow.title] || {
             enabled: false,
             priority: 0,
@@ -581,20 +581,19 @@ async function onAnkiFieldTemplatesReset(e) {
  */
 
 async function getBrowser() {
-    if (typeof chrome !== "undefined") {
-        if (typeof browser !== "undefined") {
-            try {
-                const info = await browser.runtime.getBrowserInfo();
-                if (info.name === "Fennec") {
-                    return "firefox-mobile";
-                }
-            } catch (e) { }
-            return "firefox";
-        } else {
-            return "chrome";
-        }
+    if (EXTENSION_IS_BROWSER_EDGE) {
+        return 'edge';
+    }
+    if (typeof browser !== 'undefined') {
+        try {
+            const info = await browser.runtime.getBrowserInfo();
+            if (info.name === 'Fennec') {
+                return 'firefox-mobile';
+            }
+        } catch (e) { }
+        return 'firefox';
     } else {
-        return "edge";
+        return 'chrome';
     }
 }
 

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -87,6 +87,20 @@ function utilDatabasePurge() {
     return utilBackend().translator.database.purge();
 }
 
-function utilDatabaseImport(data, progress, exceptions) {
+async function utilDatabaseImport(data, progress, exceptions) {
+    // Edge cannot read data on the background page due to the File object
+    // being created from a different window. Read on the same page instead.
+    if (EXTENSION_IS_BROWSER_EDGE) {
+        data = await utilReadFile(data);
+    }
     return utilBackend().translator.database.importDictionary(data, progress, exceptions);
+}
+
+function utilReadFile(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsBinaryString(file);
+    });
 }

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -37,6 +37,8 @@
         <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
+        <script src="/mixed/js/extension.js"></script>
+
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/audio.js"></script>
         <script src="/bg/js/dictionary.js"></script>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -399,6 +399,8 @@
         <script src="/mixed/lib/bootstrap/js/bootstrap.min.js"></script>
         <script src="/mixed/lib/handlebars.min.js"></script>
 
+        <script src="/mixed/js/extension.js"></script>
+
         <script src="/bg/js/anki.js"></script>
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/dictionary.js"></script>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -34,6 +34,8 @@
         <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
+        <script src="/mixed/js/extension.js"></script>
+
         <script src="/fg/js/api.js"></script>
         <script src="/fg/js/util.js"></script>
         <script src="/fg/js/document.js"></script>

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -23,7 +23,7 @@ class DisplayFloat extends Display {
         this.autoPlayAudioTimer = null;
         this.styleNode = null;
 
-        this.dependencies = {...this.dependencies, ...{docRangeFromPoint, docSentenceExtract}};
+        this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
         $(window).on('message', utilAsync(this.onMessage.bind(this)));
     }

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -11,10 +11,14 @@
     },
 
     "author": "Alex Yatskov",
-    "background": {"page": "bg/background.html"},
+    "background": {
+        "page": "bg/background.html",
+        "persistent": true
+    },
     "content_scripts": [{
         "matches": ["http://*/*", "https://*/*", "file://*/*"],
         "js": [
+            "mixed/js/extension.js",
             "fg/js/api.js",
             "fg/js/document.js",
             "fg/js/popup.js",

--- a/ext/mixed/js/extension.js
+++ b/ext/mixed/js/extension.js
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+function toIterable(value) {
+    if (typeof Symbol !== 'undefined' && typeof value[Symbol.iterator] !== 'undefined') {
+        return value;
+    }
+
+    const array = JSON.parse(JSON.stringify(value));
+    return Array.isArray(array) ? array : [];
+}
+
+function extensionHasChrome() {
+    try {
+        return typeof chrome === 'object' && chrome !== null;
+    } catch (e) {
+        return false;
+    }
+}
+
+function extensionHasBrowser() {
+    try {
+        return typeof browser === 'object' && browser !== null;
+    } catch (e) {
+        return false;
+    }
+}
+
+const EXTENSION_IS_BROWSER_EDGE = (
+    extensionHasBrowser() &&
+    (!extensionHasChrome() || (typeof chrome.runtime === 'undefined' && typeof browser.runtime !== 'undefined'))
+);
+
+if (EXTENSION_IS_BROWSER_EDGE) {
+    // Edge does not have chrome defined.
+    chrome = browser;
+}


### PR DESCRIPTION
Resolves #124, but there's a catch.

Here is the [source code](https://github.com/FooSoft/yomichan/blob/168285097004bcc99ecc1dae43e1429c05443d40/ext/bg/js/translator.js#L42) of a basic performance test:
![test-code](https://user-images.githubusercontent.com/11037431/63622074-a475f800-c5c3-11e9-914a-f93aaaa534b1.png)

Tested on [a dictionary site](https://jisho.org/search/kyou) with only the common jmdict_english.zip dictionary installed:
![test](https://user-images.githubusercontent.com/11037431/63621922-42b58e00-c5c3-11e9-81ed-c4e8d5815d51.png)


Behold, the performance of scanning the word *exactly once* in various different browsers. The result is the number of milliseconds it took to run ```findTerms```.
**Chrome:**
![test-chrome](https://user-images.githubusercontent.com/11037431/63621955-5eb92f80-c5c3-11e9-918e-261d10607305.png)

**Firefox:**
![test-firefox](https://user-images.githubusercontent.com/11037431/63621965-64af1080-c5c3-11e9-8cf8-f7e8cc480a6c.png)

**Edge:**
![test-edge](https://user-images.githubusercontent.com/11037431/63621972-68db2e00-c5c3-11e9-8cba-43b6c0eec83a.png)

---

These numbers can vary a bit, but the gist is that Edge is *very* slow. More often than not, a basic scan will take in excess of 1 second (the test case was actually one of the better timings). The test was not performed on an exceptionally powerful device, but the difference is still quite significant.

The origin of the slowdown seems to be anything involving querying the IndexedDB, I was a single query take ~12ms frequently, sometimes more, sometimes less. Tried with the most recent version of dexie also with the same results. Could also be something to do with Edge's method of scheduling callbacks, as it [wouldn't be the first time](https://danyow.net/edge-promise-perf/) [that has happened](https://wpdev.uservoice.com/forums/257854-microsoft-edge-developer/suggestions/11329845-improve-promise-implementation-performance).

Oh well.