### PR TITLE
Temporary object optimization

### DIFF
--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -140,16 +140,17 @@ function dictTermsCompressTags(definitions) {
 function dictTermsGroup(definitions, dictionaries) {
     const groups = {};
     for (const definition of definitions) {
-        const key = [definition.source, definition.expression].concat(definition.reasons);
+        const key = [definition.source, definition.expression];
+        key.push(...definition.reasons);
         if (definition.reading) {
             key.push(definition.reading);
         }
 
-        const group = groups[key];
-        if (group) {
-            group.push(definition);
+        const keyString = key.toString();
+        if (groups.hasOwnProperty(keyString)) {
+            groups[keyString].push(definition);
         } else {
-            groups[key] = [definition];
+            groups[keyString] = [definition];
         }
     }
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -186,7 +186,7 @@ class Translator {
         let deinflections = await this.findTermDeinflections(text, titles, cache);
         const textHiragana = jpKatakanaToHiragana(text);
         if (text !== textHiragana) {
-            deinflections = deinflections.concat(await this.findTermDeinflections(textHiragana, titles, cache));
+            deinflections.push(...await this.findTermDeinflections(textHiragana, titles, cache));
         }
 
         let definitions = [];
@@ -235,7 +235,7 @@ class Translator {
         let deinflections = [];
         for (let i = text.length; i > 0; --i) {
             const textSlice = text.slice(0, i);
-            deinflections = deinflections.concat(await this.deinflector.deinflect(textSlice, definer));
+            deinflections.push(...await this.deinflector.deinflect(textSlice, definer));
         }
 
         return deinflections;
@@ -247,7 +247,7 @@ class Translator {
         const titles = Object.keys(dictionaries);
         for (const c of text) {
             if (!processed[c]) {
-                definitions = definitions.concat(await this.database.findKanji(c, titles));
+                definitions.push(...await this.database.findKanji(c, titles));
                 processed[c] = true;
             }
         }
@@ -277,7 +277,7 @@ class Translator {
     async buildTermFrequencies(definition, titles) {
         let terms = [];
         if (definition.expressions) {
-            terms = terms.concat(definition.expressions);
+            terms.push(...definition.expressions);
         } else {
             terms.push(definition);
         }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -299,7 +299,7 @@ class Translator {
     async expandTags(names, title) {
         const tags = [];
         for (const name of names) {
-            const base = name.split(':')[0];
+            const base = Translator.getNameBase(name);
             const meta = await this.database.findTagForTitle(base, title);
 
             const tag = {name};
@@ -318,7 +318,7 @@ class Translator {
     async expandStats(items, title) {
         const stats = {};
         for (const name in items) {
-            const base = name.split(':')[0];
+            const base = Translator.getNameBase(name);
             const meta = await this.database.findTagForTitle(base, title);
             const group = stats[meta.category] = stats[meta.category] || [];
 
@@ -345,5 +345,10 @@ class Translator {
         }
 
         return stats;
+    }
+
+    static getNameBase(name) {
+        const pos = name.indexOf(':');
+        return (pos >= 0 ? name.substr(0, pos) : name);
     }
 }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -152,7 +152,7 @@ function docSentenceExtract(source, extent) {
         if (quoteStack.length > 0 && c === quoteStack[0]) {
             quoteStack.pop();
         } else if (c in quotesBwd) {
-            quoteStack = [quotesBwd[c]].concat(quoteStack);
+            quoteStack.unshift(quotesBwd[c]);
         }
     }
 
@@ -181,7 +181,7 @@ function docSentenceExtract(source, extent) {
         if (quoteStack.length > 0 && c === quoteStack[0]) {
             quoteStack.pop();
         } else if (c in quotesFwd) {
-            quoteStack = [quotesFwd[c]].concat(quoteStack);
+            quoteStack.unshift(quotesFwd[c]);
         }
     }
 


### PR DESCRIPTION
First of several optimizations; this change should slightly reduce memory footprint and slightly increase speed. This change largely optimizes several calls to ```Array.concat``` and ```String.split```, which can be replaced with calls which don't generate intermediate arrays. Also makes a change to ```dictTermsGroup``` to only convert the key array to a string once.

Timing information won't be as relevant for this change, especially since the precision of [```performance.now()```](https://developer.mozilla.org/en-US/docs/Web/API/Performance/now) was reduced in most browsers in light of Spectre and similar exploits. However, I did create several tests for the changes in isolation, which can be run in node or browser.

https://gist.github.com/toasted-nutbread/1b8bab884e95e56483af7d494909baef
For all 4 files, ```test1()``` mimics behavior before this change, ```test2()``` mimics the behavior after this change. All changes except ```perf-lookup.js``` are universally faster; ```perf-lookup.js``` is faster in Firefox, but marginally slower in Chrome. This difference should not be noticeable in practice.

#189