### PR TITLE
Remove Download check when resolving Audio data

### DIFF
--- a/ext/mixed/js/audio.js
+++ b/ext/mixed/js/audio.js
@@ -88,17 +88,13 @@ class TextToSpeechAudio {
 
 }
 
-function audioGetFromUrl(url, download) {
+function audioGetFromUrl(url, willDownload) {
     const tts = TextToSpeechAudio.createFromUri(url);
     if (tts !== null) {
-        if (download) {
-            throw new Error('Download not supported for text-to-speech');
+        if (willDownload) {
+            throw new Error('AnkiConnect does not support downloading text-to-speech audio.');
         }
         return Promise.resolve(tts);
-    }
-
-    if (download) {
-        return Promise.resolve(null);
     }
 
     return new Promise((resolve, reject) => {
@@ -115,7 +111,7 @@ function audioGetFromUrl(url, download) {
     });
 }
 
-async function audioGetFromSources(expression, sources, optionsContext, download, cache=null) {
+async function audioGetFromSources(expression, sources, optionsContext, willDownload, cache=null) {
     const key = `${expression.expression}:${expression.reading}`;
     if (cache !== null && cache.hasOwnProperty(expression)) {
         return cache[key];
@@ -129,7 +125,11 @@ async function audioGetFromSources(expression, sources, optionsContext, download
         }
 
         try {
-            const audio = await audioGetFromUrl(url, download);
+            const audio = await audioGetFromUrl(url, willDownload);
+            if (willDownload) {
+                // AnkiConnect handles downloading URLs into cards
+                audio = null
+            }
             const result = {audio, url, source};
             if (cache !== null) {
                 cache[key] = result;


### PR DESCRIPTION
There is a bug (seemingly unreported) in Yomichan where an Anki card
will not contain any audio if the JapanesePod101 audio source trumps
a secondary audio source (e.g. JapanesePod101-alternate) where
the jpod101 source can't find the word requested.

For example, そして has an audio entry in the alternate source but not
the standard source, so Anki cards created from そして won't have an
audio field set.

(Alternatively, there may be a bug in the jpod101 audioUrlBuilder,
because I've only noticed this problem with hiragana-only expressions.
JPod101 may not host those on the same url scheme any more.  I'm not
sure how to fix that, though, and the bug I'm addressing here does
still persist).

The reason this happens is that audioGetFromUrl uses downloaded audio
to effectively check for a 404 (by examining the audio duration), but
that check doesn't happen when an Anki card is being created (i.e.
"download" is set, which I've changed to "willDownload" here). So it happily
reports that the first URL it creates is the correct download URL, even if that
URL would have been passed over if listened to normally.

This change removes that check, but retains the will-download intent
information to prevent attempts to download tts data, which AnkiConnect
cannot do. I've also added a short explanation as to why the download
check happens where it does.

I think the unused audio object will get garbage collected since it's
not referenced again, but I've explicitly unset it as well.