### PR TITLE
Add writingMode to PopupProxy* termsShow and kanjiShow

### DIFF
--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -43,8 +43,8 @@ class PopupProxyHost {
             hide: ({id}) => this.hide(id),
             setVisible: ({id, visible}) => this.setVisible(id, visible),
             containsPoint: ({id, point}) => this.containsPoint(id, point),
-            termsShow: ({id, elementRect, definitions, options, context}) => this.termsShow(id, elementRect, definitions, options, context),
-            kanjiShow: ({id, elementRect, definitions, options, context}) => this.kanjiShow(id, elementRect, definitions, options, context),
+            termsShow: ({id, elementRect, writingMode, definitions, options, context}) => this.termsShow(id, elementRect, writingMode, definitions, options, context),
+            kanjiShow: ({id, elementRect, writingMode, definitions, options, context}) => this.kanjiShow(id, elementRect, writingMode, definitions, options, context),
             clearAutoPlayTimer: ({id}) => this.clearAutoPlayTimer(id)
         });
     }
@@ -113,16 +113,16 @@ class PopupProxyHost {
         return await popup.containsPoint(point);
     }
 
-    async termsShow(id, elementRect, definitions, options, context) {
+    async termsShow(id, elementRect, writingMode, definitions, options, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
-        return await popup.termsShow(elementRect, definitions, options, context);
+        return await popup.termsShow(elementRect, writingMode, definitions, options, context);
     }
 
-    async kanjiShow(id, elementRect, definitions, options, context) {
+    async kanjiShow(id, elementRect, writingMode, definitions, options, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
-        return await popup.kanjiShow(elementRect, definitions, options, context);
+        return await popup.kanjiShow(elementRect, writingMode, definitions, options, context);
     }
 
     async clearAutoPlayTimer(id) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -76,16 +76,16 @@ class PopupProxy {
         return await this.invokeHostApi('containsPoint', {id: this.id, point});
     }
 
-    async termsShow(elementRect, definitions, options, context) {
+    async termsShow(elementRect, writingMode, definitions, options, context) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('termsShow', {id, elementRect, definitions, options, context});
+        return await this.invokeHostApi('termsShow', {id, elementRect, writingMode, definitions, options, context});
     }
 
-    async kanjiShow(elementRect, definitions, options, context) {
+    async kanjiShow(elementRect, writingMode, definitions, options, context) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('kanjiShow', {id, elementRect, definitions, options, context});
+        return await this.invokeHostApi('kanjiShow', {id, elementRect, writingMode, definitions, options, context});
     }
 
     async clearAutoPlayTimer() {


### PR DESCRIPTION
writingMode feature was added in parallel to recursive popup feature, so this value didn't work its way in to the PopupProxy* classes.