### PR TITLE
Fix nested popups being shown if parent is hidden

### DIFF
--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -116,18 +116,24 @@ class PopupProxyHost {
     async termsShow(id, elementRect, writingMode, definitions, options, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        if (!PopupProxyHost.popupCanShow(popup)) { return false; }
         return await popup.termsShow(elementRect, writingMode, definitions, options, context);
     }
 
     async kanjiShow(id, elementRect, writingMode, definitions, options, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        if (!PopupProxyHost.popupCanShow(popup)) { return false; }
         return await popup.kanjiShow(elementRect, writingMode, definitions, options, context);
     }
 
     async clearAutoPlayTimer(id) {
         const popup = this.getPopup(id);
         return popup.clearAutoPlayTimer();
+    }
+
+    static popupCanShow(popup) {
+        return popup.parent === null || popup.parent.isVisible();
     }
 }
 


### PR DESCRIPTION
If popups are closed and a scan is still occurring, this would result in an orphaned popup which has hidden parents. This would make the orphan popup hard to close without first showing its ancestor popups.