### PR TITLE
Imposter element improvements

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -30,7 +30,7 @@ function docOffsetCalc(elementRect) {
     return {top, left};
 }
 
-function docImposterCreate(element) {
+function docImposterCreate(element, isTextarea) {
     const styleProps = window.getComputedStyle(element);
     const stylePairs = [];
     for (const key of styleProps) {
@@ -49,8 +49,14 @@ function docImposterCreate(element) {
     imposter.style.opacity = 0;
     imposter.style.zIndex = 2147483646;
     imposter.style.margin = '0';
-    if (element.nodeName === 'TEXTAREA' && styleProps.overflow === 'visible') {
-        imposter.style.overflow = 'auto';
+    if (isTextarea) {
+        if (styleProps.overflow === 'visible') {
+            imposter.style.overflow = 'auto';
+        }
+    } else {
+        imposter.style.overflow = 'hidden';
+        imposter.style.whiteSpace = 'nowrap';
+        imposter.style.lineHeight = styleProps.height;
     }
 
     document.body.appendChild(imposter);
@@ -79,8 +85,10 @@ function docRangeFromPoint(point) {
             case 'BUTTON':
                 return new TextSourceElement(element);
             case 'INPUT':
+                imposter = docImposterCreate(element, false);
+                break;
             case 'TEXTAREA':
-                imposter = docImposterCreate(element);
+                imposter = docImposterCreate(element, true);
                 break;
         }
     }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -70,12 +70,6 @@ function docImposterCreate(element) {
     return imposter;
 }
 
-function docImposterDestroy() {
-    for (const element of document.getElementsByClassName('yomichan-imposter')) {
-        element.parentNode.removeChild(element);
-    }
-}
-
 function docRangeFromPoint(point) {
     const element = document.elementFromPoint(point.x, point.y);
     let imposter = null;
@@ -92,12 +86,18 @@ function docRangeFromPoint(point) {
     }
 
     const range = document.caretRangeFromPoint(point.x, point.y);
-    if (imposter !== null) {
-        imposter.style.zIndex = -2147483646;
-        imposter.style.pointerEvents = 'none';
+    if (range !== null && isPointInRange(point, range)) {
+        if (imposter !== null) {
+            imposter.style.zIndex = -2147483646;
+            imposter.style.pointerEvents = 'none';
+        }
+        return new TextSourceRange(range, '', imposter);
+    } else {
+        if (imposter !== null) {
+            imposter.parentNode.removeChild(imposter);
+        }
+        return null;
     }
-
-    return range !== null && isPointInRange(point, range) ? new TextSourceRange(range) : null;
 }
 
 function docSentenceExtract(source, extent) {

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -17,16 +17,15 @@
  */
 
 
-function docOffsetCalc(element) {
+function docOffsetCalc(elementRect) {
     const scrollTop = window.pageYOffset || document.documentElement.scrollTop || document.body.scrollTop;
     const scrollLeft = window.pageXOffset || document.documentElement.scrollLeft || document.body.scrollLeft;
 
     const clientTop = document.documentElement.clientTop || document.body.clientTop || 0;
     const clientLeft = document.documentElement.clientLeft || document.body.clientLeft || 0;
 
-    const rect = element.getBoundingClientRect();
-    const top  = Math.round(rect.top +  scrollTop - clientTop);
-    const left = Math.round(rect.left + scrollLeft - clientLeft);
+    const top  = Math.round(elementRect.top +  scrollTop - clientTop);
+    const left = Math.round(elementRect.left + scrollLeft - clientLeft);
 
     return {top, left};
 }
@@ -38,7 +37,8 @@ function docImposterCreate(element) {
         stylePairs.push(`${key}: ${styleProps[key]};`);
     }
 
-    const offset = docOffsetCalc(element);
+    const elementRect = element.getBoundingClientRect();
+    const offset = docOffsetCalc(elementRect);
     const imposter = document.createElement('div');
     imposter.className = 'yomichan-imposter';
     imposter.innerText = element.value;
@@ -48,11 +48,22 @@ function docImposterCreate(element) {
     imposter.style.left = `${offset.left}px`;
     imposter.style.opacity = 0;
     imposter.style.zIndex = 2147483646;
+    imposter.style.margin = '0';
     if (element.nodeName === 'TEXTAREA' && styleProps.overflow === 'visible') {
         imposter.style.overflow = 'auto';
     }
 
     document.body.appendChild(imposter);
+
+    // Adjust size
+    const imposterRect = imposter.getBoundingClientRect();
+    if (imposterRect.width !== elementRect.width || imposterRect.height !== elementRect.height) {
+        const width = parseFloat(styleProps.width) + (elementRect.width - imposterRect.width);
+        const height = parseFloat(styleProps.height) + (elementRect.height - imposterRect.height);
+        imposter.style.width = `${width}px`;
+        imposter.style.height = `${height}px`;
+    }
+
     imposter.scrollTop = element.scrollTop;
     imposter.scrollLeft = element.scrollLeft;
 

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -24,8 +24,8 @@ function docOffsetCalc(elementRect) {
     const clientTop = document.documentElement.clientTop || document.body.clientTop || 0;
     const clientLeft = document.documentElement.clientLeft || document.body.clientLeft || 0;
 
-    const top  = Math.round(elementRect.top +  scrollTop - clientTop);
-    const left = Math.round(elementRect.left + scrollLeft - clientLeft);
+    const top  = elementRect.top +  scrollTop - clientTop;
+    const left = elementRect.left + scrollLeft - clientLeft;
 
     return {top, left};
 }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -94,6 +94,7 @@ function docRangeFromPoint(point) {
     const range = document.caretRangeFromPoint(point.x, point.y);
     if (imposter !== null) {
         imposter.style.zIndex = -2147483646;
+        imposter.style.pointerEvents = 'none';
     }
 
     return range !== null && isPointInRange(point, range) ? new TextSourceRange(range) : null;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -307,10 +307,11 @@ class Frontend {
                 this.onError(e);
             }
         } finally {
+            if (textSource !== null) {
+                textSource.cleanup();
+            }
             if (hideResults && this.options.scanning.autoHideResults) {
                 this.searchClear();
-            } else {
-                docImposterDestroy();
             }
 
             this.pendingLookup = false;
@@ -371,7 +372,6 @@ class Frontend {
     }
 
     searchClear() {
-        docImposterDestroy();
         this.popup.hide();
         this.popup.clearAutoPlayTimer();
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -25,19 +25,19 @@ const IGNORE_TEXT_PATTERN = /\u200c/;
  */
 
 class TextSourceRange {
-    constructor(range, content, imposter) {
+    constructor(range, content, imposterContainer) {
         this.range = range;
         this.content = content;
-        this.imposter = imposter;
+        this.imposterContainer = imposterContainer;
     }
 
     clone() {
-        return new TextSourceRange(this.range.cloneRange(), this.content, this.imposter);
+        return new TextSourceRange(this.range.cloneRange(), this.content, this.imposterContainer);
     }
 
     cleanup() {
-        if (this.imposter !== null && this.imposter.parentNode !== null) {
-            this.imposter.parentNode.removeChild(this.imposter);
+        if (this.imposterContainer !== null && this.imposterContainer.parentNode !== null) {
+            this.imposterContainer.parentNode.removeChild(this.imposterContainer);
         }
     }
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -25,13 +25,20 @@ const IGNORE_TEXT_PATTERN = /\u200c/;
  */
 
 class TextSourceRange {
-    constructor(range, content='') {
+    constructor(range, content, imposter) {
         this.range = range;
         this.content = content;
+        this.imposter = imposter;
     }
 
     clone() {
-        return new TextSourceRange(this.range.cloneRange(), this.content);
+        return new TextSourceRange(this.range.cloneRange(), this.content, this.imposter);
+    }
+
+    cleanup() {
+        if (this.imposter !== null && this.imposter.parentNode !== null) {
+            this.imposter.parentNode.removeChild(this.imposter);
+        }
     }
 
     text() {
@@ -219,6 +226,10 @@ class TextSourceElement {
 
     clone() {
         return new TextSourceElement(this.element, this.content);
+    }
+
+    cleanup() {
+        // NOP
     }
 
     text() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -84,16 +84,22 @@ class Display {
             if (textSource === null) {
                 return false;
             }
-            textSource.setEndOffset(this.options.scanning.length);
 
-            const {definitions, length} = await apiTermsFind(textSource.text());
-            if (definitions.length === 0) {
-                return false;
+            let definitions, length, sentence;
+            try {
+                textSource.setEndOffset(this.options.scanning.length);
+
+                ({definitions, length} = await apiTermsFind(textSource.text()));
+                if (definitions.length === 0) {
+                    return false;
+                }
+
+                textSource.setEndOffset(length);
+
+                sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
+            } finally {
+                textSource.cleanup();
             }
-
-            textSource.setEndOffset(length);
-
-            const sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
 
             const context = {
                 source: {


### PR DESCRIPTION
This change fixes and improves the use of the imposter element:

* CSS ```margin``` property not being zeroed out. This was causing the imposter element to appear in the wrong location in #148, since the ```<textarea>``` had margins and [```getBoundingClientRect```](https://developer.mozilla.org/en-US/docs/Web/API/Element/getBoundingClientRect) does not include margins in the returned ```DOMRect```.
* Fixed element size sometimes not being correct. Due to rendering differences between ```<textarea>``` and ```<div>```, the size of the imposter element would sometimes not match the original textarea. This is usually due to how the size of the scrollbar(s) affect the size of the textarea. The size of the imposter element is now adjusted to match the textarea if there is a difference.
* Removed ```Math.round``` from ```docOffsetCalc``` results, since it reduces accuracy; CSS ```left``` and ```top``` can take decimals values. Rounding could previously cause the imposter position to be off by ~1px. (Usually not noticeable, but I saw no reason to keep it that way.)
* Sets [```pointer-events```](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) to ```'none'``` when moving the imposter to the lowest ```z-index``` to further prevent any unwanted interactions.
* Fixes some styling issues with ```<input type="text">```.
  * CSS ```overflow``` set to ```'hidden'``` and ```white-space``` to ```'nowrap'``` to prevent wrapped text. Text inputs are single line.
  * CSS ```line-height``` set to the height of the element in order to get the text to middle align vertically.
* Force all style overrides to use CSS priority ```important```, preventing styles on the underlying webpage from being able to affect it.
* Finally, I also made a change to how the imposter elements are tracked and ultimately removed. The imposter elements are now tracked by the corresponding ```TextSourceRange``` which is created. ```TextSourceRange``` now has a ```cleanup``` function to remove the imposter from the DOM. This should make the lifetime of the imposter more clear, and removes the need to search for nodes to remove using ```document.getElementsByClassName('yomichan-imposter')```.

Fixes #148
Maybe related: #125?