### PR TITLE
Remove jQuery usage from Display.js

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -28,7 +28,8 @@ class DisplaySearch extends Display {
 
         this.search = $('#search').click(this.onSearch.bind(this));
         this.query = $('#query').on('input', this.onSearchInput.bind(this));
-        this.intro = $('#intro');
+        this.intro = document.querySelector('#intro');
+        this.introHidden = false;
 
         this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
@@ -50,12 +51,30 @@ class DisplaySearch extends Display {
     async onSearch(e) {
         try {
             e.preventDefault();
-            this.intro.slideUp();
+            this.hideIntro();
             const {length, definitions} = await apiTermsFind(this.query.val(), this.optionsContext);
             super.termsShow(definitions, await apiOptionsGet(this.optionsContext));
         } catch (e) {
             this.onError(e);
         }
+    }
+
+    hideIntro() {
+        if (this.introHidden) {
+            return;
+        }
+
+        this.introHidden = true;
+
+        if (this.intro === null) {
+            return;
+        }
+
+        const size = this.intro.getBoundingClientRect();
+        this.intro.style.height = `${size.height}px`;
+        this.intro.style.transition = 'height 0.4s ease-in-out 0s';
+        window.getComputedStyle(this.intro).getPropertyValue('height'); // Commits height so next line can start animation
+        this.intro.style.height = '0';
     }
 }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -26,14 +26,20 @@ class DisplaySearch extends Display {
             url: window.location.href
         };
 
-        this.search = $('#search').click(this.onSearch.bind(this));
-        this.query = $('#query').on('input', this.onSearchInput.bind(this));
+        this.search = document.querySelector('#search');
+        this.query = document.querySelector('#query');
         this.intro = document.querySelector('#intro');
         this.introHidden = false;
 
         this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
-        window.wanakana.bind(this.query.get(0));
+        if (this.search !== null) {
+            this.search.addEventListener('click', (e) => this.onSearch(e), false);
+        }
+        if (this.query !== null) {
+            this.query.addEventListener('input', () => this.onSearchInput(), false);
+            window.wanakana.bind(this.query);
+        }
     }
 
     onError(error) {
@@ -41,18 +47,27 @@ class DisplaySearch extends Display {
     }
 
     onSearchClear() {
-        this.query.focus().select();
+        if (this.query === null) {
+            return;
+        }
+
+        this.query.focus();
+        this.query.select();
     }
 
     onSearchInput() {
-        this.search.prop('disabled', this.query.val().length === 0);
+        this.search.disabled = (this.query === null || this.query.value.length === 0);
     }
 
     async onSearch(e) {
+        if (this.query === null) {
+            return;
+        }
+
         try {
             e.preventDefault();
             this.hideIntro();
-            const {length, definitions} = await apiTermsFind(this.query.val(), this.optionsContext);
+            const {length, definitions} = await apiTermsFind(this.query.value, this.optionsContext);
             super.termsShow(definitions, await apiOptionsGet(this.optionsContext));
         } catch (e) {
             this.onError(e);

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -19,7 +19,7 @@
 
 class DisplaySearch extends Display {
     constructor() {
-        super($('#spinner'), $('#content'));
+        super(document.querySelector('#spinner'), document.querySelector('#content'));
 
         this.optionsContext = {
             depth: 0,

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -32,7 +32,6 @@
         </div>
 
         <script src="/mixed/lib/handlebars.min.js"></script>
-        <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/extension.js"></script>

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -10,21 +10,19 @@
     </head>
     <body>
         <div class="container-fluid">
-            <div id="intro">
+            <div id="intro" style="overflow: hidden;">
                 <div class="page-header">
                     <h1>Yomichan Search</h1>
                 </div>
-                <p>Search your installed dictionaries by entering a Japanese expression into the field below.</p>
+                <p style="margin-bottom: 0;">Search your installed dictionaries by entering a Japanese expression into the field below.</p>
             </div>
 
-            <p>
-                <form class="input-group">
-                    <input type="text" class="form-control" placeholder="Search for..." id="query" autofocus>
-                    <span class="input-group-btn">
-                        <input type="submit" class="btn btn-default form-control" id="search" value="Search" disabled>
-                    </span>
-                </form>
-            </p>
+            <form class="input-group" style="padding-top: 10px;">
+                <input type="text" class="form-control" placeholder="Search for..." id="query" autofocus>
+                <span class="input-group-btn">
+                    <input type="submit" class="btn btn-default form-control" id="search" value="Search" disabled>
+                </span>
+            </form>
 
             <div id="spinner">
                 <img src="/mixed/img/spinner.gif">

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -47,6 +47,7 @@
         <script src="/fg/js/source.js"></script>
         <script src="/mixed/js/display.js"></script>
         <script src="/mixed/js/japanese.js"></script>
+        <script src="/mixed/js/scroll.js"></script>
 
         <script src="/bg/js/search.js"></script>
         <script src="/bg/js/search-frontend.js"></script>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -41,6 +41,7 @@
         <script src="/fg/js/document.js"></script>
         <script src="/fg/js/source.js"></script>
         <script src="/mixed/js/display.js"></script>
+        <script src="/mixed/js/scroll.js"></script>
 
         <script src="/fg/js/float.js"></script>
 

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -31,7 +31,6 @@
             </div>
         </div>
 
-        <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/extension.js"></script>

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -19,7 +19,7 @@
 
 class DisplayFloat extends Display {
     constructor() {
-        super($('#spinner'), $('#definitions'));
+        super(document.querySelector('#spinner'), document.querySelector('#definitions'));
         this.autoPlayAudioTimer = null;
         this.styleNode = null;
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -30,7 +30,7 @@ class DisplayFloat extends Display {
 
         this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
 
-        $(window).on('message', utilAsync(this.onMessage.bind(this)));
+        window.addEventListener('message', (e) => this.onMessage(e), false);
     }
 
     onError(error) {
@@ -42,8 +42,16 @@ class DisplayFloat extends Display {
     }
 
     onOrphaned() {
-        $('#definitions').hide();
-        $('#error-orphaned').show();
+        const definitions = document.querySelector('#definitions');
+        const errorOrphaned = document.querySelector('#error-orphaned');
+
+        if (definitions !== null) {
+            definitions.style.setProperty('display', 'none', 'important');
+        }
+
+        if (errorOrphaned !== null) {
+            errorOrphaned.style.setProperty('display', 'block', 'important');
+        }
     }
 
     onSearchClear() {
@@ -86,7 +94,7 @@ class DisplayFloat extends Display {
             }
         };
 
-        const {action, params} = e.originalEvent.data;
+        const {action, params} = e.data;
         const handler = handlers[action];
         if (handler) {
             handler(params);

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -230,3 +230,7 @@ div.glossary-item.compact-glossary {
 .info-output td {
     text-align: right;
 }
+
+.entry:not(.entry-current) .current {
+    display: none;
+}

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -310,7 +310,7 @@ class Display {
             }
 
             const content = await apiTemplateRender('terms.html', params);
-            this.container.html(content);
+            this.container.innerHTML = content;
             const {index, scroll} = context || {};
             this.entryScrollIntoView(index || 0, scroll);
 
@@ -362,7 +362,7 @@ class Display {
             }
 
             const content = await apiTemplateRender('kanji.html', params);
-            this.container.html(content);
+            this.container.innerHTML = content;
             const {index, scroll} = context || {};
             this.entryScrollIntoView(index || 0, scroll);
 
@@ -446,7 +446,7 @@ class Display {
 
     async noteAdd(definition, mode) {
         try {
-            this.spinner.show();
+            this.setSpinnerVisible(true);
 
             const context = {};
             if (this.noteUsesScreenshot()) {
@@ -467,13 +467,13 @@ class Display {
         } catch (e) {
             this.onError(e);
         } finally {
-            this.spinner.hide();
+            this.setSpinnerVisible(false);
         }
     }
 
     async audioPlay(definition, expressionIndex) {
         try {
-            this.spinner.show();
+            this.setSpinnerVisible(true);
 
             const expression = expressionIndex === -1 ? definition : definition.expressions[expressionIndex];
             let url = await apiAudioGetUrl(expression, this.options.general.audioSource);
@@ -505,7 +505,7 @@ class Display {
         } catch (e) {
             this.onError(e);
         } finally {
-            this.spinner.hide();
+            this.setSpinnerVisible(false);
         }
     }
 
@@ -542,6 +542,10 @@ class Display {
         return apiForward('popupSetVisible', {visible});
     }
 
+    setSpinnerVisible(visible) {
+        this.spinner.style.display = visible ? 'block' : '';
+    }
+
     static clozeBuild(sentence, source) {
         const result = {
             sentence: sentence.text.trim()
@@ -558,7 +562,7 @@ class Display {
 
     entryIndexFind(element) {
         const entry = element.closest('.entry');
-        return entry !== null ? Display.indexOf(this.container.get(0).querySelectorAll('.entry'), entry) : -1;
+        return entry !== null ? Display.indexOf(this.container.querySelectorAll('.entry'), entry) : -1;
     }
 
     static adderButtonFind(index, mode) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -412,16 +412,23 @@ class Display {
         index = Math.min(index, this.definitions.length - 1);
         index = Math.max(index, 0);
 
-        $('.current').hide().eq(index).show();
+        const entryPre = this.getEntry(this.index);
+        if (entryPre !== null) {
+            entryPre.classList.remove('entry-current');
+        }
+
+        const entry = this.getEntry(index);
+        if (entry !== null) {
+            entry.classList.add('entry-current');
+        }
 
         this.windowScroll.stop();
-        const entry = $('.entry').eq(index);
         let target;
 
         if (scroll) {
             target = scroll;
         } else {
-            target = index === 0 ? 0 : entry.offset().top;
+            target = index === 0 || entry === null ? 0 : Display.getElementTop(entry);
         }
 
         if (smooth) {
@@ -605,5 +612,11 @@ class Display {
 
     addEventListeners(selector, ...args) {
         this.container.querySelectorAll(selector).forEach((node) => node.addEventListener(...args));
+    }
+
+    static getElementTop(element) {
+        const elementRect = element.getBoundingClientRect();
+        const documentRect = document.documentElement.getBoundingClientRect();
+        return elementRect.top - documentRect.top;
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -31,6 +31,8 @@ class Display {
 
         this.dependencies = {};
 
+        this.windowScroll = new WindowScroll();
+
         document.addEventListener('keydown', this.onKeyDown.bind(this));
         document.addEventListener('wheel', this.onWheel.bind(this), {passive: false});
     }
@@ -53,11 +55,12 @@ class Display {
             e.preventDefault();
 
             const link = e.target;
+            this.windowScroll.toY(0);
             const context = {
                 source: {
                     definitions: this.definitions,
                     index: this.entryIndexFind(link),
-                    scroll: $('html,body').scrollTop()
+                    scroll: this.windowScroll.y
                 }
             };
 
@@ -102,11 +105,12 @@ class Display {
                 textSource.cleanup();
             }
 
+            this.windowScroll.toY(0);
             const context = {
                 source: {
                     definitions: this.definitions,
                     index: this.entryIndexFind(clickedElement),
-                    scroll: $('html,body').scrollTop()
+                    scroll: this.windowScroll.y
                 }
             };
 
@@ -410,7 +414,7 @@ class Display {
 
         $('.current').hide().eq(index).show();
 
-        const container = $('html,body').stop();
+        this.windowScroll.stop();
         const entry = $('.entry').eq(index);
         let target;
 
@@ -421,9 +425,9 @@ class Display {
         }
 
         if (smooth) {
-            container.animate({scrollTop: target}, 200);
+            this.windowScroll.animate(this.windowScroll.x, target, 200);
         } else {
-            container.scrollTop(target);
+            this.windowScroll.toY(target);
         }
 
         this.index = index;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -52,11 +52,11 @@ class Display {
         try {
             e.preventDefault();
 
-            const link = $(e.target);
+            const link = e.target;
             const context = {
                 source: {
                     definitions: this.definitions,
-                    index: Display.entryIndexFind(link),
+                    index: this.entryIndexFind(link),
                     scroll: $('html,body').scrollTop()
                 }
             };
@@ -67,7 +67,7 @@ class Display {
                 context.source.source = this.context.source;
             }
 
-            const kanjiDefs = await apiKanjiFind(link.text(), this.optionsContext);
+            const kanjiDefs = await apiKanjiFind(link.textContent, this.optionsContext);
             this.kanjiShow(kanjiDefs, this.options, context);
         } catch (e) {
             this.onError(e);
@@ -80,7 +80,7 @@ class Display {
 
             const {docRangeFromPoint, docSentenceExtract} = this.dependencies;
 
-            const clickedElement = $(e.target);
+            const clickedElement = e.target;
             const textSource = docRangeFromPoint(e.clientX, e.clientY, this.options);
             if (textSource === null) {
                 return false;
@@ -105,7 +105,7 @@ class Display {
             const context = {
                 source: {
                     definitions: this.definitions,
-                    index: Display.entryIndexFind(clickedElement),
+                    index: this.entryIndexFind(clickedElement),
                     scroll: $('html,body').scrollTop()
                 }
             };
@@ -124,24 +124,24 @@ class Display {
 
     onAudioPlay(e) {
         e.preventDefault();
-        const link = $(e.currentTarget);
-        const definitionIndex = Display.entryIndexFind(link);
-        const expressionIndex = link.closest('.entry').find('.expression .action-play-audio').index(link);
+        const link = e.currentTarget;
+        const entry = link.closest('.entry');
+        const definitionIndex = this.entryIndexFind(entry);
+        const expressionIndex = Display.indexOf(entry.querySelectorAll('.expression .action-play-audio'), link);
         this.audioPlay(this.definitions[definitionIndex], expressionIndex);
     }
 
     onNoteAdd(e) {
         e.preventDefault();
-        const link = $(e.currentTarget);
-        const index = Display.entryIndexFind(link);
-        this.noteAdd(this.definitions[index], link.data('mode'));
+        const link = e.currentTarget;
+        const index = this.entryIndexFind(link);
+        this.noteAdd(this.definitions[index], link.dataset.mode);
     }
 
     onNoteView(e) {
         e.preventDefault();
-        const link = $(e.currentTarget);
-        const index = Display.entryIndexFind(link);
-        apiNoteView(link.data('noteId'));
+        const link = e.currentTarget;
+        apiNoteView(link.dataset.noteId);
     }
 
     onKeyDown(e) {
@@ -556,8 +556,9 @@ class Display {
         return result;
     }
 
-    static entryIndexFind(element) {
-        return $('.entry').index(element.closest('.entry'));
+    entryIndexFind(element) {
+        const entry = element.closest('.entry');
+        return entry !== null ? Display.indexOf(this.container.get(0).querySelectorAll('.entry'), entry) : -1;
     }
 
     static adderButtonFind(index, mode) {
@@ -570,5 +571,14 @@ class Display {
 
     static delay(time) {
         return new Promise((resolve) => setTimeout(resolve, time));
+    }
+
+    static indexOf(nodeList, node) {
+        for (let i = 0, ii = nodeList.length; i < ii; ++i) {
+            if (nodeList[i] === node) {
+                return i;
+            }
+        }
+        return -1;
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -31,8 +31,8 @@ class Display {
 
         this.dependencies = {};
 
-        $(document).keydown(this.onKeyDown.bind(this));
-        $(document).on('wheel', this.onWheel.bind(this));
+        document.addEventListener('keydown', this.onKeyDown.bind(this));
+        document.addEventListener('wheel', this.onWheel.bind(this), {passive: false});
     }
 
     onError(error) {
@@ -259,13 +259,12 @@ class Display {
     }
 
     onWheel(e) {
-        const event = e.originalEvent;
         const handler = () => {
-            if (event.altKey) {
-                if (event.deltaY < 0) { // scroll up
+            if (e.altKey) {
+                if (e.deltaY < 0) { // scroll up
                     this.entryScrollIntoView(this.index - 1, null, true);
                     return true;
-                } else if (event.deltaY > 0) { // scroll down
+                } else if (e.deltaY > 0) { // scroll down
                     this.entryScrollIntoView(this.index + 1, null, true);
                     return true;
                 }
@@ -273,7 +272,7 @@ class Display {
         };
 
         if (handler()) {
-            event.preventDefault();
+            e.preventDefault();
         }
     }
 
@@ -318,13 +317,13 @@ class Display {
                 this.autoPlayAudio();
             }
 
-            $('.action-add-note').click(this.onNoteAdd.bind(this));
-            $('.action-view-note').click(this.onNoteView.bind(this));
-            $('.action-play-audio').click(this.onAudioPlay.bind(this));
-            $('.kanji-link').click(this.onKanjiLookup.bind(this));
-            $('.source-term').click(this.onSourceTermView.bind(this));
+            this.addEventListeners('.action-add-note', 'click', this.onNoteAdd.bind(this));
+            this.addEventListeners('.action-view-note', 'click', this.onNoteView.bind(this));
+            this.addEventListeners('.action-play-audio', 'click', this.onAudioPlay.bind(this));
+            this.addEventListeners('.kanji-link', 'click', this.onKanjiLookup.bind(this));
+            this.addEventListeners('.source-term', 'click', this.onSourceTermView.bind(this));
             if (this.options.scanning.enablePopupSearch) {
-                $('.glossary-item').click(this.onTermLookup.bind(this));
+                this.addEventListeners('.glossary-item', 'click', this.onTermLookup.bind(this));
             }
 
             await this.adderButtonUpdate(['term-kanji', 'term-kana'], sequence);
@@ -366,9 +365,9 @@ class Display {
             const {index, scroll} = context || {};
             this.entryScrollIntoView(index || 0, scroll);
 
-            $('.action-add-note').click(this.onNoteAdd.bind(this));
-            $('.action-view-note').click(this.onNoteView.bind(this));
-            $('.source-term').click(this.onSourceTermView.bind(this));
+            this.addEventListeners('.action-add-note', 'click', this.onNoteAdd.bind(this));
+            this.addEventListeners('.action-view-note', 'click', this.onNoteView.bind(this));
+            this.addEventListeners('.source-term', 'click', this.onSourceTermView.bind(this));
 
             await this.adderButtonUpdate(['kanji'], sequence);
         } catch (e) {
@@ -584,5 +583,9 @@ class Display {
             }
         }
         return -1;
+    }
+
+    addEventListeners(selector, ...args) {
+        this.container.querySelectorAll(selector).forEach((node) => node.addEventListener(...args));
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -28,6 +28,7 @@ class Display {
         this.index = 0;
         this.audioCache = {};
         this.optionsContext = {};
+        this.eventListeners = [];
 
         this.dependencies = {};
 
@@ -283,6 +284,8 @@ class Display {
 
     async termsShow(definitions, options, context) {
         try {
+            this.clearEventListeners();
+
             if (!context || context.focus !== false) {
                 window.focus();
             }
@@ -339,6 +342,8 @@ class Display {
 
     async kanjiShow(definitions, options, context) {
         try {
+            this.clearEventListeners();
+
             if (!context || context.focus !== false) {
                 window.focus();
             }
@@ -610,8 +615,18 @@ class Display {
         return -1;
     }
 
-    addEventListeners(selector, ...args) {
-        this.container.querySelectorAll(selector).forEach((node) => node.addEventListener(...args));
+    addEventListeners(selector, type, listener, options) {
+        this.container.querySelectorAll(selector).forEach((node) => {
+            node.addEventListener(type, listener, options);
+            this.eventListeners.push([node, type, listener, options]);
+        });
+    }
+
+    clearEventListeners() {
+        for (const [node, type, listener, options] of this.eventListeners) {
+            node.removeEventListener(type, listener, options);
+        }
+        this.eventListeners = [];
     }
 
     static getElementTop(element) {

--- a/ext/mixed/js/scroll.js
+++ b/ext/mixed/js/scroll.js
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class WindowScroll {
+    constructor() {
+        this.animationRequestId = null;
+        this.animationStartTime = 0;
+        this.animationStartX = 0;
+        this.animationStartY = 0;
+        this.animationEndTime = 0;
+        this.animationEndX = 0;
+        this.animationEndY = 0;
+        this.requestAnimationFrameCallback = (t) => this.onAnimationFrame(t);
+    }
+
+    toY(y) {
+        this.to(this.x, y);
+    }
+
+    toX(x) {
+        this.to(x, this.y);
+    }
+
+    to(x, y) {
+        this.stop();
+        window.scroll(x, y);
+    }
+
+    animate(x, y, time) {
+        this.animationStartX = this.x;
+        this.animationStartY = this.y;
+        this.animationStartTime = window.performance.now();
+        this.animationEndX = x;
+        this.animationEndY = y;
+        this.animationEndTime = this.animationStartTime + time;
+        this.animationRequestId = window.requestAnimationFrame(this.requestAnimationFrameCallback);
+    }
+
+    stop() {
+        if (this.animationRequestId === null) {
+            return;
+        }
+
+        window.cancelAnimationFrame(this.animationRequestId);
+        this.animationRequestId = null;
+    }
+
+    onAnimationFrame(time) {
+        if (time >= this.animationEndTime) {
+            window.scroll(this.animationEndX, this.animationEndY);
+            this.animationRequestId = null;
+            return;
+        }
+
+        const t = WindowScroll.easeInOutCubic((time - this.animationStartTime) / (this.animationEndTime - this.animationStartTime));
+        window.scroll(
+            WindowScroll.lerp(this.animationStartX, this.animationEndX, t),
+            WindowScroll.lerp(this.animationStartY, this.animationEndY, t)
+        );
+
+        this.animationRequestId = window.requestAnimationFrame(this.requestAnimationFrameCallback);
+    }
+
+    get x() {
+        return window.scrollX || window.pageXOffset;
+    }
+
+    get y() {
+        return window.scrollY || window.pageYOffset;
+    }
+
+    static easeInOutCubic(t) {
+        if (t < 0.5) {
+            return (4.0 * t * t * t);
+        } else {
+            t = 1.0 - t;
+            return 1.0 - (4.0 * t * t * t);
+        }
+    }
+
+    static lerp(start, end, percent) {
+        return (end - start) * percent + start;
+    }
+}


### PR DESCRIPTION
There are many places in the ```Display``` class and its subclasses where jQuery is used, but it doesn't (IMO) provide much benefit over native Javascript APIs. The goal of this change is to remove the need to have jQuery loaded in each popup, which would reduce load times and memory footprint. The only thing that didn't really have a counterpart with native Javascript APIs was the smooth scrolling animation, but that is simple enough to recreate (IMO).

Note that I do not think there would be any benefit to try and remove the jQuery dependency from the settings page, as that page actually takes greater advantage of jQuery's features.

This change falls under the purview of #189. Let me know if any of the changes are disagreeable.

---

High level changes:
* Event listeners like ```$(node).on('event', callback)``` has been changed to ```node.addEventListener('event', callback, false)```. jQuery does a lot of extra tracking and wrapping when setting up event callbacks which is largely not used, so eliding this will save some instructions.
* Use direct references to DOM nodes rather than ```$(node)```.
* ```$(node).data('name')``` replaced with ```node.dataset.name```.
* ```$(node).hasClass/addClass/removeClass``` replaced with ```node.classList.contains/add/remove```.


Improvements:
* The slide-up animation on the search page had some issues with jQuery's implementation. Some tweaks to the HTML makes it such that a native CSS transition can be used to accomplish the same animation without any resize jitter.
* ```Display.entryIndexFind``` changed into a non-static. Now does a local search for entries (using ```container.querySelectorAll```), rather than searching in the full DOM (```document.querySelectorAll```). This could be further improved by caching the returned ```NodeList```, but it wasn't a big deal for now.
* ```wheel``` event is now specified to be ```passive:false``` since Chrome's default changed to ```passive:true```. See: [browser compatibility](https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Browser_compatibility).
* Current entry now has the ```current-entry``` CSS class applied to it, which also controls visibility of the yellow ✱ indicator. This also provides the ability to use custom popup CSS to apply styles to just the current entry.
* Event listeners now explicitly removed when regenerating HTML. There previously may have been a memory leak here, but it's a bit hard to determine whether the event callbacks were garbage collected or not.


Re-implemented functionality:
* Implemented custom smooth scrolling animation when using Alt+Arrows/Page*/Home/End keys. This was relying on jQuery's ```node.animate({scrollTop: target}, time)``` functionality. This new functionality was built into a new class for API simplicity and reusability.