### PR TITLE
Frontend cleanup

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -89,7 +89,7 @@ function docImposterCreate(element, isTextarea) {
     return [imposter, container];
 }
 
-function docRangeFromPoint({x, y}, options) {
+function docRangeFromPoint(x, y, options) {
     const elements = document.elementsFromPoint(x, y);
     let imposter = null;
     let imposterContainer = null;

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -89,8 +89,18 @@ function docImposterCreate(element, isTextarea) {
     return [imposter, container];
 }
 
+function docElementsFromPoint(x, y, all) {
+    if (all) {
+        return document.elementsFromPoint(x, y);
+    }
+
+    const e = document.elementFromPoint(x, y);
+    return e !== null ? [e] : [];
+}
+
 function docRangeFromPoint(x, y, options) {
-    const elements = document.elementsFromPoint(x, y);
+    const deepDomScan = options.scanning.deepDomScan;
+    const elements = docElementsFromPoint(x, y, deepDomScan);
     let imposter = null;
     let imposterContainer = null;
     if (elements.length > 0) {
@@ -108,7 +118,7 @@ function docRangeFromPoint(x, y, options) {
         }
     }
 
-    const range = caretRangeFromPointExt(x, y, options.scanning.deepDomScan ? elements : []);
+    const range = caretRangeFromPointExt(x, y, deepDomScan ? elements : []);
     if (range !== null) {
         if (imposter !== null) {
             docSetImposterStyle(imposterContainer.style, 'z-index', '-2147483646');

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -77,7 +77,7 @@ class Frontend {
     }
 
     onMouseOver(e) {
-        if (e.target === this.popup.container && this.popupTimer) {
+        if (e.target === this.popup.container && this.popupTimer !== null) {
             this.popupTimerClear();
         }
     }
@@ -269,12 +269,11 @@ class Frontend {
     }
 
     popupTimerSet(callback) {
-        this.popupTimerClear();
         this.popupTimer = window.setTimeout(callback, this.options.scanning.delay);
     }
 
     popupTimerClear() {
-        if (this.popupTimer) {
+        if (this.popupTimer !== null) {
             window.clearTimeout(this.popupTimer);
             this.popupTimer = null;
         }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -219,8 +219,8 @@ class Frontend {
         }
     }
 
-    onAfterSearch(newRange, type, searched, success) {
-        if (type === 'mouse') {
+    onAfterSearch(newRange, cause, searched, success) {
+        if (cause === 'mouse') {
             return;
         }
 
@@ -230,7 +230,7 @@ class Frontend {
             return;
         }
 
-        if (type === 'touchStart' && newRange !== null) {
+        if (cause === 'touchStart' && newRange !== null) {
             this.scrollPrevent = true;
         }
 
@@ -280,7 +280,7 @@ class Frontend {
         }
     }
 
-    async searchAt(x, y, type) {
+    async searchAt(x, y, cause) {
         if (this.pendingLookup || await this.popup.containsPoint(x, y)) {
             return;
         }
@@ -294,7 +294,7 @@ class Frontend {
             if (!hideResults && (!this.textSourceLast || !this.textSourceLast.equals(textSource))) {
                 searched = true;
                 this.pendingLookup = true;
-                const focus = (type === 'mouse');
+                const focus = (cause === 'mouse');
                 hideResults = !await this.searchTerms(textSource, focus) && !await this.searchKanji(textSource, focus);
                 success = true;
             }
@@ -319,7 +319,7 @@ class Frontend {
             }
 
             this.pendingLookup = false;
-            this.onAfterSearch(this.textSourceLast, type, searched, success);
+            this.onAfterSearch(this.textSourceLast, cause, searched, success);
         }
     }
 
@@ -461,7 +461,7 @@ class Frontend {
         this.clickPrevent = value;
     }
 
-    searchFromTouch(x, y, type) {
+    searchFromTouch(x, y, cause) {
         this.popupTimerClear();
 
         if (!this.options.general.enable || this.pendingLookup) {
@@ -470,7 +470,7 @@ class Frontend {
 
         const search = async () => {
             try {
-                await this.searchAt(x, y, type);
+                await this.searchAt(x, y, cause);
             } catch (e) {
                 this.onError(e);
             }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -126,7 +126,6 @@ class Frontend {
             return false;
         }
 
-        this.mousePosLast = {x: e.clientX, y: e.clientY};
         this.popupTimerClear();
         this.searchClear();
     }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -104,7 +104,7 @@ class Frontend {
 
         const search = async () => {
             try {
-                await this.searchAt({x: e.clientX, y: e.clientY}, 'mouse');
+                await this.searchAt(e.clientX, e.clientY, 'mouse');
             } catch (e) {
                 this.onError(e);
             }
@@ -280,12 +280,12 @@ class Frontend {
         }
     }
 
-    async searchAt(point, type) {
-        if (this.pendingLookup || await this.popup.containsPoint(point)) {
+    async searchAt(x, y, type) {
+        if (this.pendingLookup || await this.popup.containsPoint(x, y)) {
             return;
         }
 
-        const textSource = docRangeFromPoint(point, this.options);
+        const textSource = docRangeFromPoint(x, y, this.options);
         let hideResults = textSource === null;
         let searched = false;
         let success = false;
@@ -470,7 +470,7 @@ class Frontend {
 
         const search = async () => {
             try {
-                await this.searchAt({x, y}, type);
+                await this.searchAt(x, y, type);
             } catch (e) {
                 this.onError(e);
             }

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -42,7 +42,7 @@ class PopupProxyHost {
             showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
             hide: ({id}) => this.hide(id),
             setVisible: ({id, visible}) => this.setVisible(id, visible),
-            containsPoint: ({id, point}) => this.containsPoint(id, point),
+            containsPoint: ({id, x, y}) => this.containsPoint(id, x, y),
             termsShow: ({id, elementRect, writingMode, definitions, options, context}) => this.termsShow(id, elementRect, writingMode, definitions, options, context),
             kanjiShow: ({id, elementRect, writingMode, definitions, options, context}) => this.kanjiShow(id, elementRect, writingMode, definitions, options, context),
             clearAutoPlayTimer: ({id}) => this.clearAutoPlayTimer(id)
@@ -108,9 +108,9 @@ class PopupProxyHost {
         return popup.setVisible(visible);
     }
 
-    async containsPoint(id, point) {
+    async containsPoint(id, x, y) {
         const popup = this.getPopup(id);
-        return await popup.containsPoint(point);
+        return await popup.containsPoint(x, y);
     }
 
     async termsShow(id, elementRect, writingMode, definitions, options, context) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -69,11 +69,11 @@ class PopupProxy {
         return await this.invokeHostApi('setVisible', {id, visible});
     }
 
-    async containsPoint(point) {
+    async containsPoint(x, y) {
         if (this.id === null) {
             return false;
         }
-        return await this.invokeHostApi('containsPoint', {id: this.id, point});
+        return await this.invokeHostApi('containsPoint', {id: this.id, x, y});
     }
 
     async termsShow(elementRect, writingMode, definitions, options, context) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -251,7 +251,7 @@ class Popup {
         }
     }
 
-    async containsPoint({x, y}) {
+    async containsPoint(x, y) {
         for (let popup = this; popup !== null && popup.isVisible(); popup = popup.child) {
             const rect = popup.container.getBoundingClientRect();
             if (x >= rect.left && y >= rect.top && x < rect.right && y < rect.bottom) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -81,7 +81,7 @@ class Display {
             const {docRangeFromPoint, docSentenceExtract} = this.dependencies;
 
             const clickedElement = $(e.target);
-            const textSource = docRangeFromPoint({x: e.clientX, y: e.clientY}, this.options);
+            const textSource = docRangeFromPoint(e.clientX, e.clientY, this.options);
             if (textSource === null) {
                 return false;
             }


### PR DESCRIPTION
* Remove manual tracking of mouse left/middle button states from frontend.js. These states are already publicized via [```MouseEvent.buttons```](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons). This should also prevent against inconsistent state issues caused by ```mouseup```/```mousedown``` events not propagating due to external sources calling ```stopPropagation```.
* Simplified early exit condition logic for ```onMouseMove```.
* Removed ```Frontend.mousePosLast```, which does not seem to be referenced anywhere.
* Remove construction of ```{x, y}``` point object and subsequent destructurings in ```Frontend.searchAt```, ```Popup*.containsPoint```, and ```docRangeFromPoint```.
* Rename ```type``` variable to ```cause```, since it better reflects the purpose. (Values are ```mouse```, ```touchStart```, ```touchMove```; this feature was initially added by me for the touch input support.)
* Use [```document.elementFromPoint```](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/elementFromPoint) (singular) rather than [```document.elementsFromPoint```](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/elementsFromPoint) (array) when only a single element is required. The default settings only require a single element.
* Remove a redundant call to ```popupTimerClear``` in ```popupTimerSet```. Also changes some truthy checks on ```this.popupTimer``` to use explicit ```!== null```, since technically ```!== null``` can be (marginally) faster than a truthy check.

These changes fall under the scope of performance optimizations (#189) since the modified functions are frequently invoked.