### PR TITLE
Add unlimited storage permission

### DIFF
--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -499,7 +499,11 @@
                 </div></div>
 
                 <div data-show-for-browser="chrome"><div class="alert alert-warning storage-persist-fail-warning storage-hidden">
-                    <p>It may not be possible to enable Persistent Storage on Chrome-based browsers.</p>
+                    <p>
+                        It may not be possible to enable Persistent Storage on Chrome-based browsers.
+                        However, the Yomichan extension has permission for unlimited storage which should
+                        prevent Chrome from deleting data.<sup><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=680392#c15" target="_blank" rel="noopener">[1]</a></sup>
+                    </p>
                 </div></div>
             </div>
 

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -41,7 +41,8 @@
     "permissions": [
         "<all_urls>",
         "storage",
-        "clipboardWrite"
+        "clipboardWrite",
+        "unlimitedStorage"
     ],
     "commands": {
         "toggle": {


### PR DESCRIPTION
Turns out that the ```unlimitedStorage``` permission cannot be an optional permission in the manifest and enabled on demand, so it would have to be added to the manifest as a default permission.

However, I don't know if adding this permission will cause the extension to be disabled when it is updated. Some research seems to indicate that [adding the ```unlimitedStorage``` permission won't disable the extension](https://stackoverflow.com/questions/42868472/unlimitedstorage-not-supported-by-chrome-optional-permission-api-how-to-update), but this info may be out of date.

I'm not sure what the behaviour is on Chrome, but the behaviour on Firefox is to show a popup warning about additional required permissions when it updates versions. For reference, I have seen [uBlock](https://github.com/gorhill/uBlock) do this, and its [change notes for version 1.18.12](https://github.com/gorhill/uBlock/releases/tag/1.18.12) shows some info about it.

So I'm creating this as a PR, and @FooSoft can decide whether or not this should be merged.