### PR TITLE
Fix focus

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -145,7 +145,7 @@ class Frontend {
     }
 
     onResize() {
-        this.searchClear(true);
+        this.searchClear(false);
     }
 
     onClick(e) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -527,8 +527,8 @@ Frontend.runtimeMessageHandlers = {
         self.updateOptions();
     },
 
-    popupSetVisible: (self, {visible}) => {
-        self.popup.setVisible(visible);
+    popupSetVisibleOverride: (self, {visible}) => {
+        self.popup.setVisibleOverride(visible);
     }
 };
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -41,7 +41,7 @@ class PopupProxyHost {
             show: ({id, elementRect, options}) => this.show(id, elementRect, options),
             showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
             hide: ({id, changeFocus}) => this.hide(id, changeFocus),
-            setVisible: ({id, visible}) => this.setVisible(id, visible),
+            setVisibleOverride: ({id, visible}) => this.setVisibleOverride(id, visible),
             containsPoint: ({id, x, y}) => this.containsPoint(id, x, y),
             termsShow: ({id, elementRect, writingMode, definitions, options, context}) => this.termsShow(id, elementRect, writingMode, definitions, options, context),
             kanjiShow: ({id, elementRect, writingMode, definitions, options, context}) => this.kanjiShow(id, elementRect, writingMode, definitions, options, context),
@@ -103,9 +103,9 @@ class PopupProxyHost {
         return popup.hide(changeFocus);
     }
 
-    async setVisible(id, visible) {
+    async setVisibleOverride(id, visible) {
         const popup = this.getPopup(id);
-        return popup.setVisible(visible);
+        return popup.setVisibleOverride(visible);
     }
 
     async containsPoint(id, x, y) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -65,9 +65,9 @@ class PopupProxy {
         return await this.invokeHostApi('hide', {id: this.id, changeFocus});
     }
 
-    async setVisible(visible) {
+    async setVisibleOverride(visible) {
         const id = await this.getPopupId();
-        return await this.invokeHostApi('setVisible', {id, visible});
+        return await this.invokeHostApi('setVisibleOverride', {id, visible});
     }
 
     async containsPoint(x, y) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -238,7 +238,7 @@ class Popup {
         return this.isInjected && this.container.style.visibility !== 'hidden';
     }
 
-    setVisible(visible) {
+    setVisibleOverride(visible) {
         if (visible) {
             this.container.style.setProperty('display', '');
         } else {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -34,6 +34,9 @@ class Popup {
         this.container.style.height = '0px';
         this.injectPromise = null;
         this.isInjected = false;
+        this.visible = false;
+        this.visibleOverride = null;
+        this.updateVisibility();
     }
 
     inject(options) {
@@ -105,9 +108,11 @@ class Popup {
         container.style.top = `${y}px`;
         container.style.width = `${width}px`;
         container.style.height = `${height}px`;
-        container.style.visibility = 'visible';
 
-        this.hideChildren(true);
+        this.setVisible(true);
+        if (this.child !== null) {
+            this.child.hide(true);
+        }
     }
 
     static getPositionForHorizontalText(elementRect, width, height, maxWidth, maxHeight, optionsGeneral) {
@@ -209,41 +214,35 @@ class Popup {
     }
 
     hide(changeFocus) {
-        if (this.isContainerHidden()) {
-            changeFocus = false;
+        if (!this.isVisible()) {
+            return;
         }
-        this.hideChildren(changeFocus);
-        this.hideContainer();
+
+        this.setVisible(false);
+        if (this.child !== null) {
+            this.child.hide(false);
+        }
         if (changeFocus) {
             this.focusParent();
         }
     }
 
-    hideChildren(changeFocus) {
-        // Recursively hides all children.
-        if (this.child !== null && !this.child.isContainerHidden()) {
-            this.child.hide(changeFocus);
-        }
-    }
-
-    hideContainer() {
-        this.container.style.visibility = 'hidden';
-    }
-
-    isContainerHidden() {
-        return (this.container.style.visibility === 'hidden');
-    }
-
     isVisible() {
-        return this.isInjected && this.container.style.visibility !== 'hidden';
+        return this.isInjected && (this.visibleOverride !== null ? this.visibleOverride : this.visible);
+    }
+
+    setVisible(visible) {
+        this.visible = visible;
+        this.updateVisibility();
     }
 
     setVisibleOverride(visible) {
-        if (visible) {
-            this.container.style.setProperty('display', '');
-        } else {
-            this.container.style.setProperty('display', 'none', 'important');
-        }
+        this.visibleOverride = visible;
+        this.updateVisibility();
+    }
+
+    updateVisibility() {
+        this.container.style.setProperty('visibility', this.isVisible() ? 'visible' : 'hidden', 'important');
     }
 
     focusParent() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -454,7 +454,7 @@ class Display {
 
             return {dataUrl, format};
         } finally {
-            await this.setPopupVisibleOverride(true);
+            await this.setPopupVisibleOverride(null);
         }
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -445,7 +445,7 @@ class Display {
 
     async getScreenshot() {
         try {
-            await this.setPopupVisible(false);
+            await this.setPopupVisibleOverride(false);
             await Display.delay(1); // Wait for popup to be hidden.
 
             const {format, quality} = this.options.anki.screenshot;
@@ -454,7 +454,7 @@ class Display {
 
             return {dataUrl, format};
         } finally {
-            await this.setPopupVisible(true);
+            await this.setPopupVisibleOverride(true);
         }
     }
 
@@ -462,8 +462,8 @@ class Display {
         return this.options.general.resultOutputMode === 'merge' ? 0 : -1;
     }
 
-    setPopupVisible(visible) {
-        return apiForward('popupSetVisible', {visible});
+    setPopupVisibleOverride(visible) {
+        return apiForward('popupSetVisibleOverride', {visible});
     }
 
     setSpinnerVisible(visible) {


### PR DESCRIPTION
A change which fixes #239 (hopefully). I was not able to reproduce it on my end, but it sounds suspiciously similar to #227.

This PR makes a few changes to hopefully help clarify the how visibility changes work:

* Renamed ```Popup.setVisible``` to ```setVisibleOverride```. ```setVisibleOverride``` better reflects what this function does, since it was only used when hiding all popups when creating an Anki card which takes a screenshot. Its use was to temporarily force popups to be hidden and then revert them afterwards.

* Popup visibility state is now tracked more explicitly with two internal variables: ```Popup.visible``` and ```Popup.visibleOverride```.
  * ```visible``` indicates the preferred popup visibility when no override is specified.
  * ```visibleOverride``` corresponds to the value set by ```setVisibleOverride```. This also takes a value of ```null```, indicating no override.

  All popup visibility changes are now performed by changing ```style.visibility```, rather than using both ```style.visibility``` _and_ ```style.display```.

* The ```Popup.hide``` method has been changed such that it does nothing if the popup is not visible. This should fix the issue which was causing focus to change, as this could be triggered on page load.

* The ```window.onresize``` handler has been changed to only passively hide the popup if it is open. If a ```resize``` event happens on a window/tab without focus, this could potentially cause the focused tab to change.

Overall, I'm still not sure why browsers would let web-extensions change the focused tab using non-web-extension APIs; seems exploitable.