### PR TITLE
Display options improvements

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -33,23 +33,37 @@ class DisplaySearch extends Display {
         this.introAnimationTimer = null;
 
         this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
+    }
 
-        if (this.search !== null) {
-            this.search.addEventListener('click', (e) => this.onSearch(e), false);
-        }
-        if (this.query !== null) {
-            this.query.addEventListener('input', () => this.onSearchInput(), false);
+    static create() {
+        const instance = new DisplaySearch();
+        instance.prepare();
+        return instance;
+    }
 
-            const query = DisplaySearch.getSearchQueryFromLocation(window.location.href);
-            if (query !== null) {
-                this.query.value = window.wanakana.toKana(query);
-                this.onSearchQueryUpdated(query, false);
+    async prepare() {
+        try {
+            await this.initialize();
+
+            if (this.search !== null) {
+                this.search.addEventListener('click', (e) => this.onSearch(e), false);
+            }
+            if (this.query !== null) {
+                this.query.addEventListener('input', () => this.onSearchInput(), false);
+
+                const query = DisplaySearch.getSearchQueryFromLocation(window.location.href);
+                if (query !== null) {
+                    this.query.value = window.wanakana.toKana(query);
+                    this.onSearchQueryUpdated(query, false);
+                }
+
+                window.wanakana.bind(this.query);
             }
 
-            window.wanakana.bind(this.query);
+            this.updateSearchButton();
+        } catch (e) {
+            this.onError(e);
         }
-
-        this.updateSearchButton();
     }
 
     onError(error) {
@@ -89,13 +103,17 @@ class DisplaySearch extends Display {
             this.updateSearchButton();
             if (valid) {
                 const {definitions} = await apiTermsFind(query, this.optionsContext);
-                this.termsShow(definitions, await apiOptionsGet(this.optionsContext));
+                this.termsShow(definitions, this.options);
             } else {
                 this.container.textContent = '';
             }
         } catch (e) {
             this.onError(e);
         }
+    }
+
+    getOptionsContext() {
+        return this.optionsContext;
     }
 
     setIntroVisible(visible, animate) {
@@ -164,4 +182,4 @@ class DisplaySearch extends Display {
     }
 }
 
-window.yomichan_search = new DisplaySearch();
+window.yomichan_search = DisplaySearch.create();

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -103,7 +103,11 @@ class DisplaySearch extends Display {
             this.updateSearchButton();
             if (valid) {
                 const {definitions} = await apiTermsFind(query, this.optionsContext);
-                this.termsShow(definitions, this.options);
+                this.termsShow(definitions, {
+                    focus: false,
+                    sentence: null,
+                    url: window.location.href
+                });
             } else {
                 this.container.textContent = '';
             }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -31,8 +31,6 @@ class DisplaySearch extends Display {
         this.intro = document.querySelector('#intro');
         this.introVisible = true;
         this.introAnimationTimer = null;
-
-        this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
     }
 
     static create() {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -84,6 +84,10 @@ class DisplayFloat extends Display {
         super.onKeyDown(e);
     }
 
+    getOptionsContext() {
+        return this.optionsContext;
+    }
+
     autoPlayAudio() {
         this.clearAutoPlayTimer();
         this.autoPlayAudioTimer = window.setTimeout(() => super.autoPlayAudio(), 400);
@@ -96,7 +100,9 @@ class DisplayFloat extends Display {
         }
     }
 
-    initialize(options, popupInfo, url, childrenSupported) {
+    async initialize(options, popupInfo, url, childrenSupported) {
+        await super.initialize(options);
+
         const css = options.general.customPopupCss;
         if (css) {
             this.setStyle(css);

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -143,8 +143,8 @@ DisplayFloat.onKeyDownHandlers = {
 };
 
 DisplayFloat.messageHandlers = {
-    termsShow: (self, {definitions, options, context}) => self.termsShow(definitions, options, context),
-    kanjiShow: (self, {definitions, options, context}) => self.kanjiShow(definitions, options, context),
+    termsShow: (self, {definitions, context}) => self.termsShow(definitions, context),
+    kanjiShow: (self, {definitions, context}) => self.kanjiShow(definitions, context),
     clearAutoPlayTimer: (self) => self.clearAutoPlayTimer(),
     orphaned: (self) => self.onOrphaned(),
     initialize: (self, {options, popupInfo, url, childrenSupported}) => self.initialize(options, popupInfo, url, childrenSupported)

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -28,8 +28,6 @@ class DisplayFloat extends Display {
             url: window.location.href
         };
 
-        this.dependencies = Object.assign({}, this.dependencies, {docRangeFromPoint, docSentenceExtract});
-
         window.addEventListener('message', (e) => this.onMessage(e), false);
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -287,6 +287,7 @@ class Frontend {
     async updateOptions() {
         this.options = await apiOptionsGet(this.getOptionsContext());
         this.setEnabled(this.options.general.enable);
+        await this.popup.setOptions(this.options);
     }
 
     popupTimerSet(callback) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -333,8 +333,7 @@ class Frontend {
                 if (textSource && this.options.scanning.modifier !== 'none') {
                     this.popup.showOrphaned(
                         textSource.getRect(),
-                        textSource.getWritingMode(),
-                        this.options
+                        textSource.getWritingMode()
                     );
                 }
             } else {
@@ -374,7 +373,6 @@ class Frontend {
             textSource.getRect(),
             textSource.getWritingMode(),
             definitions,
-            this.options,
             {sentence, url, focus}
         );
 
@@ -405,7 +403,6 @@ class Frontend {
             textSource.getRect(),
             textSource.getWritingMode(),
             definitions,
-            this.options,
             {sentence, url, focus}
         );
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -38,6 +38,7 @@ class PopupProxyHost {
 
         this.apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, {
             createNestedPopup: ({parentId}) => this.createNestedPopup(parentId),
+            setOptions: ({id, options}) => this.setOptions(id, options),
             show: ({id, elementRect, options}) => this.show(id, elementRect, options),
             showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
             hide: ({id, changeFocus}) => this.hide(id, changeFocus),
@@ -84,6 +85,11 @@ class PopupProxyHost {
             y += popupRect.y;
         }
         return new DOMRect(x, y, jsonRect.width, jsonRect.height);
+    }
+
+    async setOptions(id, options) {
+        const popup = this.getPopup(id);
+        return await popup.setOptions(options);
     }
 
     async show(id, elementRect, options) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -39,8 +39,7 @@ class PopupProxyHost {
         this.apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, {
             createNestedPopup: ({parentId}) => this.createNestedPopup(parentId),
             setOptions: ({id, options}) => this.setOptions(id, options),
-            show: ({id, elementRect, options}) => this.show(id, elementRect, options),
-            showOrphaned: ({id, elementRect, options}) => this.show(id, elementRect, options),
+            showOrphaned: ({id, elementRect, options}) => this.showOrphaned(id, elementRect, options),
             hide: ({id, changeFocus}) => this.hide(id, changeFocus),
             setVisibleOverride: ({id, visible}) => this.setVisibleOverride(id, visible),
             containsPoint: ({id, x, y}) => this.containsPoint(id, x, y),
@@ -90,12 +89,6 @@ class PopupProxyHost {
     async setOptions(id, options) {
         const popup = this.getPopup(id);
         return await popup.setOptions(options);
-    }
-
-    async show(id, elementRect, options) {
-        const popup = this.getPopup(id);
-        elementRect = this.jsonRectToDOMRect(popup, elementRect);
-        return await popup.show(elementRect, options);
     }
 
     async showOrphaned(id, elementRect, options) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -39,12 +39,12 @@ class PopupProxyHost {
         this.apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, {
             createNestedPopup: ({parentId}) => this.createNestedPopup(parentId),
             setOptions: ({id, options}) => this.setOptions(id, options),
-            showOrphaned: ({id, elementRect, options}) => this.showOrphaned(id, elementRect, options),
+            showOrphaned: ({id, elementRect}) => this.showOrphaned(id, elementRect),
             hide: ({id, changeFocus}) => this.hide(id, changeFocus),
             setVisibleOverride: ({id, visible}) => this.setVisibleOverride(id, visible),
             containsPoint: ({id, x, y}) => this.containsPoint(id, x, y),
-            termsShow: ({id, elementRect, writingMode, definitions, options, context}) => this.termsShow(id, elementRect, writingMode, definitions, options, context),
-            kanjiShow: ({id, elementRect, writingMode, definitions, options, context}) => this.kanjiShow(id, elementRect, writingMode, definitions, options, context),
+            termsShow: ({id, elementRect, writingMode, definitions, context}) => this.termsShow(id, elementRect, writingMode, definitions, context),
+            kanjiShow: ({id, elementRect, writingMode, definitions, context}) => this.kanjiShow(id, elementRect, writingMode, definitions, context),
             clearAutoPlayTimer: ({id}) => this.clearAutoPlayTimer(id)
         });
     }
@@ -91,10 +91,10 @@ class PopupProxyHost {
         return await popup.setOptions(options);
     }
 
-    async showOrphaned(id, elementRect, options) {
+    async showOrphaned(id, elementRect) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
-        return await popup.showOrphaned(elementRect, options);
+        return await popup.showOrphaned(elementRect);
     }
 
     async hide(id, changeFocus) {
@@ -112,18 +112,18 @@ class PopupProxyHost {
         return await popup.containsPoint(x, y);
     }
 
-    async termsShow(id, elementRect, writingMode, definitions, options, context) {
+    async termsShow(id, elementRect, writingMode, definitions, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
         if (!PopupProxyHost.popupCanShow(popup)) { return false; }
-        return await popup.termsShow(elementRect, writingMode, definitions, options, context);
+        return await popup.termsShow(elementRect, writingMode, definitions, context);
     }
 
-    async kanjiShow(id, elementRect, writingMode, definitions, options, context) {
+    async kanjiShow(id, elementRect, writingMode, definitions, context) {
         const popup = this.getPopup(id);
         elementRect = this.jsonRectToDOMRect(popup, elementRect);
         if (!PopupProxyHost.popupCanShow(popup)) { return false; }
-        return await popup.kanjiShow(elementRect, writingMode, definitions, options, context);
+        return await popup.kanjiShow(elementRect, writingMode, definitions, context);
     }
 
     async clearAutoPlayTimer(id) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -51,12 +51,6 @@ class PopupProxy {
         return await this.invokeHostApi('setOptions', {id, options});
     }
 
-    async show(elementRect, options) {
-        const id = await this.getPopupId();
-        elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('show', {id, elementRect, options});
-    }
-
     async showOrphaned(elementRect, options) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -51,10 +51,10 @@ class PopupProxy {
         return await this.invokeHostApi('setOptions', {id, options});
     }
 
-    async showOrphaned(elementRect, options) {
+    async showOrphaned(elementRect) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('showOrphaned', {id, elementRect, options});
+        return await this.invokeHostApi('showOrphaned', {id, elementRect});
     }
 
     async hide(changeFocus) {
@@ -76,16 +76,16 @@ class PopupProxy {
         return await this.invokeHostApi('containsPoint', {id: this.id, x, y});
     }
 
-    async termsShow(elementRect, writingMode, definitions, options, context) {
+    async termsShow(elementRect, writingMode, definitions, context) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('termsShow', {id, elementRect, writingMode, definitions, options, context});
+        return await this.invokeHostApi('termsShow', {id, elementRect, writingMode, definitions, context});
     }
 
-    async kanjiShow(elementRect, writingMode, definitions, options, context) {
+    async kanjiShow(elementRect, writingMode, definitions, context) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('kanjiShow', {id, elementRect, writingMode, definitions, options, context});
+        return await this.invokeHostApi('kanjiShow', {id, elementRect, writingMode, definitions, context});
     }
 
     async clearAutoPlayTimer() {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -46,6 +46,11 @@ class PopupProxy {
         return id;
     }
 
+    async setOptions(options) {
+        const id = await this.getPopupId();
+        return await this.invokeHostApi('setOptions', {id, options});
+    }
+
     async show(elementRect, options) {
         const id = await this.getPopupId();
         elementRect = PopupProxy.DOMRectToJson(elementRect);

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -37,6 +37,7 @@ class Popup {
         this.isInjected = false;
         this.visible = false;
         this.visibleOverride = null;
+        this.options = null;
         this.updateVisibility();
     }
 
@@ -76,6 +77,10 @@ class Popup {
             this.onFullscreenChanged();
             this.isInjected = true;
         });
+    }
+
+    async setOptions(options) {
+        this.options = options;
     }
 
     async show(elementRect, writingMode, options) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -79,6 +79,10 @@ class Popup {
         });
     }
 
+    isInitialized() {
+        return this.options !== null;
+    }
+
     async setOptions(options) {
         this.options = options;
     }
@@ -212,6 +216,7 @@ class Popup {
     }
 
     async showOrphaned(elementRect, writingMode, options) {
+        if (!this.isInitialized()) { return; }
         await this.show(elementRect, writingMode, options);
         this.invokeApi('orphaned');
     }
@@ -275,11 +280,13 @@ class Popup {
     }
 
     async termsShow(elementRect, writingMode, definitions, options, context) {
+        if (!this.isInitialized()) { return; }
         await this.show(elementRect, writingMode, options);
         this.invokeApi('termsShow', {definitions, options, context});
     }
 
     async kanjiShow(elementRect, writingMode, definitions, options, context) {
+        if (!this.isInitialized()) { return; }
         await this.show(elementRect, writingMode, options);
         this.invokeApi('kanjiShow', {definitions, options, context});
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -61,11 +61,7 @@ class Popup {
             const parentFrameId = (typeof this.frameId === 'number' ? this.frameId : null);
             this.container.addEventListener('load', () => {
                 this.invokeApi('initialize', {
-                    options: {
-                        general: {
-                            customPopupCss: options.general.customPopupCss
-                        }
-                    },
+                    options: options,
                     popupInfo: {
                         id: this.id,
                         depth: this.depth,

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -41,14 +41,14 @@ class Popup {
         this.updateVisibility();
     }
 
-    inject(options) {
+    inject() {
         if (this.injectPromise === null) {
-            this.injectPromise = this.createInjectPromise(options);
+            this.injectPromise = this.createInjectPromise();
         }
         return this.injectPromise;
     }
 
-    async createInjectPromise(options) {
+    async createInjectPromise() {
         try {
             const {frameId} = await this.frameIdPromise;
             if (typeof frameId === 'number') {
@@ -62,7 +62,7 @@ class Popup {
             const parentFrameId = (typeof this.frameId === 'number' ? this.frameId : null);
             this.container.addEventListener('load', () => {
                 this.invokeApi('initialize', {
-                    options: options,
+                    options: this.options,
                     popupInfo: {
                         id: this.id,
                         depth: this.depth,
@@ -87,10 +87,10 @@ class Popup {
         this.options = options;
     }
 
-    async show(elementRect, writingMode, options) {
-        await this.inject(options);
+    async show(elementRect, writingMode) {
+        await this.inject();
 
-        const optionsGeneral = options.general;
+        const optionsGeneral = this.options.general;
         const container = this.container;
         const containerRect = container.getBoundingClientRect();
         const getPosition = (
@@ -215,9 +215,9 @@ class Popup {
         return [position, size, after];
     }
 
-    async showOrphaned(elementRect, writingMode, options) {
+    async showOrphaned(elementRect, writingMode) {
         if (!this.isInitialized()) { return; }
-        await this.show(elementRect, writingMode, options);
+        await this.show(elementRect, writingMode);
         this.invokeApi('orphaned');
     }
 
@@ -279,16 +279,16 @@ class Popup {
         return false;
     }
 
-    async termsShow(elementRect, writingMode, definitions, options, context) {
+    async termsShow(elementRect, writingMode, definitions, context) {
         if (!this.isInitialized()) { return; }
-        await this.show(elementRect, writingMode, options);
-        this.invokeApi('termsShow', {definitions, options, context});
+        await this.show(elementRect, writingMode);
+        this.invokeApi('termsShow', {definitions, context});
     }
 
-    async kanjiShow(elementRect, writingMode, definitions, options, context) {
+    async kanjiShow(elementRect, writingMode, definitions, context) {
         if (!this.isInitialized()) { return; }
-        await this.show(elementRect, writingMode, options);
-        this.invokeApi('kanjiShow', {definitions, options, context});
+        await this.show(elementRect, writingMode);
+        this.invokeApi('kanjiShow', {definitions, context});
     }
 
     clearAutoPlayTimer() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -35,8 +35,6 @@ class Display {
         this.interactive = false;
         this.eventListenersActive = false;
 
-        this.dependencies = {};
-
         this.windowScroll = new WindowScroll();
 
         this.setInteractive(true);
@@ -85,8 +83,6 @@ class Display {
     async onTermLookup(e) {
         try {
             e.preventDefault();
-
-            const {docRangeFromPoint, docSentenceExtract} = this.dependencies;
 
             const clickedElement = e.target;
             const textSource = docRangeFromPoint(e.clientX, e.clientY, this.options);

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -187,6 +187,10 @@ class Display {
         throw new Error('Override me');
     }
 
+    isInitialized() {
+        return this.options !== null;
+    }
+
     async initialize(options=null) {
         await this.updateOptions(options);
         chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
@@ -236,6 +240,8 @@ class Display {
     }
 
     async termsShow(definitions, options, context) {
+        if (!this.isInitialized()) { return; }
+
         try {
             this.setEventListenersActive(false);
 
@@ -287,6 +293,8 @@ class Display {
     }
 
     async kanjiShow(definitions, options, context) {
+        if (!this.isInitialized()) { return; }
+
         try {
             this.setEventListenersActive(false);
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -76,7 +76,7 @@ class Display {
             }
 
             const kanjiDefs = await apiKanjiFind(link.textContent, this.getOptionsContext());
-            this.kanjiShow(kanjiDefs, this.options, context);
+            this.kanjiShow(kanjiDefs, context);
         } catch (e) {
             this.onError(e);
         }
@@ -125,7 +125,7 @@ class Display {
                 context.source.source = this.context.source;
             }
 
-            this.termsShow(definitions, this.options, context);
+            this.termsShow(definitions, context);
         } catch (e) {
             this.onError(e);
         }
@@ -239,10 +239,12 @@ class Display {
         });
     }
 
-    async termsShow(definitions, options, context) {
+    async termsShow(definitions, context) {
         if (!this.isInitialized()) { return; }
 
         try {
+            const options = this.options;
+
             this.setEventListenersActive(false);
 
             if (!context || context.focus !== false) {
@@ -250,7 +252,6 @@ class Display {
             }
 
             this.definitions = definitions;
-            this.options = options;
             this.context = context;
 
             const sequence = ++this.sequence;
@@ -280,7 +281,7 @@ class Display {
             const {index, scroll} = context || {};
             this.entryScrollIntoView(index || 0, scroll);
 
-            if (this.options.audio.enabled && this.options.audio.autoPlay) {
+            if (options.audio.enabled && options.audio.autoPlay) {
                 this.autoPlayAudio();
             }
 
@@ -292,10 +293,12 @@ class Display {
         }
     }
 
-    async kanjiShow(definitions, options, context) {
+    async kanjiShow(definitions, context) {
         if (!this.isInitialized()) { return; }
 
         try {
+            const options = this.options;
+
             this.setEventListenersActive(false);
 
             if (!context || context.focus !== false) {
@@ -303,7 +306,6 @@ class Display {
             }
 
             this.definitions = definitions;
-            this.options = options;
             this.context = context;
 
             const sequence = ++this.sequence;
@@ -415,7 +417,7 @@ class Display {
                 source: this.context.source.source
             };
 
-            this.termsShow(this.context.source.definitions, this.options, context);
+            this.termsShow(this.context.source.definitions, context);
         }
     }
 


### PR DESCRIPTION
The goal of this change is to remove the frequency at which options updates are propagated to popups and Display implementations. Since the options structure is non-trivially sized, there is likely some overhead involved in sharing it across the cross-frame messaging systems. Reducing the size should improve speed slightly.

* ```Display``` is now required to be ```.initialize()```'d before it can properly be used. The initialization process sets up the options value.
* ```Popup``` also now stores options.
* Removed ```.show``` function on ```PopupProxy``` since it's not publicly used.
* Remove ```options``` argument for ```termsShow```, ```kanjiShow```, ```showOrphaned```. These functions now use the reference stored from initialization and options updates.
* Removed ```Display.dependencies``` since this doesn't seem to be necessary.

PR'd for tracking purposes. #189