### PR TITLE
Handle null return value of document.caretPositionFromPoint

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -267,6 +267,9 @@ const caretRangeFromPoint = (() => {
         // Firefox
         return (x, y) => {
             const position = document.caretPositionFromPoint(x, y);
+            if (position === null) {
+                return null;
+            }
             const node = position.offsetNode;
             if (node === null) {
                 return null;


### PR DESCRIPTION
This would happen when you use press the middle click button and then move the cursor outside of the window while the button is still held. MDN doesn't document that [caretPositionFromPoint](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint) can return null which is why this case was overlooked.