### PR TITLE
Deep DOM scanning through transparent elements

### DIFF
--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -218,7 +218,8 @@ function optionsSetDefaults(options) {
             autoHideResults: false,
             delay: 20,
             length: 10,
-            modifier: 'shift'
+            modifier: 'shift',
+            deepDomScan: false
         },
 
         dictionaries: {},

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -47,6 +47,7 @@ async function formRead() {
     optionsNew.scanning.selectText = $('#select-matched-text').prop('checked');
     optionsNew.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
     optionsNew.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
+    optionsNew.scanning.deepDomScan = $('#deep-dom-scan').prop('checked');
     optionsNew.scanning.delay = parseInt($('#scan-delay').val(), 10);
     optionsNew.scanning.length = parseInt($('#scan-length').val(), 10);
     optionsNew.scanning.modifier = $('#scan-modifier-key').val();
@@ -187,6 +188,7 @@ async function onReady() {
     $('#select-matched-text').prop('checked', options.scanning.selectText);
     $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
     $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);
+    $('#deep-dom-scan').prop('checked', options.scanning.deepDomScan);
     $('#scan-delay').val(options.scanning.delay);
     $('#scan-length').val(options.scanning.length);
     $('#scan-modifier-key').val(options.scanning.modifier);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -192,6 +192,10 @@
                     <label><input type="checkbox" id="auto-hide-results"> Automatically hide results</label>
                 </div>
 
+                <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="deep-dom-scan"> Deep DOM scan</label>
+                </div>
+
                 <div class="form-group options-advanced">
                     <label for="scan-delay">Scan delay (in milliseconds)</label>
                     <input type="number" min="1" id="scan-delay" class="form-control">

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -269,15 +269,19 @@ function caretRangeFromPointExt(x, y, elements) {
     const modifications = [];
     try {
         let i = 0;
+        let startContinerPre = null;
         while (true) {
             const range = caretRangeFromPoint(x, y);
             if (range === null) {
                 return null;
             }
 
-            const inRange = isPointInRange(x, y, range);
-            if (inRange) {
-                return range;
+            const startContainer = range.startContainer;
+            if (startContinerPre !== startContainer) {
+                if (isPointInRange(x, y, range)) {
+                    return range;
+                }
+                startContinerPre = startContainer;
             }
 
             i = disableTransparentElement(elements, i, modifications);

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -87,8 +87,8 @@ function docImposterCreate(element, isTextarea) {
     return [imposter, container];
 }
 
-function docRangeFromPoint(point) {
-    const element = document.elementFromPoint(point.x, point.y);
+function docRangeFromPoint({x, y}) {
+    const element = document.elementFromPoint(x, y);
     let imposter = null;
     let imposterContainer = null;
     if (element) {
@@ -105,7 +105,7 @@ function docRangeFromPoint(point) {
         }
     }
 
-    const range = document.caretRangeFromPoint(point.x, point.y);
+    const range = document.caretRangeFromPoint(x, y);
     if (range !== null && isPointInRange(point, range)) {
         if (imposter !== null) {
             docSetImposterStyle(imposterContainer.style, 'z-index', '-2147483646');
@@ -191,7 +191,7 @@ function docSentenceExtract(source, extent) {
     };
 }
 
-function isPointInRange(point, range) {
+function isPointInRange(x, y, range) {
     // Scan forward
     const nodePre = range.endContainer;
     const offsetPre = range.endOffset;
@@ -199,7 +199,7 @@ function isPointInRange(point, range) {
         const {node, offset} = TextSourceRange.seekForward(range.endContainer, range.endOffset, 1);
         range.setEnd(node, offset);
 
-        if (isPointInAnyRect(point, range.getClientRects())) {
+        if (isPointInAnyRect(x, y, range.getClientRects())) {
             return true;
         }
     } finally {
@@ -210,7 +210,7 @@ function isPointInRange(point, range) {
     const {node, offset} = TextSourceRange.seekBackward(range.startContainer, range.startOffset, 1);
     range.setStart(node, offset);
 
-    if (isPointInAnyRect(point, range.getClientRects())) {
+    if (isPointInAnyRect(x, y, range.getClientRects())) {
         // This purposefully leaves the starting offset as modified and sets teh range length to 0.
         range.setEnd(node, offset);
         return true;
@@ -220,19 +220,19 @@ function isPointInRange(point, range) {
     return false;
 }
 
-function isPointInAnyRect(point, rects) {
+function isPointInAnyRect(x, y, rects) {
     for (const rect of rects) {
-        if (isPointInRect(point, rect)) {
+        if (isPointInRect(x, y, rect)) {
             return true;
         }
     }
     return false;
 }
 
-function isPointInRect(point, rect) {
+function isPointInRect(x, y, rect) {
     return (
-        point.x >= rect.left && point.x < rect.right &&
-        point.y >= rect.top && point.y < rect.bottom);
+        x >= rect.left && x < rect.right &&
+        y >= rect.top && y < rect.bottom);
 }
 
 if (typeof document.caretRangeFromPoint !== 'function') {

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -199,10 +199,10 @@ function isPointInRange(x, y, range) {
     const nodePre = range.endContainer;
     const offsetPre = range.endOffset;
     try {
-        const {node, offset} = TextSourceRange.seekForward(range.endContainer, range.endOffset, 1);
+        const {node, offset, content} = TextSourceRange.seekForward(range.endContainer, range.endOffset, 1);
         range.setEnd(node, offset);
 
-        if (isPointInAnyRect(x, y, range.getClientRects())) {
+        if (!isWhitespace(content) && isPointInAnyRect(x, y, range.getClientRects())) {
             return true;
         }
     } finally {
@@ -210,10 +210,10 @@ function isPointInRange(x, y, range) {
     }
 
     // Scan backward
-    const {node, offset} = TextSourceRange.seekBackward(range.startContainer, range.startOffset, 1);
+    const {node, offset, content} = TextSourceRange.seekBackward(range.startContainer, range.startOffset, 1);
     range.setStart(node, offset);
 
-    if (isPointInAnyRect(x, y, range.getClientRects())) {
+    if (!isWhitespace(content) && isPointInAnyRect(x, y, range.getClientRects())) {
         // This purposefully leaves the starting offset as modified and sets teh range length to 0.
         range.setEnd(node, offset);
         return true;
@@ -221,6 +221,10 @@ function isPointInRange(x, y, range) {
 
     // No match
     return false;
+}
+
+function isWhitespace(string) {
+    return string.trim().length === 0;
 }
 
 function isPointInAnyRect(x, y, rects) {

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -89,7 +89,7 @@ function docImposterCreate(element, isTextarea) {
     return [imposter, container];
 }
 
-function docRangeFromPoint({x, y}) {
+function docRangeFromPoint({x, y}, options) {
     const elements = document.elementsFromPoint(x, y);
     let imposter = null;
     let imposterContainer = null;
@@ -108,7 +108,7 @@ function docRangeFromPoint({x, y}) {
         }
     }
 
-    const range = caretRangeFromPointExt(x, y, elements);
+    const range = caretRangeFromPointExt(x, y, options.scanning.deepDomScan ? elements : []);
     if (range !== null) {
         if (imposter !== null) {
             docSetImposterStyle(imposterContainer.style, 'z-index', '-2147483646');

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -219,7 +219,7 @@ function isPointInRange(x, y, range) {
     range.setStart(node, offset);
 
     if (!isWhitespace(content) && isPointInAnyRect(x, y, range.getClientRects())) {
-        // This purposefully leaves the starting offset as modified and sets teh range length to 0.
+        // This purposefully leaves the starting offset as modified and sets the range length to 0.
         range.setEnd(node, offset);
         return true;
     }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -195,6 +195,11 @@ function docSentenceExtract(source, extent) {
 }
 
 function isPointInRange(x, y, range) {
+    // Require a text node to start
+    if (range.startContainer.nodeType !== Node.TEXT_NODE) {
+        return false;
+    }
+
     // Scan forward
     const nodePre = range.endContainer;
     const offsetPre = range.endOffset;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -285,7 +285,7 @@ class Frontend {
             return;
         }
 
-        const textSource = docRangeFromPoint(point);
+        const textSource = docRangeFromPoint(point, this.options);
         let hideResults = !textSource || !textSource.containsPoint(point);
         let searched = false;
         let success = false;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -80,7 +80,7 @@ class Display {
             const {docRangeFromPoint, docSentenceExtract} = this.dependencies;
 
             const clickedElement = $(e.target);
-            const textSource = docRangeFromPoint({x: e.clientX, y: e.clientY});
+            const textSource = docRangeFromPoint({x: e.clientX, y: e.clientY}, this.options);
             if (textSource === null) {
                 return false;
             }


### PR DESCRIPTION
This change allows Yomichan to be able to scan through transparent elements, which includes overlays. There are a few comments to be made about this:

1. There is performance overhead when this change is applied. I did not profile any timings, and my testing didn't necessarily _feel_ slower, but more code will be executed depending on the DOM structure of website.
2. Basically how this works is that when scanning using [```caretRangeFromPoint```](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint), if no valid text range is found, the "transparent" elements underneath the scan cursor are disabled one-by-one, and the ```caretRangeFromPoint``` sequence is repeated. However, this adds the overhead of adding additional ```caretRangeFromPoint``` and ```isPointInRange``` calls. (0aeb61eadea8d4ea1040632082f49856e0fa20c2 improves this a little bit.)
3. In order to prevent elements from being returned when using ```caretRangeFromPoint```, the [```pointer-events```](https://developer.mozilla.org/en-US/docs/Web/CSS/pointer-events) style is set to ```'none'``` temporarily. While the style is restored after scanning has completed, these changes are likely observable via [```MutationObserver```](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver), which could have a performance impact depending on DOM structure and event listeners.

Due to these two concerns, there is a setting to control whether this feature is enabled, which is currently disabled by default: ```deepDomScan```. It could be potentially more efficient to have a whitelist option to enable this on a site-by-site basis, but I didn't want to go that far unless it's deemed necessary.

This change does not work for ```textarea```s or ```input```s which are covered by transparent elements, since that would likely incur a bigger merge conflict between #197. This can be addressed later.

Fixes #143