### PR TITLE
Isolate options objects created via settings.js

### DIFF
--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -60,7 +60,7 @@ async function formRead(options) {
 
     const optionsAnkiEnableOld = options.anki.enable;
     options.anki.enable = $('#anki-enable').prop('checked');
-    options.anki.tags = $('#card-tags').val().split(/[,; ]+/);
+    options.anki.tags = utilBackgroundIsolate($('#card-tags').val().split(/[,; ]+/));
     options.anki.sentenceExt = parseInt($('#sentence-detection-extent').val(), 10);
     options.anki.server = $('#interface-server').val();
     options.anki.screenshot.format = $('#screenshot-format').val();
@@ -70,20 +70,20 @@ async function formRead(options) {
     if (optionsAnkiEnableOld && !ankiErrorShown()) {
         options.anki.terms.deck = $('#anki-terms-deck').val();
         options.anki.terms.model = $('#anki-terms-model').val();
-        options.anki.terms.fields = ankiFieldsToDict($('#terms .anki-field-value'));
+        options.anki.terms.fields = utilBackgroundIsolate(ankiFieldsToDict($('#terms .anki-field-value')));
         options.anki.kanji.deck = $('#anki-kanji-deck').val();
         options.anki.kanji.model = $('#anki-kanji-model').val();
-        options.anki.kanji.fields = ankiFieldsToDict($('#kanji .anki-field-value'));
+        options.anki.kanji.fields = utilBackgroundIsolate(ankiFieldsToDict($('#kanji .anki-field-value')));
     }
 
     options.general.mainDictionary = $('#dict-main').val();
     $('.dict-group').each((index, element) => {
         const dictionary = $(element);
-        options.dictionaries[dictionary.data('title')] = {
+        options.dictionaries[dictionary.data('title')] = utilBackgroundIsolate({
             priority: parseInt(dictionary.find('.dict-priority').val(), 10),
             enabled: dictionary.find('.dict-enabled').prop('checked'),
             allowSecondarySearches: dictionary.find('.dict-allow-secondary-searches').prop('checked')
-        };
+        });
     });
 }
 
@@ -426,7 +426,7 @@ async function onDictionaryPurge(e) {
         await utilDatabasePurge();
         const optionsContext = getOptionsContext();
         const options = await apiOptionsGet(optionsContext);
-        options.dictionaries = {};
+        options.dictionaries = utilBackgroundIsolate({});
         options.general.mainDictionary = '';
         await settingsSaveOptions();
 
@@ -468,7 +468,11 @@ async function onDictionaryImport(e) {
         const summary = await utilDatabaseImport(e.target.files[0], updateProgress, exceptions);
         const optionsContext = getOptionsContext();
         const options = await apiOptionsGet(optionsContext);
-        options.dictionaries[summary.title] = {enabled: true, priority: 0, allowSecondarySearches: false};
+        options.dictionaries[summary.title] = utilBackgroundIsolate({
+            enabled: true,
+            priority: 0,
+            allowSecondarySearches: false
+        });
         if (summary.sequenced && options.general.mainDictionary === '') {
             options.general.mainDictionary = summary.title;
         }
@@ -621,7 +625,7 @@ async function onAnkiModelChanged(e) {
         const optionsContext = getOptionsContext();
         const options = await apiOptionsGet(optionsContext);
         await formRead(options);
-        options.anki[tabId].fields = {};
+        options.anki[tabId].fields = utilBackgroundIsolate({});
         await settingsSaveOptions();
 
         ankiSpinnerShow(true);

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -26,6 +26,11 @@ function utilIsolate(data) {
     return JSON.parse(JSON.stringify(data));
 }
 
+function utilBackgroundIsolate(data) {
+    const backgroundPage = chrome.extension.getBackgroundPage();
+    return backgroundPage.utilIsolate(data);
+}
+
 function utilSetEqual(setA, setB) {
     if (setA.size !== setB.size) {
         return false;


### PR DESCRIPTION
Prevents dead objects created by different windows. This is primarily an issue in Firefox. The warning produced looked like the following:
<pre><code>TypeError: can't access dead object <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Errors/Dead_object">[Learn More]</a></code></pre>

Edge may have a similar issue which I will have to check at some point (just guessing based on that I had to add [```utilReadFile```](https://github.com/FooSoft/yomichan/pull/188/files#diff-da3eea94ffe40f4c8793b0546dc0e6f4R93-R95) for Edge due to a similar cross-window-source object).

Once this is merged, I will have to make changes to #209 to include calls to ```utilBackgroundIsolate``` also.

---

Another note on what I noticed while debugging: settings.html will still display a dead object error if you have Anki integration enabled, Anki turned off, and quickly refresh the page. The error shows no source file, and seems to be caused by ```AnkiConnect.getDeckNames``` -> ```requestJson```. The error does not seem to be able to be caught, and looks to be harmless. Its presence also predates any of my changes, so thankfully it's not some new issue that I incurred :)