### PR TITLE
Validate contentWindow before focus

### DIFF
--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -239,9 +239,12 @@ class Popup {
     }
 
     focusParent() {
-        if (this.parent && this.parent.container) {
+        if (this.parent !== null) {
             // Chrome doesn't like focusing iframe without contentWindow.
-            this.parent.container.contentWindow.focus();
+            const contentWindow = this.parent.container.contentWindow;
+            if (contentWindow !== null) {
+                contentWindow.focus();
+            }
         } else {
             // Firefox doesn't like focusing window without first blurring the iframe.
             // this.container.contentWindow.blur() doesn't work on Firefox for some reason.


### PR DESCRIPTION
Simplify the check to see if the popup has a parent, since the ```.container``` field should never be null. Also adds a null check to ```contentWindow```, since I encountered a case where this was null. This null case will not occur with the existing features, but I encountered this issue while testing some ideas for moving the popup out of iframes into the root frame.