### PR TITLE
Static handlers

### DIFF
--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -126,35 +126,35 @@ async function apiTemplateRender(template, data, dynamic) {
 }
 
 async function apiCommandExec(command) {
-    const handlers = {
-        search: () => {
-            chrome.tabs.create({url: chrome.extension.getURL('/bg/search.html')});
-        },
-
-        help: () => {
-            chrome.tabs.create({url: 'https://foosoft.net/projects/yomichan/'});
-        },
-
-        options: () => {
-            chrome.runtime.openOptionsPage();
-        },
-
-        toggle: async () => {
-            const optionsContext = {
-                depth: 0,
-                url: window.location.href
-            };
-            const options = await apiOptionsGet(optionsContext);
-            options.general.enable = !options.general.enable;
-            await apiOptionsSave('popup');
-        }
-    };
-
-    const handler = handlers[command];
-    if (handler) {
+    const handlers = apiCommandExec.handlers;
+    if (handlers.hasOwnProperty(command)) {
+        const handler = handlers[command];
         handler();
     }
 }
+apiCommandExec.handlers = {
+    search: () => {
+        chrome.tabs.create({url: chrome.extension.getURL('/bg/search.html')});
+    },
+
+    help: () => {
+        chrome.tabs.create({url: 'https://foosoft.net/projects/yomichan/'});
+    },
+
+    options: () => {
+        chrome.runtime.openOptionsPage();
+    },
+
+    toggle: async () => {
+        const optionsContext = {
+            depth: 0,
+            url: window.location.href
+        };
+        const options = await apiOptionsGet(optionsContext);
+        options.general.enable = !options.general.enable;
+        await apiOptionsSave('popup');
+    }
+};
 
 async function apiAudioGetUrl(definition, source) {
     return audioBuildUrl(definition, source);

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -102,21 +102,16 @@ class DisplayFloat extends Display {
     }
 
     onKeyDown(e) {
-        const handlers = {
-            67: /* c */ () => {
-                if (e.ctrlKey && !window.getSelection().toString()) {
-                    this.onSelectionCopy();
-                    return true;
-                }
+        const key = Display.getKeyFromEvent(e);
+        const handlers = DisplayFloat.onKeyDownHandlers;
+        if (handlers.hasOwnProperty(key)) {
+            const handler = handlers[key];
+            if (handler(this, e)) {
+                e.preventDefault();
+                return;
             }
-        };
-
-        const handler = handlers[e.keyCode];
-        if (handler && handler()) {
-            e.preventDefault();
-        } else {
-            super.onKeyDown(e);
         }
+        super.onKeyDown(e);
     }
 
     autoPlayAudio() {
@@ -145,5 +140,15 @@ class DisplayFloat extends Display {
         }
     }
 }
+
+DisplayFloat.onKeyDownHandlers = {
+    'C': (self, e) => {
+        if (e.ctrlKey && !window.getSelection().toString()) {
+            self.onSelectionCopy();
+            return true;
+        }
+        return false;
+    }
+};
 
 window.yomichan_display = new DisplayFloat();

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -63,41 +63,11 @@ class DisplayFloat extends Display {
     }
 
     onMessage(e) {
-        const handlers = {
-            termsShow: ({definitions, options, context}) => {
-                this.termsShow(definitions, options, context);
-            },
-
-            kanjiShow: ({definitions, options, context}) => {
-                this.kanjiShow(definitions, options, context);
-            },
-
-            clearAutoPlayTimer: () => {
-                this.clearAutoPlayTimer();
-            },
-
-            orphaned: () => {
-                this.onOrphaned();
-            },
-
-            setOptions: (options) => {
-                const css = options.general.customPopupCss;
-                if (css) {
-                    this.setStyle(css);
-                }
-            },
-
-            popupNestedInitialize: ({id, depth, parentFrameId, url}) => {
-                this.optionsContext.depth = depth;
-                this.optionsContext.url = url;
-                popupNestedInitialize(id, depth, parentFrameId, url);
-            }
-        };
-
         const {action, params} = e.data;
-        const handler = handlers[action];
-        if (handler) {
-            handler(params);
+        const handlers = DisplayFloat.messageHandlers;
+        if (handlers.hasOwnProperty(action)) {
+            const handler = handlers[action];
+            handler(this, params);
         }
     }
 
@@ -148,6 +118,37 @@ DisplayFloat.onKeyDownHandlers = {
             return true;
         }
         return false;
+    }
+};
+
+DisplayFloat.messageHandlers = {
+    termsShow: (self, {definitions, options, context}) => {
+        self.termsShow(definitions, options, context);
+    },
+
+    kanjiShow: (self, {definitions, options, context}) => {
+        self.kanjiShow(definitions, options, context);
+    },
+
+    clearAutoPlayTimer: (self) => {
+        self.clearAutoPlayTimer();
+    },
+
+    orphaned: (self) => {
+        self.onOrphaned();
+    },
+
+    setOptions: (self, options) => {
+        const css = options.general.customPopupCss;
+        if (css) {
+            self.setStyle(css);
+        }
+    },
+
+    popupNestedInitialize: (self, {id, depth, parentFrameId, url}) => {
+        self.optionsContext.depth = depth;
+        self.optionsContext.url = url;
+        popupNestedInitialize(id, depth, parentFrameId, url);
     }
 };
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -96,6 +96,18 @@ class DisplayFloat extends Display {
         }
     }
 
+    initialize(options, popupInfo, url) {
+        const css = options.general.customPopupCss;
+        if (css) {
+            this.setStyle(css);
+        }
+
+        const {id, depth, parentFrameId} = popupInfo;
+        this.optionsContext.depth = depth;
+        this.optionsContext.url = url;
+        popupNestedInitialize(id, depth, parentFrameId, url);
+    }
+
     setStyle(css) {
         const parent = document.head;
 
@@ -122,34 +134,11 @@ DisplayFloat.onKeyDownHandlers = {
 };
 
 DisplayFloat.messageHandlers = {
-    termsShow: (self, {definitions, options, context}) => {
-        self.termsShow(definitions, options, context);
-    },
-
-    kanjiShow: (self, {definitions, options, context}) => {
-        self.kanjiShow(definitions, options, context);
-    },
-
-    clearAutoPlayTimer: (self) => {
-        self.clearAutoPlayTimer();
-    },
-
-    orphaned: (self) => {
-        self.onOrphaned();
-    },
-
-    setOptions: (self, options) => {
-        const css = options.general.customPopupCss;
-        if (css) {
-            self.setStyle(css);
-        }
-    },
-
-    popupNestedInitialize: (self, {id, depth, parentFrameId, url}) => {
-        self.optionsContext.depth = depth;
-        self.optionsContext.url = url;
-        popupNestedInitialize(id, depth, parentFrameId, url);
-    }
+    termsShow: (self, {definitions, options, context}) => self.termsShow(definitions, options, context),
+    kanjiShow: (self, {definitions, options, context}) => self.kanjiShow(definitions, options, context),
+    clearAutoPlayTimer: (self) => self.clearAutoPlayTimer(),
+    orphaned: (self) => self.onOrphaned(),
+    initialize: (self, {options, popupInfo, url}) => self.initialize(options, popupInfo, url)
 };
 
 window.yomichan_display = new DisplayFloat();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -56,16 +56,18 @@ class Popup {
         return new Promise((resolve) => {
             const parentFrameId = (typeof this.frameId === 'number' ? this.frameId : null);
             this.container.addEventListener('load', () => {
-                this.invokeApi('popupNestedInitialize', {
-                    id: this.id,
-                    depth: this.depth,
-                    parentFrameId,
+                this.invokeApi('initialize', {
+                    options: {
+                        general: {
+                            customPopupCss: options.general.customPopupCss
+                        }
+                    },
+                    popupInfo: {
+                        id: this.id,
+                        depth: this.depth,
+                        parentFrameId
+                    },
                     url: this.url
-                });
-                this.invokeApi('setOptions', {
-                    general: {
-                        customPopupCss: options.general.customPopupCss
-                    }
                 });
                 resolve();
             });

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -161,20 +161,12 @@ class Display {
     }
 
     onWheel(e) {
-        const handler = () => {
-            if (e.altKey) {
-                if (e.deltaY < 0) { // scroll up
-                    this.entryScrollIntoView(this.index - 1, null, true);
-                    return true;
-                } else if (e.deltaY > 0) { // scroll down
-                    this.entryScrollIntoView(this.index + 1, null, true);
-                    return true;
-                }
+        if (e.altKey) {
+            const delta = e.deltaY;
+            if (delta !== 0) {
+                this.entryScrollIntoView(this.index + (delta > 0 ? 1 : -1), null, true);
+                e.preventDefault();
             }
-        };
-
-        if (handler()) {
-            e.preventDefault();
         }
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -150,117 +150,13 @@ class Display {
     }
 
     onKeyDown(e) {
-        const noteTryAdd = mode => {
-            const button = this.adderButtonFind(this.index, mode);
-            if (button !== null && !button.classList.contains('disabled')) {
-                this.noteAdd(this.definitions[this.index], mode);
+        const key = Display.getKeyFromEvent(e);
+        const handlers = Display.onKeyDownHandlers;
+        if (handlers.hasOwnProperty(key)) {
+            const handler = handlers[key];
+            if (handler(this, e)) {
+                e.preventDefault();
             }
-        };
-
-        const noteTryView = mode => {
-            const button = this.viewerButtonFind(this.index);
-            if (button !== null && !button.classList.contains('disabled')) {
-                apiNoteView(button.dataset.noteId);
-            }
-        };
-
-        const handlers = {
-            27: /* escape */ () => {
-                this.onSearchClear();
-                return true;
-            },
-
-            33: /* page up */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(this.index - 3, null, true);
-                    return true;
-                }
-            },
-
-            34: /* page down */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(this.index + 3, null, true);
-                    return true;
-                }
-            },
-
-            35: /* end */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(this.definitions.length - 1, null, true);
-                    return true;
-                }
-            },
-
-            36: /* home */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(0, null, true);
-                    return true;
-                }
-            },
-
-            38: /* up */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(this.index - 1, null, true);
-                    return true;
-                }
-            },
-
-            40: /* down */ () => {
-                if (e.altKey) {
-                    this.entryScrollIntoView(this.index + 1, null, true);
-                    return true;
-                }
-            },
-
-            66: /* b */ () => {
-                if (e.altKey) {
-                    this.sourceTermView();
-                    return true;
-                }
-            },
-
-            69: /* e */ () => {
-                if (e.altKey) {
-                    noteTryAdd('term-kanji');
-                    return true;
-                }
-            },
-
-            75: /* k */ () => {
-                if (e.altKey) {
-                    noteTryAdd('kanji');
-                    return true;
-                }
-            },
-
-            82: /* r */ () => {
-                if (e.altKey) {
-                    noteTryAdd('term-kana');
-                    return true;
-                }
-            },
-
-            80: /* p */ () => {
-                if (e.altKey) {
-                    const entry = this.getEntry(this.index);
-                    if (entry !== null && entry.dataset.type === 'term') {
-                        this.audioPlay(this.definitions[this.index], this.firstExpressionIndex);
-                    }
-
-                    return true;
-                }
-            },
-
-            86: /* v */ () => {
-                if (e.altKey) {
-                    noteTryView();
-                }
-            }
-        };
-
-        const handler = handlers[e.keyCode];
-        if (handler && handler()) {
-            e.preventDefault();
         }
     }
 
@@ -459,6 +355,20 @@ class Display {
         }
     }
 
+    noteTryAdd(mode) {
+        const button = this.adderButtonFind(this.index, mode);
+        if (button !== null && !button.classList.contains('disabled')) {
+            this.noteAdd(this.definitions[this.index], mode);
+        }
+    }
+
+    noteTryView() {
+        const button = this.viewerButtonFind(this.index);
+        if (button !== null && !button.classList.contains('disabled')) {
+            apiNoteView(button.dataset.noteId);
+        }
+    }
+
     async noteAdd(definition, mode) {
         try {
             this.setSpinnerVisible(true);
@@ -634,4 +544,115 @@ class Display {
         const documentRect = document.documentElement.getBoundingClientRect();
         return elementRect.top - documentRect.top;
     }
+
+    static getKeyFromEvent(event) {
+        const key = event.key;
+        return key.length === 1 ? key.toUpperCase() : key;
+    }
 }
+
+Display.onKeyDownHandlers = {
+    'Escape': (self) => {
+        self.onSearchClear();
+        return true;
+    },
+
+    'PageUp': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(self.index - 3, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'PageDown': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(self.index + 3, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'End': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(self.definitions.length - 1, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'Home': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(0, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'ArrowUp': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(self.index - 1, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'ArrowDown': (self, e) => {
+        if (e.altKey) {
+            self.entryScrollIntoView(self.index + 1, null, true);
+            return true;
+        }
+        return false;
+    },
+
+    'B': (self, e) => {
+        if (e.altKey) {
+            self.sourceTermView();
+            return true;
+        }
+        return false;
+    },
+
+    'E': (self, e) => {
+        if (e.altKey) {
+            self.noteTryAdd('term-kanji');
+            return true;
+        }
+        return false;
+    },
+
+    'K': (self, e) => {
+        if (e.altKey) {
+            self.noteTryAdd('kanji');
+            return true;
+        }
+        return false;
+    },
+
+    'R': (self, e) => {
+        if (e.altKey) {
+            self.noteTryAdd('term-kana');
+            return true;
+        }
+        return false;
+    },
+
+    'P': (self, e) => {
+        if (e.altKey) {
+            const entry = self.getEntry(self.index);
+            if (entry !== null && entry.dataset.type === 'term') {
+                self.audioPlay(self.definitions[self.index], self.firstExpressionIndex);
+            }
+            return true;
+        }
+        return false;
+    },
+
+    'V': (self, e) => {
+        if (e.altKey) {
+            self.noteTryView();
+            return true;
+        }
+        return false;
+    }
+};


### PR DESCRIPTION
Changes various handler definitions to be static objects rather than constructed for every event invocation.

* ```keydown``` events now use [KeyboardEvent.key](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/key) rather than [KeyboardEvent.keyCode](https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/keyCode), since keyCode is supposedly deprecated.
* Normalized return types of ```keydown``` handlers to only return ```true``` or ```false```.
* ```wheel``` event handler for ```Display``` simplified.
* Initialization of popups simplified. Combined the ```setOptions``` and ```popupNestedInitialize``` messages into a single ```initialize``` message which contains all of the necessary data. This reduces the number of messages sent.

#189