### PR TITLE
Database optimizations part 2

### DIFF
--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -182,7 +182,12 @@ class Database {
         this.validate();
 
         let result = null;
-        await this.db.tagMeta.where('name').equals(name).each(row => {
+        const db = this.db.backendDB();
+        const dbTransaction = db.transaction(['tagMeta'], 'readonly');
+        const dbTerms = dbTransaction.objectStore('tagMeta');
+        const dbIndex = dbTerms.index('name');
+        const only = IDBKeyRange.only(name);
+        await Database.getAll(dbIndex, only, null, row => {
             if (title === row.dictionary) {
                 result = row;
             }

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -123,7 +123,7 @@ class Database {
         const results = [];
         const processRow = (row, index) => {
             if (titles.includes(row.dictionary)) {
-                results.push(Database.createTermMeta(row, index));
+                results.push(Database.createMeta(row, index));
             }
         };
 
@@ -148,15 +148,7 @@ class Database {
         const results = [];
         await this.db.kanji.where('character').equals(kanji).each(row => {
             if (titles.includes(row.dictionary)) {
-                results.push({
-                    character: row.character,
-                    onyomi: dictFieldSplit(row.onyomi),
-                    kunyomi: dictFieldSplit(row.kunyomi),
-                    tags: dictFieldSplit(row.tags),
-                    glossary: row.meanings,
-                    stats: row.stats,
-                    dictionary: row.dictionary
-                });
+                results.push(Database.createKanji(row));
             }
         });
 
@@ -169,11 +161,7 @@ class Database {
         const results = [];
         await this.db.kanjiMeta.where('character').equals(kanji).each(row => {
             if (titles.includes(row.dictionary)) {
-                results.push({
-                    mode: row.mode,
-                    data: row.data,
-                    dictionary: row.dictionary
-                });
+                results.push(Database.createMeta(row));
             }
         });
 
@@ -494,7 +482,20 @@ class Database {
         };
     }
 
-    static createTermMeta(row, index) {
+    static createKanji(row, index) {
+        return {
+            index,
+            character: row.character,
+            onyomi: dictFieldSplit(row.onyomi),
+            kunyomi: dictFieldSplit(row.kunyomi),
+            tags: dictFieldSplit(row.tags),
+            glossary: row.meanings,
+            stats: row.stats,
+            dictionary: row.dictionary
+        };
+    }
+
+    static createMeta(row, index) {
         return {
             index,
             mode: row.mode,

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -59,6 +59,8 @@ class Database {
     }
 
     async findTermsBulk(terms, titles) {
+        this.validate();
+
         const promises = [];
         const visited = {};
         const results = [];
@@ -116,6 +118,8 @@ class Database {
     }
 
     async findTermMetaBulk(terms, titles) {
+        this.validate();
+
         const promises = [];
         const results = [];
         const createResult = Database.createTermMeta;

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -90,19 +90,6 @@ class Database {
         return results;
     }
 
-    async findTermsExact(term, reading, titles) {
-        this.validate();
-
-        const results = [];
-        await this.db.terms.where('expression').equals(term).each(row => {
-            if (row.reading === reading && titles.includes(row.dictionary)) {
-                results.push(Database.createTerm(row));
-            }
-        });
-
-        return results;
-    }
-
     async findTermsExactBulk(termList, readingList, titles) {
         this.validate();
 
@@ -125,19 +112,6 @@ class Database {
         }
 
         await Promise.all(promises);
-
-        return results;
-    }
-
-    async findTermsBySequence(sequence, mainDictionary) {
-        this.validate();
-
-        const results = [];
-        await this.db.terms.where('sequence').equals(sequence).each(row => {
-            if (row.dictionary === mainDictionary) {
-                results.push(Database.createTerm(row));
-            }
-        });
 
         return results;
     }
@@ -172,34 +146,8 @@ class Database {
         return this.findGenericBulk('termMeta', 'expression', termList, titles, Database.createMeta);
     }
 
-    async findKanji(kanji, titles) {
-        this.validate();
-
-        const results = [];
-        await this.db.kanji.where('character').equals(kanji).each(row => {
-            if (titles.includes(row.dictionary)) {
-                results.push(Database.createKanji(row));
-            }
-        });
-
-        return results;
-    }
-
     async findKanjiBulk(kanjiList, titles) {
         return this.findGenericBulk('kanji', 'character', kanjiList, titles, Database.createKanji);
-    }
-
-    async findKanjiMeta(kanji, titles) {
-        this.validate();
-
-        const results = [];
-        await this.db.kanjiMeta.where('character').equals(kanji).each(row => {
-            if (titles.includes(row.dictionary)) {
-                results.push(Database.createMeta(row));
-            }
-        });
-
-        return results;
     }
 
     async findKanjiMetaBulk(kanjiList, titles) {

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -64,11 +64,10 @@ class Database {
         const promises = [];
         const visited = {};
         const results = [];
-        const createResult = Database.createTerm;
         const processRow = (row, index) => {
             if (titles.includes(row.dictionary) && !visited.hasOwnProperty(row.id)) {
                 visited[row.id] = true;
-                results.push(createResult(row, index));
+                results.push(Database.createTerm(row, index));
             }
         };
 
@@ -122,10 +121,9 @@ class Database {
 
         const promises = [];
         const results = [];
-        const createResult = Database.createTermMeta;
         const processRow = (row, index) => {
             if (titles.includes(row.dictionary)) {
-                results.push(createResult(row, index));
+                results.push(Database.createTermMeta(row, index));
             }
         };
 

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -20,7 +20,6 @@
 class Database {
     constructor() {
         this.db = null;
-        this.tagCache = {};
     }
 
     async prepare() {
@@ -53,7 +52,6 @@ class Database {
         this.db.close();
         await this.db.delete();
         this.db = null;
-        this.tagCache = {};
 
         await this.prepare();
     }
@@ -180,19 +178,8 @@ class Database {
         return results;
     }
 
-    findTagForTitleCached(name, title) {
-        if (this.tagCache.hasOwnProperty(title)) {
-            const cache = this.tagCache[title];
-            if (cache.hasOwnProperty(name)) {
-                return cache[name];
-            }
-        }
-    }
-
     async findTagForTitle(name, title) {
         this.validate();
-
-        const cache = (this.tagCache.hasOwnProperty(title) ? this.tagCache[title] : (this.tagCache[title] = {}));
 
         let result = null;
         await this.db.tagMeta.where('name').equals(name).each(row => {
@@ -200,8 +187,6 @@ class Database {
                 result = row;
             }
         });
-
-        cache[name] = result;
 
         return result;
     }

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -58,19 +58,6 @@ class Database {
         await this.prepare();
     }
 
-    async findTerms(term, titles) {
-        this.validate();
-
-        const results = [];
-        await this.db.terms.where('expression').equals(term).or('reading').equals(term).each(row => {
-            if (titles.includes(row.dictionary)) {
-                results.push(Database.createTerm(row));
-            }
-        });
-
-        return results;
-    }
-
     async findTermsBulk(terms, titles) {
         const promises = [];
         const visited = {};
@@ -122,23 +109,6 @@ class Database {
         await this.db.terms.where('sequence').equals(sequence).each(row => {
             if (row.dictionary === mainDictionary) {
                 results.push(Database.createTerm(row));
-            }
-        });
-
-        return results;
-    }
-
-    async findTermMeta(term, titles) {
-        this.validate();
-
-        const results = [];
-        await this.db.termMeta.where('expression').equals(term).each(row => {
-            if (titles.includes(row.dictionary)) {
-                results.push({
-                    mode: row.mode,
-                    data: row.data,
-                    dictionary: row.dictionary
-                });
             }
         });
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -70,29 +70,34 @@ class Translator {
     }
 
     async getMergedSecondarySearchResults(text, expressionsMap, secondarySearchTitles) {
-        const secondarySearchResults = [];
         if (secondarySearchTitles.length === 0) {
-            return secondarySearchResults;
+            return [];
         }
 
+        const expressionList = [];
+        const readingList = [];
         for (const expression of expressionsMap.keys()) {
-            if (expression === text) {
-                continue;
-            }
-
+            if (expression === text) { continue; }
             for (const reading of expressionsMap.get(expression).keys()) {
-                for (const definition of await this.database.findTermsExact(expression, reading, secondarySearchTitles)) {
-                    const definitionTags = await this.expandTags(definition.definitionTags, definition.dictionary);
-                    definitionTags.push(dictTagBuildSource(definition.dictionary));
-                    definition.definitionTags = definitionTags;
-                    const termTags = await this.expandTags(definition.termTags, definition.dictionary);
-                    definition.termTags = termTags;
-                    secondarySearchResults.push(definition);
-                }
+                expressionList.push(expression);
+                readingList.push(reading);
             }
         }
 
-        return secondarySearchResults;
+        const definitions = await this.database.findTermsExactBulk(expressionList, readingList, secondarySearchTitles);
+        for (const definition of definitions) {
+            const definitionTags = await this.expandTags(definition.definitionTags, definition.dictionary);
+            definitionTags.push(dictTagBuildSource(definition.dictionary));
+            definition.definitionTags = definitionTags;
+            const termTags = await this.expandTags(definition.termTags, definition.dictionary);
+            definition.termTags = termTags;
+        }
+
+        if (definitions.length > 1) {
+            definitions.sort((a, b) => a.index - b.index);
+        }
+
+        return definitions;
     }
 
     async getMergedDefinition(text, dictionaries, sequencedDefinition, defaultDefinitions, secondarySearchTitles, mergedByTermIndices) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -135,19 +135,12 @@ class Translator {
         for (const expression of result.expressions.keys()) {
             for (const reading of result.expressions.get(expression).keys()) {
                 const termTags = result.expressions.get(expression).get(reading);
+                const score = termTags.map(tag => tag.score).reduce((p, v) => p + v, 0);
                 expressions.push({
                     expression: expression,
                     reading: reading,
                     termTags: dictTagsSort(termTags),
-                    termFrequency: (score => {
-                        if (score > 0) {
-                            return 'popular';
-                        } else if (score < 0) {
-                            return 'rare';
-                        } else {
-                            return 'normal';
-                        }
-                    })(termTags.map(tag => tag.score).reduce((p, v) => p + v, 0))
+                    termFrequency: Translator.scoreToTermFrequency(score)
                 });
             }
         }
@@ -468,6 +461,16 @@ class Translator {
         }
 
         return tagMetaList;
+    }
+
+    static scoreToTermFrequency(score) {
+        if (score > 0) {
+            return 'popular';
+        } else if (score < 0) {
+            return 'rare';
+        } else {
+            return 'normal';
+        }
     }
 
     static getNameBase(name) {

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -89,7 +89,7 @@ function utilAnkiGetModelFieldNames(modelName) {
 }
 
 function utilDatabasePurge() {
-    return utilBackend().translator.database.purge();
+    return utilBackend().translator.purgeDatabase();
 }
 
 async function utilDatabaseImport(data, progress, exceptions) {


### PR DESCRIPTION
Optimization of the remainder of the database calls. Completes the database read optimizations started in #229.

* Bulk operations are now used for all database reads, all of which use native IndexedDB APIs for maximum speed.
* Reduced complexity of ```Translator.findTermsMerged```'s function body by creating some helper functions which do portions of the work. This should also make it easier for Javascript compilers to optimize (typically they're bad at dealing with very large functions).
* Moved the tag cache out of ```Database``` and into ```Translator```. This makes it so that ```Database``` doesn't have to worry about caching, only requesting and updating data.
* A few other simplifications to ```sort``` calls and other inline functions.

This change mostly affects the speed when the result grouping method is set to "Group results by main dictionary entry".

#189