### PR TITLE
Database optimizations

### DIFF
--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -68,18 +68,7 @@ class Database {
         const results = [];
         await this.db.terms.where('expression').equals(term).or('reading').equals(term).each(row => {
             if (titles.includes(row.dictionary)) {
-                results.push({
-                    expression: row.expression,
-                    reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
-                    termTags: dictFieldSplit(row.termTags || ''),
-                    rules: dictFieldSplit(row.rules),
-                    glossary: row.glossary,
-                    score: row.score,
-                    dictionary: row.dictionary,
-                    id: row.id,
-                    sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
-                });
+                results.push(Database.createTerm(row));
             }
         });
 
@@ -94,18 +83,7 @@ class Database {
         const results = [];
         await this.db.terms.where('expression').equals(term).each(row => {
             if (row.reading === reading && titles.includes(row.dictionary)) {
-                results.push({
-                    expression: row.expression,
-                    reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
-                    termTags: dictFieldSplit(row.termTags || ''),
-                    rules: dictFieldSplit(row.rules),
-                    glossary: row.glossary,
-                    score: row.score,
-                    dictionary: row.dictionary,
-                    id: row.id,
-                    sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
-                });
+                results.push(Database.createTerm(row));
             }
         });
 
@@ -120,18 +98,7 @@ class Database {
         const results = [];
         await this.db.terms.where('sequence').equals(sequence).each(row => {
             if (row.dictionary === mainDictionary) {
-                results.push({
-                    expression: row.expression,
-                    reading: row.reading,
-                    definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
-                    termTags: dictFieldSplit(row.termTags || ''),
-                    rules: dictFieldSplit(row.rules),
-                    glossary: row.glossary,
-                    score: row.score,
-                    dictionary: row.dictionary,
-                    id: row.id,
-                    sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
-                });
+                results.push(Database.createTerm(row));
             }
         });
 
@@ -488,5 +455,20 @@ class Database {
         await loadBank(summary, buildTagBankName, tagBankCount, tagDataLoaded);
 
         return summary;
+    }
+
+    static createTerm(row) {
+        return {
+            expression: row.expression,
+            reading: row.reading,
+            definitionTags: dictFieldSplit(row.definitionTags || row.tags || ''),
+            termTags: dictFieldSplit(row.termTags || ''),
+            rules: dictFieldSplit(row.rules),
+            glossary: row.glossary,
+            score: row.score,
+            dictionary: row.dictionary,
+            id: row.id,
+            sequence: typeof row.sequence === 'undefined' ? -1 : row.sequence
+        };
     }
 }

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -166,23 +166,30 @@ class Database {
         return results;
     }
 
+    findTagForTitleCached(name, title) {
+        if (this.tagCache.hasOwnProperty(title)) {
+            const cache = this.tagCache[title];
+            if (cache.hasOwnProperty(name)) {
+                return cache[name];
+            }
+        }
+    }
+
     async findTagForTitle(name, title) {
         if (!this.db) {
             throw 'Database not initialized';
         }
 
-        this.tagCache[title] = this.tagCache[title] || {};
+        const cache = (this.tagCache.hasOwnProperty(title) ? this.tagCache[title] : (this.tagCache[title] = {}));
 
-        let result = this.tagCache[title][name];
-        if (!result) {
-            await this.db.tagMeta.where('name').equals(name).each(row => {
-                if (title === row.dictionary) {
-                    result = row;
-                }
-            });
+        let result = null;
+        await this.db.tagMeta.where('name').equals(name).each(row => {
+            if (title === row.dictionary) {
+                result = row;
+            }
+        });
 
-            this.tagCache[title][name] = result;
-        }
+        cache[name] = result;
 
         return result;
     }


### PR DESCRIPTION
This change adds support for bulk database lookups and a few other smaller optimizations. A majority of the work came from restructuring some of the code to support bulk lookups, so the changes are listed below.

**Database changes:**
* In database.js, two new bulk functions were added: ```findTermsBulk``` and ```findTermMetaBulk```. These correspond to the old ```findTerms``` and ```findTermMeta```, the difference being that they take an array of terms instead of a single term.
* In order to get the maximum performance, the database lookups are implemented using native IndexedDB API calls. I found that this gave increased performance over Dexie in all browsers, particularly Edge. Edge has some sort of issue with Dexie where ```db.table.getAll()``` will hang before resolving the promise; updating Dexie did not fix that issue.

**Deinflector changes:**
* The way that the deinflector was implemented was not not suitable for bulk database lookups. The reason was that the deinflector runs the database lookups _as_ it was finding deinflections, rather than saving them all and returning them at the end. The API was changed to return an array of all deinflections.
* The Deinflection class is no longer needed. The list of deinflections can be returned using a single function without recursion, which should be overall faster.

**Translator changes:**
* translator.js had some changes to accommodate the new database bulk functions and deinflection changes.
* Fewer redundant lookups should be performed for deinflections. I think this is not an extremely common case though. As a contrived example: ```すル``` would previously look up ```すル, する, す, す```, where す would be looked up twice.
* A few other changes to make sure that any repeated terms would not be looked up more than once in the database. This primarily involved creating some unique sets and mappings to the original arrays in ```buildTermFrequencies```.


**Results:**
* In Firefox, the speeds I tested were about 2x faster. I tested this by building two versions of the addon, one with the current source and one with this new change, and ran them at the same time on the same words.
* I saw similar results in Chrome while testing each individually.
* In Edge, the scan times went from 1000ms+ to about 200ms, which made it tolerably usable. It could potentially fare a bit better on a full powered device also.

If there is interest in testing these timings, I have two branches which output timing information:
* [database-optimizations-timing-old](https://github.com/toasted-nutbread/yomichan/tree/database-optimizations-timing-old)
* [database-optimizations-timing-new](https://github.com/toasted-nutbread/yomichan/tree/database-optimizations-timing-new)

---

Let me know if there's anything I can clarify or test. I know the deinflector was modified pretty significantly in order to accomplish the bulk database actions; I did test it quite a bit and it seemed to function the same, but it's possible I could have overlooked something.

#189