### PR TITLE
Dark mode in popup using customPopupCss

### DIFF
--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -262,6 +262,7 @@ function profileOptionsCreateDefaults() {
             resultOutputMode: 'group',
             debugInfo: false,
             maxResults: 32,
+            darkMode: false,
             showAdvanced: false,
             popupDisplayMode: 'default',
             popupWidth: 400,

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -28,6 +28,7 @@ async function formRead(options) {
     options.general.compactGlossaries = $('#compact-glossaries').prop('checked');
     options.general.resultOutputMode = $('#result-output-mode').val();
     options.general.debugInfo = $('#show-debug-info').prop('checked');
+    options.general.darkMode = $('#dark-mode-popup').prop('checked');
     options.general.showAdvanced = $('#show-advanced-options').prop('checked');
     options.general.maxResults = parseInt($('#max-displayed-results').val(), 10);
     options.general.popupDisplayMode = $('#popup-display-mode').val();
@@ -96,6 +97,7 @@ async function formWrite(options) {
     $('#compact-glossaries').prop('checked', options.general.compactGlossaries);
     $('#result-output-mode').val(options.general.resultOutputMode);
     $('#show-debug-info').prop('checked', options.general.debugInfo);
+    $('#dark-mode-popup').prop('checked', options.general.darkMode);
     $('#show-advanced-options').prop('checked', options.general.showAdvanced);
     $('#max-displayed-results').val(options.general.maxResults);
     $('#popup-display-mode').val(options.general.popupDisplayMode);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -141,6 +141,10 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="dark-mode-popup"> Enable dark mode in popup</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-advanced-options"> Show advanced options</label>
                 </div>
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -97,7 +97,20 @@ class DisplayFloat extends Display {
     }
 
     initialize(options, popupInfo, url) {
-        const css = options.general.customPopupCss;
+        const darkModeCss = `
+body {
+    color: #fff;
+    background: #000;
+}
+.expression .kanji-link {
+    color: rgb(191, 191, 191);
+}
+.glossary-item {
+    color: #fff;
+}
+        `.trim();
+
+        const css = options.general.customPopupCss + (options.general.darkMode ? '\n' + darkModeCss : '');
         if (css) {
             this.setStyle(css);
         }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -99,14 +99,19 @@ class DisplayFloat extends Display {
     initialize(options, popupInfo, url) {
         const darkModeCss = `
 body {
-    color: #fff;
-    background: #000;
+    background-color: #000;
+}
+.expression {
+    color: rgb(200, 200, 200);
 }
 .expression .kanji-link {
-    color: rgb(191, 191, 191);
+    color: rgb(200, 200, 200);
 }
 .glossary-item {
-    color: #fff;
+    color: rgb(236, 236, 236);
+}
+.label {
+    color: rgb(236, 236, 236);
 }
         `.trim();
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -62,7 +62,8 @@ class Popup {
                 this.invokeApi('initialize', {
                     options: {
                         general: {
-                            customPopupCss: options.general.customPopupCss
+                            customPopupCss: options.general.customPopupCss,
+                            darkMode: options.general.darkMode
                         }
                     },
                     popupInfo: {


### PR DESCRIPTION
This seems quick and dirty but I believe it gets the job done reasonably enough. I can see other more logical ways of implementing dark mode such as directly changing the css itself instead of appending darkModeCss to @toasted-nutbread's customPopupCss.

As @toasted-nutbread said in #242, it would be nice to have "some sort of live view of a popup to show what the results look like, because currently it requires a full page refresh of any webpage using yomichan before the differences will be shown."

This satisfies #249, I hope.