### PR TITLE
Normalize XHTML document node.nodeNode to upper case

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -105,7 +105,7 @@ function docRangeFromPoint(x, y, options) {
     let imposterContainer = null;
     if (elements.length > 0) {
         const element = elements[0];
-        switch (element.nodeName) {
+        switch (element.nodeName.toUpperCase()) {
             case 'IMG':
             case 'BUTTON':
                 return new TextSourceElement(element);

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -88,7 +88,7 @@ class TextSourceRange {
         }
 
         const skip = ['RT', 'SCRIPT', 'STYLE'];
-        if (skip.includes(node.nodeName)) {
+        if (skip.includes(node.nodeName.toUpperCase())) {
             return false;
         }
 
@@ -285,7 +285,7 @@ class TextSourceElement {
     }
 
     setEndOffset(length) {
-        switch (this.element.nodeName) {
+        switch (this.element.nodeName.toUpperCase()) {
             case 'BUTTON':
                 this.content = this.element.innerHTML;
                 break;


### PR DESCRIPTION
Fixes #215; element names were being reported as lower case.