### PR TITLE
Omit containsPoint check on searchAt

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -286,7 +286,7 @@ class Frontend {
         }
 
         const textSource = docRangeFromPoint(point, this.options);
-        let hideResults = !textSource || !textSource.containsPoint(point);
+        let hideResults = textSource === null;
         let searched = false;
         let success = false;
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -59,29 +59,12 @@ class TextSourceRange {
         return length - state.remainder;
     }
 
-    containsPoint(point) {
-        const rect = this.getPaddedRect();
-        return point.x >= rect.left && point.x <= rect.right;
-    }
-
     getRect() {
         return this.range.getBoundingClientRect();
     }
 
     getWritingMode() {
         return TextSourceRange.getElementWritingMode(TextSourceRange.getParentElement(this.range.startContainer));
-    }
-
-    getPaddedRect() {
-        const range = this.range.cloneRange();
-        const startOffset = range.startOffset;
-        const endOffset = range.endOffset;
-        const node = range.startContainer;
-
-        range.setStart(node, Math.max(0, startOffset - 1));
-        range.setEnd(node, Math.min(node.length, endOffset + 1));
-
-        return range.getBoundingClientRect();
     }
 
     select() {
@@ -288,11 +271,6 @@ class TextSourceElement {
 
     setStartOffset(length) {
         return 0;
-    }
-
-    containsPoint(point) {
-        const rect = this.getRect();
-        return point.x >= rect.left && point.x <= rect.right;
     }
 
     getRect() {


### PR DESCRIPTION
The range returned by [```docRangeFromPoint```](https://github.com/toasted-nutbread/yomichan/blob/5c793180d04e6b5eafaf01c823f5f5e07639cfa9/ext/fg/js/document.js#L92) is now guaranteed to contain the point due to the addition of [```isPointInRange```](https://github.com/toasted-nutbread/yomichan/blob/5c793180d04e6b5eafaf01c823f5f5e07639cfa9/ext/fg/js/document.js#L290) checks.