### PR TITLE
Fix tab focus being changed due to settings changes

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -128,7 +128,7 @@ class Frontend {
         }
 
         this.popupTimerClear();
-        this.searchClear();
+        this.searchClear(true);
     }
 
     onMouseOut(e) {
@@ -138,7 +138,7 @@ class Frontend {
     onFrameMessage(e) {
         const handlers = {
             popupClose: () => {
-                this.searchClear();
+                this.searchClear(true);
             },
 
             selectionCopy: () => {
@@ -153,7 +153,7 @@ class Frontend {
     }
 
     onResize() {
-        this.searchClear();
+        this.searchClear(true);
     }
 
     onClick(e) {
@@ -265,7 +265,7 @@ class Frontend {
     async updateOptions() {
         this.options = await apiOptionsGet(this.getOptionsContext());
         if (!this.options.enable) {
-            this.searchClear();
+            this.searchClear(false);
         }
     }
 
@@ -320,7 +320,7 @@ class Frontend {
                 textSource.cleanup();
             }
             if (hideResults && this.options.scanning.autoHideResults) {
-                this.searchClear();
+                this.searchClear(true);
             }
 
             this.pendingLookup = false;
@@ -392,8 +392,8 @@ class Frontend {
         return true;
     }
 
-    searchClear() {
-        this.popup.hide();
+    searchClear(changeFocus) {
+        this.popup.hide(changeFocus);
         this.popup.clearAutoPlayTimer();
 
         if (this.options.scanning.selectText && this.textSourceLast) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -40,7 +40,7 @@ class PopupProxyHost {
             createNestedPopup: ({parentId}) => this.createNestedPopup(parentId),
             show: ({id, elementRect, options}) => this.show(id, elementRect, options),
             showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
-            hide: ({id}) => this.hide(id),
+            hide: ({id, changeFocus}) => this.hide(id, changeFocus),
             setVisible: ({id, visible}) => this.setVisible(id, visible),
             containsPoint: ({id, x, y}) => this.containsPoint(id, x, y),
             termsShow: ({id, elementRect, writingMode, definitions, options, context}) => this.termsShow(id, elementRect, writingMode, definitions, options, context),
@@ -98,9 +98,9 @@ class PopupProxyHost {
         return await popup.showOrphaned(elementRect, options);
     }
 
-    async hide(id) {
+    async hide(id, changeFocus) {
         const popup = this.getPopup(id);
-        return popup.hide();
+        return popup.hide(changeFocus);
     }
 
     async setVisible(id, visible) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -58,11 +58,11 @@ class PopupProxy {
         return await this.invokeHostApi('showOrphaned', {id, elementRect, options});
     }
 
-    async hide() {
+    async hide(changeFocus) {
         if (this.id === null) {
             return;
         }
-        return await this.invokeHostApi('hide', {id: this.id});
+        return await this.invokeHostApi('hide', {id: this.id, changeFocus});
     }
 
     async setVisible(visible) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -105,7 +105,7 @@ class Popup {
         container.style.height = `${height}px`;
         container.style.visibility = 'visible';
 
-        this.hideChildren();
+        this.hideChildren(true);
     }
 
     static getPositionForHorizontalText(elementRect, width, height, maxWidth, maxHeight, optionsGeneral) {
@@ -206,16 +206,21 @@ class Popup {
         this.invokeApi('orphaned');
     }
 
-    hide() {
-        this.hideChildren();
+    hide(changeFocus) {
+        if (this.isContainerHidden()) {
+            changeFocus = false;
+        }
+        this.hideChildren(changeFocus);
         this.hideContainer();
-        this.focusParent();
+        if (changeFocus) {
+            this.focusParent();
+        }
     }
 
-    hideChildren() {
-        // recursively hides all children
-        if (this.child && !this.child.isContainerHidden()) {
-            this.child.hide();
+    hideChildren(changeFocus) {
+        // Recursively hides all children.
+        if (this.child !== null && !this.child.isContainerHidden()) {
+            this.child.hide(changeFocus);
         }
     }
 


### PR DESCRIPTION
Fixes #227. This seems like a bug in Chrome, since I don't think scripts should be able to force browser tab focus to change, unless web extensions are privileged enough to do that.