### PR TITLE
Remove event listeners when scanning is disabled

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -38,6 +38,9 @@ class Frontend {
         this.mouseDownPrevent = false;
         this.clickPrevent = false;
         this.scrollPrevent = false;
+
+        this.enabled = false;
+        this.eventListeners = [];
     }
 
     static create() {
@@ -53,23 +56,7 @@ class Frontend {
 
     async prepare() {
         try {
-            this.options = await apiOptionsGet(this.getOptionsContext());
-
-            window.addEventListener('message', this.onWindowMessage.bind(this));
-            window.addEventListener('mousedown', this.onMouseDown.bind(this));
-            window.addEventListener('mousemove', this.onMouseMove.bind(this));
-            window.addEventListener('mouseover', this.onMouseOver.bind(this));
-            window.addEventListener('mouseout', this.onMouseOut.bind(this));
-            window.addEventListener('resize', this.onResize.bind(this));
-
-            if (this.options.scanning.touchInputEnabled) {
-                window.addEventListener('click', this.onClick.bind(this));
-                window.addEventListener('touchstart', this.onTouchStart.bind(this));
-                window.addEventListener('touchend', this.onTouchEnd.bind(this));
-                window.addEventListener('touchcancel', this.onTouchCancel.bind(this));
-                window.addEventListener('touchmove', this.onTouchMove.bind(this), {passive: false});
-                window.addEventListener('contextmenu', this.onContextMenu.bind(this));
-            }
+            await this.updateOptions();
 
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
         } catch (e) {
@@ -88,7 +75,6 @@ class Frontend {
 
         if (
             this.pendingLookup ||
-            !this.options.general.enable ||
             (e.buttons & 0x1) !== 0x0 // Left mouse button
         ) {
             return;
@@ -245,11 +231,54 @@ class Frontend {
         console.log(error);
     }
 
-    async updateOptions() {
-        this.options = await apiOptionsGet(this.getOptionsContext());
-        if (!this.options.enable) {
+    setEnabled(enabled) {
+        if (enabled) {
+            if (!this.enabled) {
+                this.hookEvents();
+                this.enabled = true;
+            }
+        } else {
+            if (this.enabled) {
+                this.clearEventListeners();
+                this.enabled = false;
+            }
             this.searchClear(false);
         }
+    }
+
+    hookEvents() {
+        this.addEventListener(window, 'message', this.onWindowMessage.bind(this));
+        this.addEventListener(window, 'mousedown', this.onMouseDown.bind(this));
+        this.addEventListener(window, 'mousemove', this.onMouseMove.bind(this));
+        this.addEventListener(window, 'mouseover', this.onMouseOver.bind(this));
+        this.addEventListener(window, 'mouseout', this.onMouseOut.bind(this));
+        this.addEventListener(window, 'resize', this.onResize.bind(this));
+
+        if (this.options.scanning.touchInputEnabled) {
+            this.addEventListener(window, 'click', this.onClick.bind(this));
+            this.addEventListener(window, 'touchstart', this.onTouchStart.bind(this));
+            this.addEventListener(window, 'touchend', this.onTouchEnd.bind(this));
+            this.addEventListener(window, 'touchcancel', this.onTouchCancel.bind(this));
+            this.addEventListener(window, 'touchmove', this.onTouchMove.bind(this), {passive: false});
+            this.addEventListener(window, 'contextmenu', this.onContextMenu.bind(this));
+        }
+    }
+
+    addEventListener(node, type, listener, options) {
+        node.addEventListener(type, listener, options);
+        this.eventListeners.push([node, type, listener, options]);
+    }
+
+    clearEventListeners() {
+        for (const [node, type, listener, options] of this.eventListeners) {
+            node.removeEventListener(type, listener, options);
+        }
+        this.eventListeners = [];
+    }
+
+    async updateOptions() {
+        this.options = await apiOptionsGet(this.getOptionsContext());
+        this.setEnabled(this.options.general.enable);
     }
 
     popupTimerSet(callback) {
@@ -452,7 +481,7 @@ class Frontend {
     searchFromTouch(x, y, cause) {
         this.popupTimerClear();
 
-        if (!this.options.general.enable || this.pendingLookup) {
+        if (this.pendingLookup) {
             return;
         }
 


### PR DESCRIPTION
Remove event callbacks when the ```options.general.enable``` is ```false```. This is a _very_ minor performance improvement when scanning is enabled (removes the need to check the value every time an event is fired), but should be more impactful when scanning is disabled (no callbacks hooked to frequently invoked events like ```mousemove```, ```touchmove```, etc.) #189

This also fixes a line which used to be checking ```this.options.enable``` rather than ```this.options.general.enable```.

This will cause a merge conflict with #233 due to https://github.com/FooSoft/yomichan/pull/233/commits/7d15213916355a806ba687803ca94209e29f142c#diff-6559642516f798ca10f6693f70f1481eL58-R58, but I will fix those up when necessary.