### PR TITLE
Remove unsafe-eval from content_security_policy

### DIFF
--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -57,7 +57,7 @@
         }
     },
     "web_accessible_resources": ["fg/float.html"],
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+    "content_security_policy": "script-src 'self'; object-src 'self'",
     "applications": {
         "gecko": {
             "id": "alex@foosoft.net",


### PR DESCRIPTION
As far as I can tell, this is not necessary, nor should it be.

https://developer.chrome.com/extensions/contentSecurityPolicy#relaxing-eval