### PR TITLE
Proper spacing for Anki in {furigana-plain}

### DIFF
--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -49,13 +49,13 @@ function handlebarsFuriganaPlain(options) {
     let result = '';
     for (const seg of segs) {
         if (seg.furigana) {
-            result += `${seg.text}[${seg.furigana}]`;
+            result += ` ${seg.text}[${seg.furigana}]`;
         } else {
             result += seg.text;
         }
     }
 
-    return result;
+    return result.trimLeft();
 }
 
 function handlebarsKanjiLinks(options) {


### PR DESCRIPTION
This should fix #264 

Note it does not address broken segmentation, just representation within Anki itself to work properly.

I've tested these changes locally and it works fine for all cases:

```js
> plainFurigana('お祝い', 'おいわい')
"お 祝[いわ]い"
> plainFurigana('食べ物', 'たべもの')
"食[た]べ 物[もの]"
> plainFurigana('林業試験場', 'りんぎょうしけんじょう')
"林業試験場[りんぎょうしけんじょう]"
> plainFurigana('美味しい', 'おいしい')
"美味[おい]しい"
> plainFurigana('試し斬り', 'ためしぎり')
"試[ため]し 斬[ぎ]り"
> plainFurigana('飼い犬', 'かいいぬ')
"飼[かい]い 犬[ぬ]"
```

The last one has improper segmentation but it's beyond the scope of this PR.