### PR TITLE
Settings improvements part 2

### DIFF
--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -25,7 +25,7 @@ async function apiOptionsSave() {
     const backend = utilBackend();
     const options = await backend.getFullOptions();
     await optionsSave(options);
-    backend.onOptionsUpdated(options);
+    backend.onOptionsUpdated();
 }
 
 async function apiTermsFind(text, optionsContext) {

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -17,16 +17,12 @@
  */
 
 
-function apiOptionsGetSync(optionsContext) {
+function apiOptionsGet(optionsContext) {
     return utilBackend().getOptions(optionsContext);
 }
 
-async function apiOptionsGet(optionsContext) {
-    return apiOptionsGetSync(optionsContext);
-}
-
 async function apiTermsFind(text, optionsContext) {
-    const options = apiOptionsGetSync(optionsContext);
+    const options = await apiOptionsGet(optionsContext);
     const translator = utilBackend().translator;
 
     const searcher = {
@@ -49,13 +45,13 @@ async function apiTermsFind(text, optionsContext) {
 }
 
 async function apiKanjiFind(text, optionsContext) {
-    const options = apiOptionsGetSync(optionsContext);
+    const options = await apiOptionsGet(optionsContext);
     const definitions = await utilBackend().translator.findKanji(text, dictEnabledSet(options));
     return definitions.slice(0, options.general.maxResults);
 }
 
 async function apiDefinitionAdd(definition, mode, context, optionsContext) {
-    const options = apiOptionsGetSync(optionsContext);
+    const options = await apiOptionsGet(optionsContext);
 
     if (mode !== 'kanji') {
         await audioInject(
@@ -78,7 +74,7 @@ async function apiDefinitionAdd(definition, mode, context, optionsContext) {
 }
 
 async function apiDefinitionsAddable(definitions, modes, optionsContext) {
-    const options = apiOptionsGetSync(optionsContext);
+    const options = await apiOptionsGet(optionsContext);
     const states = [];
 
     try {
@@ -134,7 +130,7 @@ async function apiCommandExec(command) {
 
         toggle: async () => {
             const optionsContext = {depth: 0};
-            const options = apiOptionsGetSync(optionsContext);
+            const options = await apiOptionsGet(optionsContext);
             options.general.enable = !options.general.enable;
             await optionsSave(options);
         }

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -17,16 +17,16 @@
  */
 
 
-function apiOptionsGetSync() {
+function apiOptionsGetSync(optionsContext) {
     return utilBackend().options;
 }
 
-async function apiOptionsGet() {
-    return apiOptionsGetSync();
+async function apiOptionsGet(optionsContext) {
+    return apiOptionsGetSync(optionsContext);
 }
 
-async function apiTermsFind(text) {
-    const options = apiOptionsGetSync();
+async function apiTermsFind(text, optionsContext) {
+    const options = apiOptionsGetSync(optionsContext);
     const translator = utilBackend().translator;
 
     const searcher = {
@@ -48,14 +48,14 @@ async function apiTermsFind(text) {
     };
 }
 
-async function apiKanjiFind(text) {
-    const options = apiOptionsGetSync();
+async function apiKanjiFind(text, optionsContext) {
+    const options = apiOptionsGetSync(optionsContext);
     const definitions = await utilBackend().translator.findKanji(text, dictEnabledSet(options));
     return definitions.slice(0, options.general.maxResults);
 }
 
-async function apiDefinitionAdd(definition, mode, context) {
-    const options = apiOptionsGetSync();
+async function apiDefinitionAdd(definition, mode, context, optionsContext) {
+    const options = apiOptionsGetSync(optionsContext);
 
     if (mode !== 'kanji') {
         await audioInject(
@@ -77,14 +77,15 @@ async function apiDefinitionAdd(definition, mode, context) {
     return utilBackend().anki.addNote(note);
 }
 
-async function apiDefinitionsAddable(definitions, modes) {
+async function apiDefinitionsAddable(definitions, modes, optionsContext) {
+    const options = apiOptionsGetSync(optionsContext);
     const states = [];
 
     try {
         const notes = [];
         for (const definition of definitions) {
             for (const mode of modes) {
-                const note = await dictNoteFormat(definition, mode, apiOptionsGetSync());
+                const note = await dictNoteFormat(definition, mode, options);
                 notes.push(note);
             }
         }
@@ -132,7 +133,8 @@ async function apiCommandExec(command) {
         },
 
         toggle: async () => {
-            const options = apiOptionsGetSync();
+            const optionsContext = {depth: 0};
+            const options = apiOptionsGetSync(optionsContext);
             options.general.enable = !options.general.enable;
             await optionsSave(options);
         }

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -38,7 +38,8 @@ async function apiTermsFind(text) {
     const {definitions, length} = await searcher(
         text,
         dictEnabledSet(options),
-        options.scanning.alphanumeric
+        options.scanning.alphanumeric,
+        options
     );
 
     return {

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -18,7 +18,7 @@
 
 
 function apiOptionsGetSync(optionsContext) {
-    return utilBackend().options;
+    return utilBackend().getOptions(optionsContext);
 }
 
 async function apiOptionsGet(optionsContext) {

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -21,11 +21,11 @@ function apiOptionsGet(optionsContext) {
     return utilBackend().getOptions(optionsContext);
 }
 
-async function apiOptionsSave() {
+async function apiOptionsSave(source) {
     const backend = utilBackend();
     const options = await backend.getFullOptions();
     await optionsSave(options);
-    backend.onOptionsUpdated();
+    backend.onOptionsUpdated(source);
 }
 
 async function apiTermsFind(text, optionsContext) {
@@ -139,7 +139,7 @@ async function apiCommandExec(command) {
             const optionsContext = {depth: 0};
             const options = await apiOptionsGet(optionsContext);
             options.general.enable = !options.general.enable;
-            await apiOptionsSave();
+            await apiOptionsSave('popup');
         }
     };
 

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -21,6 +21,13 @@ function apiOptionsGet(optionsContext) {
     return utilBackend().getOptions(optionsContext);
 }
 
+async function apiOptionsSave() {
+    const backend = utilBackend();
+    const options = await backend.getFullOptions();
+    await optionsSave(options);
+    backend.onOptionsUpdated(options);
+}
+
 async function apiTermsFind(text, optionsContext) {
     const options = await apiOptionsGet(optionsContext);
     const translator = utilBackend().translator;
@@ -132,7 +139,7 @@ async function apiCommandExec(command) {
             const optionsContext = {depth: 0};
             const options = await apiOptionsGet(optionsContext);
             options.general.enable = !options.general.enable;
-            await optionsSave(options);
+            await apiOptionsSave();
         }
     };
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -34,7 +34,8 @@ class Backend {
 
     async prepare() {
         await this.translator.prepare();
-        this.onOptionsUpdated(await optionsLoad());
+        this.options = await optionsLoad();
+        this.onOptionsUpdated();
 
         if (chrome.commands !== null && typeof chrome.commands === 'object') {
             chrome.commands.onCommand.addListener(this.onCommand.bind(this));
@@ -51,8 +52,7 @@ class Backend {
         this.isPreparedPromise = null;
     }
 
-    onOptionsUpdated(options) {
-        this.options = utilIsolate(options);
+    onOptionsUpdated() {
         this.applyOptions();
 
         const callback = () => this.checkLastError(chrome.runtime.lastError);

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -59,7 +59,7 @@ class Backend {
         const callback = () => this.checkLastError(chrome.runtime.lastError);
         chrome.tabs.query({}, tabs => {
             for (const tab of tabs) {
-                chrome.tabs.sendMessage(tab.id, {action: 'optionsSet', params: {options}}, callback);
+                chrome.tabs.sendMessage(tab.id, {action: 'optionsUpdate', params: {}}, callback);
             }
         });
     }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -78,24 +78,24 @@ class Backend {
         };
 
         const handlers = {
-            optionsGet: ({callback}) => {
-                forward(apiOptionsGet(), callback);
+            optionsGet: ({optionsContext, callback}) => {
+                forward(apiOptionsGet(optionsContext), callback);
             },
 
-            kanjiFind: ({text, callback}) => {
-                forward(apiKanjiFind(text), callback);
+            kanjiFind: ({text, optionsContext, callback}) => {
+                forward(apiKanjiFind(text, optionsContext), callback);
             },
 
-            termsFind: ({text, callback}) => {
-                forward(apiTermsFind(text), callback);
+            termsFind: ({text, optionsContext, callback}) => {
+                forward(apiTermsFind(text, optionsContext), callback);
             },
 
-            definitionAdd: ({definition, mode, context, callback}) => {
-                forward(apiDefinitionAdd(definition, mode, context), callback);
+            definitionAdd: ({definition, mode, context, optionsContext, callback}) => {
+                forward(apiDefinitionAdd(definition, mode, context, optionsContext), callback);
             },
 
-            definitionsAddable: ({definitions, modes, callback}) => {
-                forward(apiDefinitionsAddable(definitions, modes), callback);
+            definitionsAddable: ({definitions, modes, optionsContext, callback}) => {
+                forward(apiDefinitionsAddable(definitions, modes, optionsContext), callback);
             },
 
             noteView: ({noteId}) => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -35,7 +35,7 @@ class Backend {
     async prepare() {
         await this.translator.prepare();
         this.options = await optionsLoad();
-        this.onOptionsUpdated();
+        this.onOptionsUpdated('background');
 
         if (chrome.commands !== null && typeof chrome.commands === 'object') {
             chrome.commands.onCommand.addListener(this.onCommand.bind(this));
@@ -52,13 +52,13 @@ class Backend {
         this.isPreparedPromise = null;
     }
 
-    onOptionsUpdated() {
+    onOptionsUpdated(source) {
         this.applyOptions();
 
         const callback = () => this.checkLastError(chrome.runtime.lastError);
         chrome.tabs.query({}, tabs => {
             for (const tab of tabs) {
-                chrome.tabs.sendMessage(tab.id, {action: 'optionsUpdate', params: {}}, callback);
+                chrome.tabs.sendMessage(tab.id, {action: 'optionsUpdate', params: {source}}, callback);
             }
         });
     }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -150,6 +150,13 @@ class Backend {
         this.anki = options.anki.enable ? new AnkiConnect(options.anki.server) : new AnkiNull();
     }
 
+    async getFullOptions() {
+        if (this.isPreparedPromise !== null) {
+            await this.isPreparedPromise;
+        }
+        return this.options;
+    }
+
     async getOptions(optionsContext) {
         if (this.isPreparedPromise !== null) {
             await this.isPreparedPromise;

--- a/ext/bg/js/context.js
+++ b/ext/bg/js/context.js
@@ -22,7 +22,8 @@ $(document).ready(utilAsync(() => {
     $('#open-options').click(() => apiCommandExec('options'));
     $('#open-help').click(() => apiCommandExec('help'));
 
-    optionsLoad().then(options => {
+    const optionsContext = {depth: 0};
+    apiOptionsGet(optionsContext).then(options => {
         const toggle = $('#enable-search');
         toggle.prop('checked', options.general.enable).change();
         toggle.bootstrapToggle();

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -330,7 +330,7 @@ function optionsLoad() {
     }).then(optionsStr => {
         if (typeof optionsStr === 'string') {
             const options = JSON.parse(optionsStr);
-            if (typeof options === 'object' && options !== null && !Array.isArray(options)) {
+            if (utilIsObject(options)) {
                 return options;
             }
         }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -343,9 +343,14 @@ function optionsLoad() {
 }
 
 function optionsSave(options) {
-    return new Promise((resolve) => {
-        chrome.storage.local.set({options: JSON.stringify(options)}, resolve);
-    }).then(() => {
-        utilBackend().onOptionsUpdated(options);
+    return new Promise((resolve, reject) => {
+        chrome.storage.local.set({options: JSON.stringify(options)}, () => {
+            const error = chrome.runtime.lastError;
+            if (error) {
+                reject(error);
+            } else {
+                resolve();
+            }
+        });
     });
 }

--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -18,7 +18,8 @@
 
 
 async function searchFrontendSetup() {
-    const options = await apiOptionsGet();
+    const optionsContext = {depth: 0};
+    const options = await apiOptionsGet(optionsContext);
     if (!options.scanning.enableOnSearchPage) { return; }
 
     const scriptSrcs = [

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -21,6 +21,10 @@ class DisplaySearch extends Display {
     constructor() {
         super($('#spinner'), $('#content'));
 
+        this.optionsContext = {
+            depth: 0
+        };
+
         this.search = $('#search').click(this.onSearch.bind(this));
         this.query = $('#query').on('input', this.onSearchInput.bind(this));
         this.intro = $('#intro');
@@ -46,8 +50,8 @@ class DisplaySearch extends Display {
         try {
             e.preventDefault();
             this.intro.slideUp();
-            const {length, definitions} = await apiTermsFind(this.query.val());
-            super.termsShow(definitions, await apiOptionsGet());
+            const {length, definitions} = await apiTermsFind(this.query.val(), this.optionsContext);
+            super.termsShow(definitions, await apiOptionsGet(this.optionsContext));
         } catch (e) {
             this.onError(e);
         }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -148,7 +148,7 @@ async function onFormOptionsChanged(e) {
     const optionsAnkiServerOld = options.anki.server;
 
     await formRead(options);
-    await optionsSave(options);
+    await apiOptionsSave();
     formUpdateVisibility(options);
 
     try {
@@ -385,7 +385,7 @@ async function onDictionaryPurge(e) {
         const options = await apiOptionsGet(optionsContext);
         options.dictionaries = {};
         options.general.mainDictionary = '';
-        await optionsSave(options);
+        await apiOptionsSave();
 
         await dictionaryGroupsPopulate(options);
         await formMainDictionaryOptionsPopulate(options);
@@ -435,7 +435,7 @@ async function onDictionaryImport(e) {
             dictionaryErrorsShow(exceptions);
         }
 
-        await optionsSave(options);
+        await apiOptionsSave();
 
         await dictionaryGroupsPopulate(options);
         await formMainDictionaryOptionsPopulate(options);
@@ -579,7 +579,7 @@ async function onAnkiModelChanged(e) {
         const options = await apiOptionsGet(optionsContext);
         await formRead(options);
         options.anki[tabId].fields = {};
-        await optionsSave(options);
+        await apiOptionsSave();
 
         ankiSpinnerShow(true);
         await ankiFieldsPopulate(element, options);
@@ -599,7 +599,7 @@ async function onAnkiFieldTemplatesReset(e) {
         const fieldTemplates = optionsFieldTemplates();
         options.anki.fieldTemplates = fieldTemplates;
         $('#field-templates').val(fieldTemplates);
-        await optionsSave(options);
+        await apiOptionsSave();
     } catch (e) {
         ankiErrorShow(e);
     }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -17,72 +17,68 @@
  */
 
 
-async function formRead() {
-    const optionsOld = await optionsLoad();
-    const optionsNew = $.extend(true, {}, optionsOld);
+async function formRead(options) {
+    options.general.showGuide = $('#show-usage-guide').prop('checked');
+    options.general.compactTags = $('#compact-tags').prop('checked');
+    options.general.compactGlossaries = $('#compact-glossaries').prop('checked');
+    options.general.autoPlayAudio = $('#auto-play-audio').prop('checked');
+    options.general.resultOutputMode = $('#result-output-mode').val();
+    options.general.audioSource = $('#audio-playback-source').val();
+    options.general.audioVolume = parseFloat($('#audio-playback-volume').val());
+    options.general.debugInfo = $('#show-debug-info').prop('checked');
+    options.general.showAdvanced = $('#show-advanced-options').prop('checked');
+    options.general.maxResults = parseInt($('#max-displayed-results').val(), 10);
+    options.general.popupDisplayMode = $('#popup-display-mode').val();
+    options.general.popupHorizontalTextPosition = $('#popup-horizontal-text-position').val();
+    options.general.popupVerticalTextPosition = $('#popup-vertical-text-position').val();
+    options.general.popupWidth = parseInt($('#popup-width').val(), 10);
+    options.general.popupHeight = parseInt($('#popup-height').val(), 10);
+    options.general.popupHorizontalOffset = parseInt($('#popup-horizontal-offset').val(), 0);
+    options.general.popupVerticalOffset = parseInt($('#popup-vertical-offset').val(), 10);
+    options.general.popupHorizontalOffset2 = parseInt($('#popup-horizontal-offset2').val(), 0);
+    options.general.popupVerticalOffset2 = parseInt($('#popup-vertical-offset2').val(), 10);
+    options.general.customPopupCss = $('#custom-popup-css').val();
 
-    optionsNew.general.showGuide = $('#show-usage-guide').prop('checked');
-    optionsNew.general.compactTags = $('#compact-tags').prop('checked');
-    optionsNew.general.compactGlossaries = $('#compact-glossaries').prop('checked');
-    optionsNew.general.autoPlayAudio = $('#auto-play-audio').prop('checked');
-    optionsNew.general.resultOutputMode = $('#result-output-mode').val();
-    optionsNew.general.audioSource = $('#audio-playback-source').val();
-    optionsNew.general.audioVolume = parseFloat($('#audio-playback-volume').val());
-    optionsNew.general.debugInfo = $('#show-debug-info').prop('checked');
-    optionsNew.general.showAdvanced = $('#show-advanced-options').prop('checked');
-    optionsNew.general.maxResults = parseInt($('#max-displayed-results').val(), 10);
-    optionsNew.general.popupDisplayMode = $('#popup-display-mode').val();
-    optionsNew.general.popupHorizontalTextPosition = $('#popup-horizontal-text-position').val();
-    optionsNew.general.popupVerticalTextPosition = $('#popup-vertical-text-position').val();
-    optionsNew.general.popupWidth = parseInt($('#popup-width').val(), 10);
-    optionsNew.general.popupHeight = parseInt($('#popup-height').val(), 10);
-    optionsNew.general.popupHorizontalOffset = parseInt($('#popup-horizontal-offset').val(), 0);
-    optionsNew.general.popupVerticalOffset = parseInt($('#popup-vertical-offset').val(), 10);
-    optionsNew.general.popupHorizontalOffset2 = parseInt($('#popup-horizontal-offset2').val(), 0);
-    optionsNew.general.popupVerticalOffset2 = parseInt($('#popup-vertical-offset2').val(), 10);
-    optionsNew.general.customPopupCss = $('#custom-popup-css').val();
+    options.scanning.middleMouse = $('#middle-mouse-button-scan').prop('checked');
+    options.scanning.touchInputEnabled = $('#touch-input-enabled').prop('checked');
+    options.scanning.selectText = $('#select-matched-text').prop('checked');
+    options.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
+    options.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
+    options.scanning.deepDomScan = $('#deep-dom-scan').prop('checked');
+    options.scanning.enableOnPopupExpressions = $('#enable-scanning-of-popup-expressions').prop('checked');
+    options.scanning.enableOnSearchPage = $('#enable-scanning-on-search-page').prop('checked');
+    options.scanning.delay = parseInt($('#scan-delay').val(), 10);
+    options.scanning.length = parseInt($('#scan-length').val(), 10);
+    options.scanning.modifier = $('#scan-modifier-key').val();
+    options.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
 
-    optionsNew.scanning.middleMouse = $('#middle-mouse-button-scan').prop('checked');
-    optionsNew.scanning.touchInputEnabled = $('#touch-input-enabled').prop('checked');
-    optionsNew.scanning.selectText = $('#select-matched-text').prop('checked');
-    optionsNew.scanning.alphanumeric = $('#search-alphanumeric').prop('checked');
-    optionsNew.scanning.autoHideResults = $('#auto-hide-results').prop('checked');
-    optionsNew.scanning.deepDomScan = $('#deep-dom-scan').prop('checked');
-    optionsNew.scanning.enableOnPopupExpressions = $('#enable-scanning-of-popup-expressions').prop('checked');
-    optionsNew.scanning.enableOnSearchPage = $('#enable-scanning-on-search-page').prop('checked');
-    optionsNew.scanning.delay = parseInt($('#scan-delay').val(), 10);
-    optionsNew.scanning.length = parseInt($('#scan-length').val(), 10);
-    optionsNew.scanning.modifier = $('#scan-modifier-key').val();
-    optionsNew.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
+    const optionsAnkiEnableOld = options.anki.enable;
+    options.anki.enable = $('#anki-enable').prop('checked');
+    options.anki.tags = $('#card-tags').val().split(/[,; ]+/);
+    options.anki.sentenceExt = parseInt($('#sentence-detection-extent').val(), 10);
+    options.anki.server = $('#interface-server').val();
+    options.anki.screenshot.format = $('#screenshot-format').val();
+    options.anki.screenshot.quality = parseInt($('#screenshot-quality').val(), 10);
+    options.anki.fieldTemplates = $('#field-templates').val();
 
-    optionsNew.anki.enable = $('#anki-enable').prop('checked');
-    optionsNew.anki.tags = $('#card-tags').val().split(/[,; ]+/);
-    optionsNew.anki.sentenceExt = parseInt($('#sentence-detection-extent').val(), 10);
-    optionsNew.anki.server = $('#interface-server').val();
-    optionsNew.anki.screenshot.format = $('#screenshot-format').val();
-    optionsNew.anki.screenshot.quality = parseInt($('#screenshot-quality').val(), 10);
-    optionsNew.anki.fieldTemplates = $('#field-templates').val();
-
-    if (optionsOld.anki.enable && !ankiErrorShown()) {
-        optionsNew.anki.terms.deck = $('#anki-terms-deck').val();
-        optionsNew.anki.terms.model = $('#anki-terms-model').val();
-        optionsNew.anki.terms.fields = ankiFieldsToDict($('#terms .anki-field-value'));
-        optionsNew.anki.kanji.deck = $('#anki-kanji-deck').val();
-        optionsNew.anki.kanji.model = $('#anki-kanji-model').val();
-        optionsNew.anki.kanji.fields = ankiFieldsToDict($('#kanji .anki-field-value'));
+    if (optionsAnkiEnableOld && !ankiErrorShown()) {
+        options.anki.terms.deck = $('#anki-terms-deck').val();
+        options.anki.terms.model = $('#anki-terms-model').val();
+        options.anki.terms.fields = ankiFieldsToDict($('#terms .anki-field-value'));
+        options.anki.kanji.deck = $('#anki-kanji-deck').val();
+        options.anki.kanji.model = $('#anki-kanji-model').val();
+        options.anki.kanji.fields = ankiFieldsToDict($('#kanji .anki-field-value'));
     }
 
-    optionsNew.general.mainDictionary = $('#dict-main').val();
+    options.general.mainDictionary = $('#dict-main').val();
     $('.dict-group').each((index, element) => {
         const dictionary = $(element);
-        optionsNew.dictionaries[dictionary.data('title')] = {
+        options.dictionaries[dictionary.data('title')] = {
             priority: parseInt(dictionary.find('.dict-priority').val(), 10),
             enabled: dictionary.find('.dict-enabled').prop('checked'),
             allowSecondarySearches: dictionary.find('.dict-allow-secondary-searches').prop('checked')
         };
     });
-
-    return {optionsNew, optionsOld};
 }
 
 function formUpdateVisibility(options) {
@@ -141,18 +137,22 @@ async function onFormOptionsChanged(e) {
         return;
     }
 
-    const {optionsNew, optionsOld} = await formRead();
-    await optionsSave(optionsNew);
-    formUpdateVisibility(optionsNew);
+    const options = await optionsLoad();
+    const optionsAnkiEnableOld = options.anki.enable;
+    const optionsAnkiServerOld = options.anki.server;
+
+    await formRead(options);
+    await optionsSave(options);
+    formUpdateVisibility(options);
 
     try {
         const ankiUpdated =
-            optionsNew.anki.enable !== optionsOld.anki.enable ||
-            optionsNew.anki.server !== optionsOld.anki.server;
+            options.anki.enable !== optionsAnkiEnableOld ||
+            options.anki.server !== optionsAnkiServerOld;
 
         if (ankiUpdated) {
             ankiSpinnerShow(true);
-            await ankiDeckAndModelPopulate(optionsNew);
+            await ankiDeckAndModelPopulate(options);
             ankiErrorShow();
         }
     } catch (e) {
@@ -566,12 +566,13 @@ async function onAnkiModelChanged(e) {
         const tab = element.closest('.tab-pane');
         const tabId = tab.attr('id');
 
-        const {optionsNew, optionsOld} = await formRead();
-        optionsNew.anki[tabId].fields = {};
-        await optionsSave(optionsNew);
+        const options = await optionsLoad();
+        await formRead(options);
+        options.anki[tabId].fields = {};
+        await optionsSave(options);
 
         ankiSpinnerShow(true);
-        await ankiFieldsPopulate(element, optionsNew);
+        await ankiFieldsPopulate(element, options);
         ankiErrorShow();
     } catch (e) {
         ankiErrorShow(e);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -86,6 +86,71 @@ async function formRead(options) {
     });
 }
 
+async function formWrite(options) {
+    $('#show-usage-guide').prop('checked', options.general.showGuide);
+    $('#compact-tags').prop('checked', options.general.compactTags);
+    $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
+    $('#auto-play-audio').prop('checked', options.general.autoPlayAudio);
+    $('#result-output-mode').val(options.general.resultOutputMode);
+    $('#audio-playback-source').val(options.general.audioSource);
+    $('#audio-playback-volume').val(options.general.audioVolume);
+    $('#show-debug-info').prop('checked', options.general.debugInfo);
+    $('#show-advanced-options').prop('checked', options.general.showAdvanced);
+    $('#max-displayed-results').val(options.general.maxResults);
+    $('#popup-display-mode').val(options.general.popupDisplayMode);
+    $('#popup-horizontal-text-position').val(options.general.popupHorizontalTextPosition);
+    $('#popup-vertical-text-position').val(options.general.popupVerticalTextPosition);
+    $('#popup-width').val(options.general.popupWidth);
+    $('#popup-height').val(options.general.popupHeight);
+    $('#popup-horizontal-offset').val(options.general.popupHorizontalOffset);
+    $('#popup-vertical-offset').val(options.general.popupVerticalOffset);
+    $('#popup-horizontal-offset2').val(options.general.popupHorizontalOffset2);
+    $('#popup-vertical-offset2').val(options.general.popupVerticalOffset2);
+    $('#custom-popup-css').val(options.general.customPopupCss);
+
+    $('#middle-mouse-button-scan').prop('checked', options.scanning.middleMouse);
+    $('#touch-input-enabled').prop('checked', options.scanning.touchInputEnabled);
+    $('#select-matched-text').prop('checked', options.scanning.selectText);
+    $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
+    $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);
+    $('#deep-dom-scan').prop('checked', options.scanning.deepDomScan);
+    $('#enable-scanning-of-popup-expressions').prop('checked', options.scanning.enableOnPopupExpressions);
+    $('#enable-scanning-on-search-page').prop('checked', options.scanning.enableOnSearchPage);
+    $('#scan-delay').val(options.scanning.delay);
+    $('#scan-length').val(options.scanning.length);
+    $('#scan-modifier-key').val(options.scanning.modifier);
+    $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
+
+    $('#dict-purge-link').click(utilAsync(onDictionaryPurge));
+    $('#dict-file').change(utilAsync(onDictionaryImport));
+
+    $('#anki-enable').prop('checked', options.anki.enable);
+    $('#card-tags').val(options.anki.tags.join(' '));
+    $('#sentence-detection-extent').val(options.anki.sentenceExt);
+    $('#interface-server').val(options.anki.server);
+    $('#screenshot-format').val(options.anki.screenshot.format);
+    $('#screenshot-quality').val(options.anki.screenshot.quality);
+    $('#field-templates').val(options.anki.fieldTemplates);
+    $('#field-templates-reset').click(utilAsync(onAnkiFieldTemplatesReset));
+    $('input, select, textarea').not('.anki-model').change(utilAsync(onFormOptionsChanged));
+    $('.anki-model').change(utilAsync(onAnkiModelChanged));
+
+    try {
+        await dictionaryGroupsPopulate(options);
+        await formMainDictionaryOptionsPopulate(options);
+    } catch (e) {
+        dictionaryErrorsShow([e]);
+    }
+
+    try {
+        await ankiDeckAndModelPopulate(options);
+    } catch (e) {
+        ankiErrorShow(e);
+    }
+
+    formUpdateVisibility(options);
+}
+
 function formUpdateVisibility(options) {
     const general = $('#anki-general');
     if (options.anki.enable) {
@@ -172,68 +237,7 @@ async function onReady() {
     const optionsContext = getOptionsContext();
     const options = await apiOptionsGet(optionsContext);
 
-    $('#show-usage-guide').prop('checked', options.general.showGuide);
-    $('#compact-tags').prop('checked', options.general.compactTags);
-    $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
-    $('#auto-play-audio').prop('checked', options.general.autoPlayAudio);
-    $('#result-output-mode').val(options.general.resultOutputMode);
-    $('#audio-playback-source').val(options.general.audioSource);
-    $('#audio-playback-volume').val(options.general.audioVolume);
-    $('#show-debug-info').prop('checked', options.general.debugInfo);
-    $('#show-advanced-options').prop('checked', options.general.showAdvanced);
-    $('#max-displayed-results').val(options.general.maxResults);
-    $('#popup-display-mode').val(options.general.popupDisplayMode);
-    $('#popup-horizontal-text-position').val(options.general.popupHorizontalTextPosition);
-    $('#popup-vertical-text-position').val(options.general.popupVerticalTextPosition);
-    $('#popup-width').val(options.general.popupWidth);
-    $('#popup-height').val(options.general.popupHeight);
-    $('#popup-horizontal-offset').val(options.general.popupHorizontalOffset);
-    $('#popup-vertical-offset').val(options.general.popupVerticalOffset);
-    $('#popup-horizontal-offset2').val(options.general.popupHorizontalOffset2);
-    $('#popup-vertical-offset2').val(options.general.popupVerticalOffset2);
-    $('#custom-popup-css').val(options.general.customPopupCss);
-
-    $('#middle-mouse-button-scan').prop('checked', options.scanning.middleMouse);
-    $('#touch-input-enabled').prop('checked', options.scanning.touchInputEnabled);
-    $('#select-matched-text').prop('checked', options.scanning.selectText);
-    $('#search-alphanumeric').prop('checked', options.scanning.alphanumeric);
-    $('#auto-hide-results').prop('checked', options.scanning.autoHideResults);
-    $('#deep-dom-scan').prop('checked', options.scanning.deepDomScan);
-    $('#enable-scanning-of-popup-expressions').prop('checked', options.scanning.enableOnPopupExpressions);
-    $('#enable-scanning-on-search-page').prop('checked', options.scanning.enableOnSearchPage);
-    $('#scan-delay').val(options.scanning.delay);
-    $('#scan-length').val(options.scanning.length);
-    $('#scan-modifier-key').val(options.scanning.modifier);
-    $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
-
-    $('#dict-purge-link').click(utilAsync(onDictionaryPurge));
-    $('#dict-file').change(utilAsync(onDictionaryImport));
-
-    $('#anki-enable').prop('checked', options.anki.enable);
-    $('#card-tags').val(options.anki.tags.join(' '));
-    $('#sentence-detection-extent').val(options.anki.sentenceExt);
-    $('#interface-server').val(options.anki.server);
-    $('#screenshot-format').val(options.anki.screenshot.format);
-    $('#screenshot-quality').val(options.anki.screenshot.quality);
-    $('#field-templates').val(options.anki.fieldTemplates);
-    $('#field-templates-reset').click(utilAsync(onAnkiFieldTemplatesReset));
-    $('input, select, textarea').not('.anki-model').change(utilAsync(onFormOptionsChanged));
-    $('.anki-model').change(utilAsync(onAnkiModelChanged));
-
-    try {
-        await dictionaryGroupsPopulate(options);
-        await formMainDictionaryOptionsPopulate(options);
-    } catch (e) {
-        dictionaryErrorsShow([e]);
-    }
-
-    try {
-        await ankiDeckAndModelPopulate(options);
-    } catch (e) {
-        ankiErrorShow(e);
-    }
-
-    formUpdateVisibility(options);
+    await formWrite(options);
 
     storageInfoInitialize();
 }

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -121,9 +121,6 @@ async function formWrite(options) {
     $('#scan-modifier-key').val(options.scanning.modifier);
     $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
 
-    $('#dict-purge-link').click(utilAsync(onDictionaryPurge));
-    $('#dict-file').change(utilAsync(onDictionaryImport));
-
     $('#anki-enable').prop('checked', options.anki.enable);
     $('#card-tags').val(options.anki.tags.join(' '));
     $('#sentence-detection-extent').val(options.anki.sentenceExt);
@@ -131,9 +128,6 @@ async function formWrite(options) {
     $('#screenshot-format').val(options.anki.screenshot.format);
     $('#screenshot-quality').val(options.anki.screenshot.quality);
     $('#field-templates').val(options.anki.fieldTemplates);
-    $('#field-templates-reset').click(utilAsync(onAnkiFieldTemplatesReset));
-    $('input, select, textarea').not('.anki-model').change(utilAsync(onFormOptionsChanged));
-    $('.anki-model').change(utilAsync(onAnkiModelChanged));
 
     try {
         await dictionaryGroupsPopulate(options);
@@ -149,6 +143,15 @@ async function formWrite(options) {
     }
 
     formUpdateVisibility(options);
+}
+
+function formSetupEventListeners() {
+    $('#dict-purge-link').click(utilAsync(onDictionaryPurge));
+    $('#dict-file').change(utilAsync(onDictionaryImport));
+
+    $('#field-templates-reset').click(utilAsync(onAnkiFieldTemplatesReset));
+    $('input, select, textarea').not('.anki-model').not('.profile-form *').change(utilAsync(onFormOptionsChanged));
+    $('.anki-model').change(utilAsync(onAnkiModelChanged));
 }
 
 function formUpdateVisibility(options) {
@@ -237,6 +240,7 @@ async function onReady() {
     const optionsContext = getOptionsContext();
     const options = await apiOptionsGet(optionsContext);
 
+    formSetupEventListeners();
     await formWrite(options);
 
     storageInfoInitialize();

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -16,6 +16,11 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+function getOptionsContext() {
+    return {
+        depth: 0
+    };
+}
 
 async function formRead(options) {
     options.general.showGuide = $('#show-usage-guide').prop('checked');
@@ -137,7 +142,8 @@ async function onFormOptionsChanged(e) {
         return;
     }
 
-    const options = await optionsLoad();
+    const optionsContext = getOptionsContext();
+    const options = await apiOptionsGet(optionsContext);
     const optionsAnkiEnableOld = options.anki.enable;
     const optionsAnkiServerOld = options.anki.server;
 
@@ -163,7 +169,8 @@ async function onFormOptionsChanged(e) {
 }
 
 async function onReady() {
-    const options = await optionsLoad();
+    const optionsContext = getOptionsContext();
+    const options = await apiOptionsGet(optionsContext);
 
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
@@ -374,7 +381,8 @@ async function onDictionaryPurge(e) {
         dictionarySpinnerShow(true);
 
         await utilDatabasePurge();
-        const options = await optionsLoad();
+        const optionsContext = getOptionsContext();
+        const options = await apiOptionsGet(optionsContext);
         options.dictionaries = {};
         options.general.mainDictionary = '';
         await optionsSave(options);
@@ -414,8 +422,9 @@ async function onDictionaryImport(e) {
         setProgress(0.0);
 
         const exceptions = [];
-        const options = await optionsLoad();
         const summary = await utilDatabaseImport(e.target.files[0], updateProgress, exceptions);
+        const optionsContext = getOptionsContext();
+        const options = await apiOptionsGet(optionsContext);
         options.dictionaries[summary.title] = {enabled: true, priority: 0, allowSecondarySearches: false};
         if (summary.sequenced && options.general.mainDictionary === '') {
             options.general.mainDictionary = summary.title;
@@ -566,7 +575,8 @@ async function onAnkiModelChanged(e) {
         const tab = element.closest('.tab-pane');
         const tabId = tab.attr('id');
 
-        const options = await optionsLoad();
+        const optionsContext = getOptionsContext();
+        const options = await apiOptionsGet(optionsContext);
         await formRead(options);
         options.anki[tabId].fields = {};
         await optionsSave(options);
@@ -584,8 +594,11 @@ async function onAnkiModelChanged(e) {
 async function onAnkiFieldTemplatesReset(e) {
     try {
         e.preventDefault();
-        const options = await optionsLoad();
-        $('#field-templates').val(options.anki.fieldTemplates = optionsFieldTemplates());
+        const optionsContext = getOptionsContext();
+        const options = await apiOptionsGet(optionsContext);
+        const fieldTemplates = optionsFieldTemplates();
+        options.anki.fieldTemplates = fieldTemplates;
+        $('#field-templates').val(fieldTemplates);
         await optionsSave(options);
     } catch (e) {
         ankiErrorShow(e);

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -23,6 +23,7 @@ function getOptionsContext() {
 }
 
 async function formRead(options) {
+    options.general.enable = $('#enable').prop('checked');
     options.general.showGuide = $('#show-usage-guide').prop('checked');
     options.general.compactTags = $('#compact-tags').prop('checked');
     options.general.compactGlossaries = $('#compact-glossaries').prop('checked');
@@ -87,6 +88,7 @@ async function formRead(options) {
 }
 
 async function formWrite(options) {
+    $('#enable').prop('checked', options.general.enable);
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
     $('#compact-glossaries').prop('checked', options.general.compactGlossaries);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -36,8 +36,7 @@ class Translator {
         }
     }
 
-    async findTermsGrouped(text, dictionaries, alphanumeric) {
-        const options = await apiOptionsGet();
+    async findTermsGrouped(text, dictionaries, alphanumeric, options) {
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);
 
@@ -55,8 +54,7 @@ class Translator {
         return {length, definitions: definitionsGrouped};
     }
 
-    async findTermsMerged(text, dictionaries, alphanumeric) {
-        const options = await apiOptionsGet();
+    async findTermsMerged(text, dictionaries, alphanumeric, options) {
         const secondarySearchTitles = Object.keys(options.dictionaries).filter(dict => options.dictionaries[dict].allowSecondarySearches);
         const titles = Object.keys(dictionaries);
         const {length, definitions} = await this.findTerms(text, dictionaries, alphanumeric);

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -104,3 +104,7 @@ function utilReadFile(file) {
         reader.readAsBinaryString(file);
     });
 }
+
+function utilIsObject(value) {
+    return typeof value === 'object' && value !== null && !Array.isArray(value);
+}

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -222,14 +222,6 @@
                 </div>
 
                 <div class="checkbox options-advanced">
-                    <label><input type="checkbox" id="enable-scanning-of-popup-expressions"> Enable scanning of popup expressions</label>
-                </div>
-
-                <div class="checkbox">
-                    <label><input type="checkbox" id="enable-scanning-on-search-page"> Enable scanning on search page</label>
-                </div>
-
-                <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="deep-dom-scan"> Deep DOM scan</label>
                 </div>
 
@@ -252,9 +244,26 @@
                         <option value="shift">Shift</option>
                     </select>
                 </div>
+            </div>
 
-                <div class="form-group options-advanced">
-                    <label for="popup-nesting-max-depth">Maximum nested popup depth</label>
+            <div id="popup-content-scanning">
+                <h3>Popup Content Scanning Options</h3>
+
+                <p class="help-block">
+                    Yomichan is able to create additional popups in order to scan the content of other popups.
+                    This feature can be enabled if the <strong>Maximum number of additional popups</strong> option is set to a value greater than 0.
+                </p>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="enable-scanning-on-search-page"> Enable scanning on search page</label>
+                </div>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="enable-scanning-of-popup-expressions"> Enable scanning of popup expressions</label>
+                </div>
+
+                <div class="form-group">
+                    <label for="popup-nesting-max-depth">Maximum number of additional popups</label>
                     <input type="number" min="0" id="popup-nesting-max-depth" class="form-control">
                 </div>
             </div>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -71,6 +71,10 @@
                 <h3>General Options</h3>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="enable"> Enable content scanning</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-usage-guide"> Show usage guide on startup</label>
                 </div>
 

--- a/ext/fg/js/api.js
+++ b/ext/fg/js/api.js
@@ -17,24 +17,24 @@
  */
 
 
-function apiOptionsGet() {
-    return utilInvoke('optionsGet');
+function apiOptionsGet(optionsContext) {
+    return utilInvoke('optionsGet', {optionsContext});
 }
 
-function apiTermsFind(text) {
-    return utilInvoke('termsFind', {text});
+function apiTermsFind(text, optionsContext) {
+    return utilInvoke('termsFind', {text, optionsContext});
 }
 
-function apiKanjiFind(text) {
-    return utilInvoke('kanjiFind', {text});
+function apiKanjiFind(text, optionsContext) {
+    return utilInvoke('kanjiFind', {text, optionsContext});
 }
 
-function apiDefinitionAdd(definition, mode, context) {
-    return utilInvoke('definitionAdd', {definition, mode, context});
+function apiDefinitionAdd(definition, mode, context, optionsContext) {
+    return utilInvoke('definitionAdd', {definition, mode, context, optionsContext});
 }
 
-function apiDefinitionsAddable(definitions, modes) {
-    return utilInvoke('definitionsAddable', {definitions, modes}).catch(() => null);
+function apiDefinitionsAddable(definitions, modes, optionsContext) {
+    return utilInvoke('definitionsAddable', {definitions, modes, optionsContext}).catch(() => null);
 }
 
 function apiNoteView(noteId) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -23,6 +23,10 @@ class DisplayFloat extends Display {
         this.autoPlayAudioTimer = null;
         this.styleNode = null;
 
+        this.optionsContext = {
+            depth: 0
+        };
+
         this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
         $(window).on('message', utilAsync(this.onMessage.bind(this)));
@@ -75,6 +79,7 @@ class DisplayFloat extends Display {
             },
 
             popupNestedInitialize: ({id, depth, parentFrameId}) => {
+                this.optionsContext.depth = depth;
                 popupNestedInitialize(id, depth, parentFrameId);
             }
         };

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -261,11 +261,8 @@ class Frontend {
 
     onBgMessage({action, params}, sender, callback) {
         const handlers = {
-            optionsSet: ({options}) => {
-                this.options = options;
-                if (!this.options.enable) {
-                    this.searchClear();
-                }
+            optionsUpdate: () => {
+                this.updateOptions();
             },
 
             popupSetVisible: ({visible}) => {
@@ -282,6 +279,13 @@ class Frontend {
 
     onError(error) {
         console.log(error);
+    }
+
+    async updateOptions() {
+        this.options = await apiOptionsGet();
+        if (!this.options.enable) {
+            this.searchClear();
+        }
     }
 
     popupTimerSet(callback) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -40,9 +40,9 @@ class Frontend {
     static create() {
         const initializationData = window.frontendInitializationData;
         const isNested = (initializationData !== null && typeof initializationData === 'object');
-        const {id, parentFrameId, ignoreNodes} = isNested ? initializationData : {};
+        const {id, depth, parentFrameId, ignoreNodes} = isNested ? initializationData : {};
 
-        const popup = isNested ? new PopupProxy(id, parentFrameId) : PopupProxyHost.instance.createPopup(null);
+        const popup = isNested ? new PopupProxy(depth + 1, id, parentFrameId) : PopupProxyHost.instance.createPopup(null);
         const frontend = new Frontend(popup, ignoreNodes);
         frontend.prepare();
         return frontend;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -28,6 +28,10 @@ class Frontend {
         this.options = null;
         this.ignoreNodes = (Array.isArray(ignoreNodes) && ignoreNodes.length > 0 ? ignoreNodes.join(',') : null);
 
+        this.optionsContext = {
+            depth: popup.depth
+        };
+
         this.primaryTouchIdentifier = null;
         this.contextMenuChecking = false;
         this.contextMenuPrevent = false;
@@ -50,7 +54,7 @@ class Frontend {
 
     async prepare() {
         try {
-            this.options = await apiOptionsGet();
+            this.options = await apiOptionsGet(this.optionsContext);
 
             window.addEventListener('message', this.onFrameMessage.bind(this));
             window.addEventListener('mousedown', this.onMouseDown.bind(this));
@@ -282,7 +286,7 @@ class Frontend {
     }
 
     async updateOptions() {
-        this.options = await apiOptionsGet();
+        this.options = await apiOptionsGet(this.optionsContext);
         if (!this.options.enable) {
             this.searchClear();
         }
@@ -351,7 +355,7 @@ class Frontend {
             return;
         }
 
-        const {definitions, length} = await apiTermsFind(searchText);
+        const {definitions, length} = await apiTermsFind(searchText, this.optionsContext);
         if (definitions.length === 0) {
             return false;
         }
@@ -384,7 +388,7 @@ class Frontend {
             return;
         }
 
-        const definitions = await apiKanjiFind(searchText);
+        const definitions = await apiKanjiFind(searchText, this.optionsContext);
         if (definitions.length === 0) {
             return false;
         }

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -25,7 +25,8 @@ async function popupNestedInitialize(id, depth, parentFrameId) {
     }
     popupNestedInitialized = true;
 
-    const options = await apiOptionsGet();
+    const optionsContext = {depth};
+    const options = await apiOptionsGet(optionsContext);
     const popupNestingMaxDepth = options.scanning.popupNestingMaxDepth;
 
     if (!(typeof popupNestingMaxDepth === 'number' && typeof depth === 'number' && depth < popupNestingMaxDepth)) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -18,14 +18,14 @@
 
 
 class PopupProxy {
-    constructor(parentId, parentFrameId) {
+    constructor(depth, parentId, parentFrameId) {
         this.parentId = parentId;
         this.parentFrameId = parentFrameId;
         this.id = null;
         this.idPromise = null;
         this.parent = null;
         this.child = null;
-        this.depth = 0;
+        this.depth = depth;
 
         this.container = null;
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -27,6 +27,7 @@ class Display {
         this.sequence = 0;
         this.index = 0;
         this.audioCache = {};
+        this.optionsContext = {};
 
         this.dependencies = {};
 
@@ -66,7 +67,7 @@ class Display {
                 context.source.source = this.context.source;
             }
 
-            const kanjiDefs = await apiKanjiFind(link.text());
+            const kanjiDefs = await apiKanjiFind(link.text(), this.optionsContext);
             this.kanjiShow(kanjiDefs, this.options, context);
         } catch (e) {
             this.onError(e);
@@ -89,7 +90,7 @@ class Display {
             try {
                 textSource.setEndOffset(this.options.scanning.length);
 
-                ({definitions, length} = await apiTermsFind(textSource.text()));
+                ({definitions, length} = await apiTermsFind(textSource.text(), this.optionsContext));
                 if (definitions.length === 0) {
                     return false;
                 }
@@ -379,7 +380,7 @@ class Display {
 
     async adderButtonUpdate(modes, sequence) {
         try {
-            const states = await apiDefinitionsAddable(this.definitions, modes);
+            const states = await apiDefinitionsAddable(this.definitions, modes, this.optionsContext);
             if (!states || sequence !== this.sequence) {
                 return;
             }
@@ -453,7 +454,7 @@ class Display {
                 }
             }
 
-            const noteId = await apiDefinitionAdd(definition, mode, context);
+            const noteId = await apiDefinitionAdd(definition, mode, context, this.optionsContext);
             if (noteId) {
                 const index = this.definitions.indexOf(definition);
                 Display.adderButtonFind(index, mode).addClass('disabled');


### PR DESCRIPTION
Follow-up of #204.

The goal of this PR is to work further towards the goal of adding support for settings profiles, a feature that should compliment the addition of recursive popups (#185). I have again decided to submit a group of commits which work towards part of this goal separately in order to have it be more manageable. I do have the remainder of the profiles feature implemented, but just trying to take integration one step at a time.

Same as #204, individual commits tell a better story. Here is a high-level description of the changes:
* backend.js is now the authoritative source for the current options. Other scripts no longer invoke ```optionsLoad``` or ```optionsSave```.
* backend.js now only notifies all other tabs that a settings change has occurred, but does not send the new options value. frontend.js et al. will now subsequently request the updated options after receiving this signal.
* All requests to get options now use a ```optionsContext``` parameter. This parameter will eventually be used to determine which profile to use depending on the context.
* Change some logic of some of the settings form read/write functions such that they can be called repeatedly without adverse side effects.
* Added checkbox for ```options.general.enable``` on the settings page since this option will be on a per-profile basis. This also exposes this option on Firefox mobile; previously the option was unable to be changed since the mobile platform does not have the popup window.
* Settings page now updates in response to options changes from external sources. For the most part, the only external source is the popup window, but technically it is possible to manually open the settings page multiple times. The primary use of this is to support displaying an up-to-date value of the new checkbox for ```options.general.enable```.

Let me know if there's anything I can clarify or if I should break this down further.