### PR TITLE
Refactoring of touch events

### DIFF
--- a/ext/bg/js/settings-popup-preview.js
+++ b/ext/bg/js/settings-popup-preview.js
@@ -158,9 +158,14 @@ class SettingsPopupPreview {
         const range = document.createRange();
         range.selectNode(textNode);
         const source = new TextSourceRange(range, range.toString(), null);
+        if (source === null) { return; }
 
         this.frontend.textSourceLast = null;
-        await this.frontend.searchSource(source, 'script');
+        try {
+            await this.frontend.searchSource(source, 'script');
+        } finally {
+            source.cleanup();
+        }
         await this.frontend.lastShowPromise;
 
         if (this.frontend.popup.isVisible()) {

--- a/ext/bg/js/settings-popup-preview.js
+++ b/ext/bg/js/settings-popup-preview.js
@@ -160,7 +160,6 @@ class SettingsPopupPreview {
         const source = new TextSourceRange(range, range.toString(), null);
         if (source === null) { return; }
 
-        this.frontend.textSourceLast = null;
         try {
             await this.frontend.searchSource(source, 'script');
         } finally {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -32,10 +32,10 @@ class Frontend {
         };
 
         this.primaryTouchIdentifier = null;
-        this.contextMenuPrevent = false;
-        this.mouseDownPrevent = false;
-        this.clickPrevent = false;
-        this.scrollPrevent = false;
+        this.preventNextContextMenu = false;
+        this.preventNextMouseDown = false;
+        this.preventNextClick = false;
+        this.preventScroll = false;
 
         this.enabled = false;
         this.eventListeners = [];
@@ -111,9 +111,9 @@ class Frontend {
     }
 
     onMouseDown(e) {
-        if (this.mouseDownPrevent) {
-            this.mouseDownPrevent = false;
-            this.clickPrevent = true;
+        if (this.preventNextMouseDown) {
+            this.preventNextMouseDown = false;
+            this.preventNextClick = true;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -147,8 +147,8 @@ class Frontend {
     }
 
     onClick(e) {
-        if (this.clickPrevent) {
-            this.clickPrevent = false;
+        if (this.preventNextClick) {
+            this.preventNextClick = false;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -185,7 +185,7 @@ class Frontend {
     }
 
     onTouchMove(e) {
-        if (!this.scrollPrevent || !e.cancelable || this.primaryTouchIdentifier === null) {
+        if (!this.preventScroll || !e.cancelable || this.primaryTouchIdentifier === null) {
             return;
         }
 
@@ -202,8 +202,8 @@ class Frontend {
     }
 
     onContextMenu(e) {
-        if (this.contextMenuPrevent) {
-            this.contextMenuPrevent = false;
+        if (this.preventNextContextMenu) {
+            this.preventNextContextMenu = false;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -434,19 +434,19 @@ class Frontend {
     setPrimaryTouch(touch) {
         if (touch === null) {
             this.primaryTouchIdentifier = null;
-            this.scrollPrevent = false;
-            this.clickPrevent = false;
+            this.preventScroll = false;
+            this.preventNextClick = false;
             // Don't revert context menu and mouse down prevention,
             // since these events can occur after the touch has ended.
-            // this.contextMenuPrevent = false;
-            // this.mouseDownPrevent = false;
+            // this.preventNextContextMenu = false;
+            // this.preventNextMouseDown = false;
         }
         else {
             this.primaryTouchIdentifier = touch.identifier;
-            this.scrollPrevent = false;
-            this.contextMenuPrevent = false;
-            this.mouseDownPrevent = false;
-            this.clickPrevent = false;
+            this.preventScroll = false;
+            this.preventNextContextMenu = false;
+            this.preventNextMouseDown = false;
+            this.preventNextClick = false;
 
             const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
 
@@ -460,9 +460,9 @@ class Frontend {
                     return;
                 }
 
-                this.scrollPrevent = true;
-                this.contextMenuPrevent = true;
-                this.mouseDownPrevent = true;
+                this.preventScroll = true;
+                this.preventNextContextMenu = true;
+                this.preventNextMouseDown = true;
             });
         }
     }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -212,7 +212,7 @@ class Frontend {
         }
     }
 
-    onAfterSearch(newRange, cause, searched, success) {
+    onAfterSearch(newRange, cause) {
         if (cause === 'mouse') {
             return;
         }
@@ -335,16 +335,12 @@ class Frontend {
 
     async searchSource(textSource, cause) {
         let hideResults = false;
-        let searched = false;
-        let success = false;
 
         try {
             if (!this.textSourceLast || !this.textSourceLast.equals(textSource)) {
-                searched = true;
                 this.pendingLookup = true;
                 const focus = (cause === 'mouse');
                 hideResults = !await this.searchTerms(textSource, focus) && !await this.searchKanji(textSource, focus);
-                success = true;
             }
         } catch (e) {
             if (window.yomichan_orphaned) {
@@ -364,7 +360,7 @@ class Frontend {
             }
 
             this.pendingLookup = false;
-            this.onAfterSearch(this.textSourceLast, cause, searched, success);
+            this.onAfterSearch(this.textSourceLast, cause);
         }
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -119,8 +119,10 @@ class Frontend {
             return false;
         }
 
-        this.popupTimerClear();
-        this.searchClear(true);
+        if (e.button === 0) {
+            this.popupTimerClear();
+            this.searchClear(true);
+        }
     }
 
     onMouseOut(e) {
@@ -231,6 +233,10 @@ class Frontend {
         e.preventDefault(); // Disable scroll
     }
 
+    onAuxClick(e) {
+        this.preventNextContextMenu = false;
+    }
+
     onContextMenu(e) {
         if (this.preventNextContextMenu) {
             this.preventNextContextMenu = false;
@@ -278,6 +284,7 @@ class Frontend {
 
         if (this.options.scanning.touchInputEnabled) {
             this.addEventListener(window, 'click', this.onClick.bind(this));
+            this.addEventListener(window, 'auxclick', this.onAuxClick.bind(this));
             this.addEventListener(window, 'touchstart', this.onTouchStart.bind(this));
             this.addEventListener(window, 'touchend', this.onTouchEnd.bind(this));
             this.addEventListener(window, 'touchcancel', this.onTouchCancel.bind(this));

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -156,10 +156,7 @@ class Frontend {
     }
 
     onTouchStart(e) {
-        if (
-            this.primaryTouchIdentifier !== null ||
-            e.changedTouches.length === 0
-        ) {
+        if (this.primaryTouchIdentifier !== null || e.changedTouches.length === 0) {
             return;
         }
 
@@ -175,7 +172,9 @@ class Frontend {
 
         this.primaryTouchIdentifier = primaryTouch.identifier;
 
-        if (this.pendingLookup) { return; }
+        if (this.pendingLookup) {
+            return;
+        }
 
         const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -99,11 +99,7 @@ class Frontend {
         }
 
         const search = async () => {
-            try {
-                await this.searchAt(e.clientX, e.clientY, 'mouse');
-            } catch (e) {
-                this.onError(e);
-            }
+            await this.searchAt(e.clientX, e.clientY, 'mouse');
         };
 
         if (scanningModifier === 'none') {
@@ -314,12 +310,16 @@ class Frontend {
     }
 
     async searchAt(x, y, cause) {
-        if (this.pendingLookup || await this.popup.containsPoint(x, y)) {
-            return;
-        }
+        try {
+            if (this.pendingLookup || await this.popup.containsPoint(x, y)) {
+                return;
+            }
 
-        const textSource = docRangeFromPoint(x, y, this.options);
-        return await this.searchSource(textSource, cause);
+            const textSource = docRangeFromPoint(x, y, this.options);
+            return await this.searchSource(textSource, cause);
+        } catch (e) {
+            this.onError(e);
+        }
     }
 
     async searchSource(textSource, cause) {
@@ -503,15 +503,7 @@ class Frontend {
             return;
         }
 
-        const search = async () => {
-            try {
-                await this.searchAt(x, y, cause);
-            } catch (e) {
-                this.onError(e);
-            }
-        };
-
-        search();
+        this.searchAt(x, y, cause);
     }
 
     selectionContainsPoint(selection, x, y) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -197,7 +197,7 @@ class Frontend {
         }
 
         const touch = touches[index];
-        this.searchFromTouch(touch.clientX, touch.clientY, 'touchMove');
+        this.searchAt(touch.clientX, touch.clientY, 'touchMove');
 
         e.preventDefault(); // Disable scroll
     }
@@ -293,6 +293,8 @@ class Frontend {
 
     async searchAt(x, y, cause) {
         try {
+            this.popupTimerClear();
+
             if (this.pendingLookup || await this.popup.containsPoint(x, y)) {
                 return;
             }
@@ -449,7 +451,7 @@ class Frontend {
 
             const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
 
-            this.searchFromTouch(touch.clientX, touch.clientY, 'touchStart')
+            this.searchAt(touch.clientX, touch.clientY, 'touchStart')
             .then(() => {
                 if (
                     this.pendingLookup ||
@@ -480,16 +482,6 @@ class Frontend {
 
     setClickPrevent(value) {
         this.clickPrevent = value;
-    }
-
-    searchFromTouch(x, y, cause) {
-        this.popupTimerClear();
-
-        if (this.pendingLookup) {
-            return Promise.resolve();
-        }
-
-        return this.searchAt(x, y, cause);
     }
 
     selectionContainsPoint(selection, x, y) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -168,7 +168,28 @@ class Frontend {
             return;
         }
 
-        this.setPrimaryTouch(primaryTouch);
+        this.primaryTouchIdentifier = primaryTouch.identifier;
+        this.preventScroll = false;
+        this.preventNextContextMenu = false;
+        this.preventNextMouseDown = false;
+        this.preventNextClick = false;
+
+        const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
+
+        this.searchAt(primaryTouch.clientX, primaryTouch.clientY, 'touchStart')
+        .then(() => {
+            if (
+                this.pendingLookup ||
+                this.textSourceCurrent === null ||
+                this.textSourceCurrent.equals(textSourceCurrentPrevious)
+            ) {
+                return;
+            }
+
+            this.preventScroll = true;
+            this.preventNextContextMenu = true;
+            this.preventNextMouseDown = true;
+        });
     }
 
     onTouchEnd(e) {
@@ -179,7 +200,13 @@ class Frontend {
             return;
         }
 
-        this.setPrimaryTouch(null);
+        this.primaryTouchIdentifier = null;
+        this.preventScroll = false;
+        this.preventNextClick = false;
+        // Don't revert context menu and mouse down prevention,
+        // since these events can occur after the touch has ended.
+        // this.preventNextContextMenu = false;
+        // this.preventNextMouseDown = false;
     }
 
     onTouchCancel(e) {
@@ -417,42 +444,6 @@ class Frontend {
             }
         }
         return -1;
-    }
-
-    setPrimaryTouch(touch) {
-        if (touch === null) {
-            this.primaryTouchIdentifier = null;
-            this.preventScroll = false;
-            this.preventNextClick = false;
-            // Don't revert context menu and mouse down prevention,
-            // since these events can occur after the touch has ended.
-            // this.preventNextContextMenu = false;
-            // this.preventNextMouseDown = false;
-        }
-        else {
-            this.primaryTouchIdentifier = touch.identifier;
-            this.preventScroll = false;
-            this.preventNextContextMenu = false;
-            this.preventNextMouseDown = false;
-            this.preventNextClick = false;
-
-            const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
-
-            this.searchAt(touch.clientX, touch.clientY, 'touchStart')
-            .then(() => {
-                if (
-                    this.pendingLookup ||
-                    this.textSourceCurrent === null ||
-                    this.textSourceCurrent.equals(textSourceCurrentPrevious)
-                ) {
-                    return;
-                }
-
-                this.preventScroll = true;
-                this.preventNextContextMenu = true;
-                this.preventNextMouseDown = true;
-            });
-        }
     }
 
     static selectionContainsPoint(selection, x, y) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -156,28 +156,30 @@ class Frontend {
     }
 
     onTouchStart(e) {
-        if (this.primaryTouchIdentifier !== null && this.getIndexOfTouch(e.touches, this.primaryTouchIdentifier) >= 0) {
+        if (
+            this.primaryTouchIdentifier !== null ||
+            e.changedTouches.length === 0
+        ) {
             return;
         }
 
-        let touch = this.getPrimaryTouch(e.changedTouches);
-        if (Frontend.selectionContainsPoint(window.getSelection(), touch.clientX, touch.clientY)) {
-            touch = null;
+        const primaryTouch = e.changedTouches[0];
+        if (Frontend.selectionContainsPoint(window.getSelection(), primaryTouch.clientX, primaryTouch.clientY)) {
+            return;
         }
 
-        this.setPrimaryTouch(touch);
+        this.setPrimaryTouch(primaryTouch);
     }
 
     onTouchEnd(e) {
-        if (this.primaryTouchIdentifier === null) {
+        if (
+            this.primaryTouchIdentifier === null ||
+            this.getIndexOfTouch(e.changedTouches, this.primaryTouchIdentifier) < 0
+        ) {
             return;
         }
 
-        if (this.getIndexOfTouch(e.changedTouches, this.primaryTouchIdentifier) < 0) {
-            return;
-        }
-
-        this.setPrimaryTouch(this.getPrimaryTouch(this.excludeTouches(e.touches, e.changedTouches)));
+        this.setPrimaryTouch(null);
     }
 
     onTouchCancel(e) {
@@ -195,8 +197,8 @@ class Frontend {
             return;
         }
 
-        const touch = touches[index];
-        this.searchAt(touch.clientX, touch.clientY, 'touchMove');
+        const primaryTouch = touches[index];
+        this.searchAt(primaryTouch.clientX, primaryTouch.clientY, 'touchMove');
 
         e.preventDefault(); // Disable scroll
     }
@@ -407,10 +409,6 @@ class Frontend {
         }
     }
 
-    getPrimaryTouch(touchList) {
-        return touchList.length > 0 ? touchList[0] : null;
-    }
-
     getIndexOfTouch(touchList, identifier) {
         for (let i in touchList) {
             let t = touchList[i];
@@ -419,16 +417,6 @@ class Frontend {
             }
         }
         return -1;
-    }
-
-    excludeTouches(touchList, excludeTouchList) {
-        const result = [];
-        for (let r of touchList) {
-            if (this.getIndexOfTouch(excludeTouchList, r.identifier) < 0) {
-                result.push(r);
-            }
-        }
-        return result;
     }
 
     setPrimaryTouch(touch) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -33,7 +33,6 @@ class Frontend {
 
         this.primaryTouchIdentifier = null;
         this.contextMenuPrevent = false;
-        this.contextMenuPreviousRange = null;
         this.mouseDownPrevent = false;
         this.clickPrevent = false;
         this.scrollPrevent = false;
@@ -435,7 +434,6 @@ class Frontend {
     setPrimaryTouch(touch) {
         if (touch === null) {
             this.primaryTouchIdentifier = null;
-            this.contextMenuPreviousRange = null;
             this.scrollPrevent = false;
             this.setContextMenuPrevent(false, true);
             this.setMouseDownPrevent(false, true);
@@ -443,7 +441,6 @@ class Frontend {
         }
         else {
             this.primaryTouchIdentifier = touch.identifier;
-            this.contextMenuPreviousRange = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
             this.scrollPrevent = false;
             this.setContextMenuPrevent(false, false);
             this.setMouseDownPrevent(false, false);

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -319,7 +319,10 @@ class Frontend {
             }
 
             const textSource = docRangeFromPoint(x, y, this.options);
-            if (textSource === null) {
+            if (
+                textSource === null ||
+                (this.textSourceLast !== null && this.textSourceLast.equals(textSource))
+            ) {
                 return;
             }
 
@@ -337,11 +340,9 @@ class Frontend {
         let hideResults = false;
 
         try {
-            if (!this.textSourceLast || !this.textSourceLast.equals(textSource)) {
-                this.pendingLookup = true;
-                const focus = (cause === 'mouse');
-                hideResults = !await this.searchTerms(textSource, focus) && !await this.searchKanji(textSource, focus);
-            }
+            this.pendingLookup = true;
+            const focus = (cause === 'mouse');
+            hideResults = !await this.searchTerms(textSource, focus) && !await this.searchKanji(textSource, focus);
         } catch (e) {
             if (window.yomichan_orphaned) {
                 if (textSource && this.options.scanning.modifier !== 'none') {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -129,28 +129,22 @@ class Frontend {
         this.popupTimerClear();
     }
 
-    onWindowMessage(e) {
-        const action = e.data;
-        const handlers = Frontend.windowMessageHandlers;
-        if (handlers.hasOwnProperty(action)) {
-            const handler = handlers[action];
-            handler(this);
-        }
-    }
-
-    async onResize() {
-        if (this.textSourceCurrent !== null && await this.popup.isVisibleAsync()) {
-            const textSource = this.textSourceCurrent;
-            this.lastShowPromise = this.popup.showContent(
-                textSource.getRect(),
-                textSource.getWritingMode()
-            );
-        }
-    }
-
     onClick(e) {
         if (this.preventNextClick) {
             this.preventNextClick = false;
+            e.preventDefault();
+            e.stopPropagation();
+            return false;
+        }
+    }
+
+    onAuxClick(e) {
+        this.preventNextContextMenu = false;
+    }
+
+    onContextMenu(e) {
+        if (this.preventNextContextMenu) {
+            this.preventNextContextMenu = false;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -233,16 +227,22 @@ class Frontend {
         e.preventDefault(); // Disable scroll
     }
 
-    onAuxClick(e) {
-        this.preventNextContextMenu = false;
+    async onResize() {
+        if (this.textSourceCurrent !== null && await this.popup.isVisibleAsync()) {
+            const textSource = this.textSourceCurrent;
+            this.lastShowPromise = this.popup.showContent(
+                textSource.getRect(),
+                textSource.getWritingMode()
+            );
+        }
     }
 
-    onContextMenu(e) {
-        if (this.preventNextContextMenu) {
-            this.preventNextContextMenu = false;
-            e.preventDefault();
-            e.stopPropagation();
-            return false;
+    onWindowMessage(e) {
+        const action = e.data;
+        const handlers = Frontend.windowMessageHandlers;
+        if (handlers.hasOwnProperty(action)) {
+            const handler = handlers[action];
+            handler(this);
         }
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -319,19 +319,27 @@ class Frontend {
             }
 
             const textSource = docRangeFromPoint(x, y, this.options);
-            return await this.searchSource(textSource, cause);
+            if (textSource === null) {
+                return;
+            }
+
+            try {
+                return await this.searchSource(textSource, cause);
+            } finally {
+                textSource.cleanup();
+            }
         } catch (e) {
             this.onError(e);
         }
     }
 
     async searchSource(textSource, cause) {
-        let hideResults = textSource === null;
+        let hideResults = false;
         let searched = false;
         let success = false;
 
         try {
-            if (!hideResults && (!this.textSourceLast || !this.textSourceLast.equals(textSource))) {
+            if (!this.textSourceLast || !this.textSourceLast.equals(textSource)) {
                 searched = true;
                 this.pendingLookup = true;
                 const focus = (cause === 'mouse');
@@ -351,9 +359,6 @@ class Frontend {
                 this.onError(e);
             }
         } finally {
-            if (textSource !== null) {
-                textSource.cleanup();
-            }
             if (hideResults && this.options.scanning.autoHideResults) {
                 this.searchClear(true);
             }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -163,16 +163,17 @@ class Frontend {
             return;
         }
 
+        this.preventScroll = false;
+        this.preventNextContextMenu = false;
+        this.preventNextMouseDown = false;
+        this.preventNextClick = false;
+
         const primaryTouch = e.changedTouches[0];
         if (Frontend.selectionContainsPoint(window.getSelection(), primaryTouch.clientX, primaryTouch.clientY)) {
             return;
         }
 
         this.primaryTouchIdentifier = primaryTouch.identifier;
-        this.preventScroll = false;
-        this.preventNextContextMenu = false;
-        this.preventNextMouseDown = false;
-        this.preventNextClick = false;
 
         if (this.pendingLookup) { return; }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -161,7 +161,7 @@ class Frontend {
         }
 
         let touch = this.getPrimaryTouch(e.changedTouches);
-        if (this.selectionContainsPoint(window.getSelection(), touch.clientX, touch.clientY)) {
+        if (Frontend.selectionContainsPoint(window.getSelection(), touch.clientX, touch.clientY)) {
             touch = null;
         }
 
@@ -467,7 +467,7 @@ class Frontend {
         }
     }
 
-    selectionContainsPoint(selection, x, y) {
+    static selectionContainsPoint(selection, x, y) {
         for (let i = 0; i < selection.rangeCount; ++i) {
             const range = selection.getRangeAt(i);
             for (const rect of range.getClientRects()) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -112,8 +112,8 @@ class Frontend {
 
     onMouseDown(e) {
         if (this.mouseDownPrevent) {
-            this.setMouseDownPrevent(false, false);
-            this.setClickPrevent(true);
+            this.mouseDownPrevent = false;
+            this.clickPrevent = true;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -148,7 +148,7 @@ class Frontend {
 
     onClick(e) {
         if (this.clickPrevent) {
-            this.setClickPrevent(false);
+            this.clickPrevent = false;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -203,7 +203,7 @@ class Frontend {
 
     onContextMenu(e) {
         if (this.contextMenuPrevent) {
-            this.setContextMenuPrevent(false, false);
+            this.contextMenuPrevent = false;
             e.preventDefault();
             e.stopPropagation();
             return false;
@@ -435,16 +435,18 @@ class Frontend {
         if (touch === null) {
             this.primaryTouchIdentifier = null;
             this.scrollPrevent = false;
-            this.setContextMenuPrevent(false, true);
-            this.setMouseDownPrevent(false, true);
-            this.setClickPrevent(false);
+            this.clickPrevent = false;
+            // Don't revert context menu and mouse down prevention,
+            // since these events can occur after the touch has ended.
+            // this.contextMenuPrevent = false;
+            // this.mouseDownPrevent = false;
         }
         else {
             this.primaryTouchIdentifier = touch.identifier;
             this.scrollPrevent = false;
-            this.setContextMenuPrevent(false, false);
-            this.setMouseDownPrevent(false, false);
-            this.setClickPrevent(false);
+            this.contextMenuPrevent = false;
+            this.mouseDownPrevent = false;
+            this.clickPrevent = false;
 
             const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
 
@@ -459,26 +461,10 @@ class Frontend {
                 }
 
                 this.scrollPrevent = true;
-                this.setContextMenuPrevent(true, false);
-                this.setMouseDownPrevent(true, false);
+                this.contextMenuPrevent = true;
+                this.mouseDownPrevent = true;
             });
         }
-    }
-
-    setContextMenuPrevent(value, delay) {
-        if (!delay) {
-            this.contextMenuPrevent = value;
-        }
-    }
-
-    setMouseDownPrevent(value, delay) {
-        if (!delay) {
-            this.mouseDownPrevent = value;
-        }
-    }
-
-    setClickPrevent(value) {
-        this.clickPrevent = value;
     }
 
     selectionContainsPoint(selection, x, y) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -174,12 +174,13 @@ class Frontend {
         this.preventNextMouseDown = false;
         this.preventNextClick = false;
 
+        if (this.pendingLookup) { return; }
+
         const textSourceCurrentPrevious = this.textSourceCurrent !== null ? this.textSourceCurrent.clone() : null;
 
         this.searchAt(primaryTouch.clientX, primaryTouch.clientY, 'touchStart')
         .then(() => {
             if (
-                this.pendingLookup ||
                 this.textSourceCurrent === null ||
                 this.textSourceCurrent.equals(textSourceCurrentPrevious)
             ) {

--- a/ext/mixed/js/extension.js
+++ b/ext/mixed/js/extension.js
@@ -95,3 +95,41 @@ if (EXTENSION_IS_BROWSER_EDGE) {
     // Edge does not have chrome defined.
     chrome = browser;
 }
+
+function promiseTimeout(delay, resolveValue) {
+    if (delay <= 0) {
+        return Promise.resolve(resolveValue);
+    }
+
+    let timer = null;
+    let promiseResolve = null;
+    let promiseReject = null;
+
+    const complete = (callback, value) => {
+        if (callback === null) { return; }
+        if (timer !== null) {
+            window.clearTimeout(timer);
+            timer = null;
+        }
+        promiseResolve = null;
+        promiseReject = null;
+        callback(value);
+    };
+
+    const resolve = (value) => complete(promiseResolve, value);
+    const reject = (value) => complete(promiseReject, value);
+
+    const promise = new Promise((resolve, reject) => {
+        promiseResolve = resolve;
+        promiseReject = reject;
+    });
+    timer = window.setTimeout(() => {
+        timer = null;
+        resolve(resolveValue);
+    }, delay);
+
+    promise.resolve = resolve;
+    promise.reject = reject;
+
+    return promise;
+}


### PR DESCRIPTION
This is the first set of changes necessary to support [pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events). This PR largely simplifies the logic and makes it easier to understand. There was previously a lot of extra code to handle edge cases which realistically won't happen (using two fingers to try to scan text), so this code has been simplified. Event prevention has also been simplified, and a few issues which would cause the context menu to not open have been fixed.

The only intentional behaviour difference is that right clicking will not close the popup; only a left click will do this. This is useful if a user wants to right click on the selected text to copy it or something.

Creating as a PR for tracking purposes. #267 