### PR TITLE
Use a Promise to trigger callback when delay is 0 or less

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -269,7 +269,12 @@ class Frontend {
     }
 
     popupTimerSet(callback) {
-        this.popupTimer = window.setTimeout(callback, this.options.scanning.delay);
+        const delay = this.options.scanning.delay;
+        if (delay > 0) {
+            this.popupTimer = window.setTimeout(callback, delay);
+        } else {
+            Promise.resolve().then(callback);
+        }
     }
 
     popupTimerClear() {


### PR DESCRIPTION
Maybe not necessarily a performance improvement in terms of optimization, this improves the delay time when the **Scan delay** option is set to 0 (or lower).

```Promise.resolve().then(callback)``` will run defer ```callback```, but should still run as part of the same event loop. Timers shouldn't be involved when it comes to scheduling when the callback will run. [Info](https://developer.mozilla.org/en-US/docs/Web/JavaScript/EventLoop#Run-to-completion).

The result is that the average time it takes to run the callback is much faster and more consistent. My testing in both Chrome and Firefox indicated that the ```setTimeout(callback, 0)``` approach generally took from 0-10ms, with the results being highly variable. Using the Promise method, the average time was generally less than 0.1ms. When taking into account the other delays incurred by scanning, savings of ~10ms can potentially result in the popup appearing 1 frame faster on a refresh rate of 60Hz.

 #189