### PR TITLE
Search page query parser

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -21,6 +21,7 @@
         <script src="/mixed/js/extension.js"></script>
 
         <script src="/bg/js/anki.js"></script>
+        <script src="/bg/js/mecab.js"></script>
         <script src="/bg/js/api.js"></script>
         <script src="/bg/js/audio.js"></script>
         <script src="/bg/js/backend-api-forwarder.js"></script>

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -92,12 +92,13 @@ async function apiTextParse(text, optionsContext) {
             const {expression, reading} = definitions[0];
             const source = text.slice(0, sourceLength);
             for (const {text, furigana} of jpDistributeFuriganaInflected(expression, reading, source)) {
-                // can't use 'furigana' in templates
-                term.push({text, reading: furigana});
+                const reading = jpConvertReading(text, furigana, options.parsing.readingMode);
+                term.push({text, reading});
             }
             text = text.slice(source.length);
         } else {
-            term.push({text: text[0]});
+            const reading = jpConvertReading(text[0], null, options.parsing.readingMode);
+            term.push({text: text[0], reading});
             text = text.slice(1);
         }
         results.push(term);
@@ -122,11 +123,12 @@ async function apiTextParseMecab(text, optionsContext) {
                         jpKatakanaToHiragana(reading),
                         source
                     )) {
-                        // can't use 'furigana' in templates
-                        term.push({text, reading: furigana});
+                        const reading = jpConvertReading(text, furigana, options.parsing.readingMode);
+                        term.push({text, reading});
                     }
                 } else {
-                    term.push({text: source});
+                    const reading = jpConvertReading(source, null, options.parsing.readingMode);
+                    term.push({text: source, reading});
                 }
                 result.push(term);
             }

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -86,7 +86,12 @@ async function apiTextParse(text, optionsContext) {
     const results = [];
     while (text.length > 0) {
         const term = [];
-        const [definitions, sourceLength] = await translator.findTerms(text, {}, options);
+        const [definitions, sourceLength] = await translator.findTermsInternal(
+            text.slice(0, options.scanning.length),
+            dictEnabledSet(options),
+            options.scanning.alphanumeric,
+            {}
+        );
         if (definitions.length > 0) {
             dictTermsSort(definitions);
             const {expression, reading} = definitions[0];

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -86,9 +86,9 @@ async function apiTextParse(text, optionsContext) {
     const results = [];
     while (text) {
         const term = [];
-        let [definitions, sourceLength] = await translator.findTerms(text, {}, options);
+        const [definitions, sourceLength] = await translator.findTerms(text, {}, options);
         if (definitions.length > 0) {
-            definitions = dictTermsSort(definitions);
+            dictTermsSort(definitions);
             const {expression, reading} = definitions[0];
             const source = text.slice(0, sourceLength);
             for (const {text, furigana} of jpDistributeFuriganaInflected(expression, reading, source)) {

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -84,7 +84,7 @@ async function apiTextParse(text, optionsContext) {
     const translator = utilBackend().translator;
 
     const results = [];
-    while (text) {
+    while (text.length > 0) {
         const term = [];
         const [definitions, sourceLength] = await translator.findTerms(text, {}, options);
         if (definitions.length > 0) {
@@ -116,7 +116,7 @@ async function apiTextParseMecab(text, optionsContext) {
         for (const parsedLine of rawResults[mecabName]) {
             for (const {expression, reading, source} of parsedLine) {
                 const term = [];
-                if (expression && reading) {
+                if (expression !== null && reading !== null) {
                     for (const {text, furigana} of jpDistributeFuriganaInflected(
                         expression,
                         jpKatakanaToHiragana(reading),

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -85,6 +85,7 @@ async function apiTextParse(text, optionsContext) {
 
     const results = [];
     while (text) {
+        const term = [];
         let [definitions, sourceLength] = await translator.findTerms(text, {}, options);
         if (definitions.length > 0) {
             definitions = dictTermsSort(definitions);
@@ -98,22 +99,23 @@ async function apiTextParse(text, optionsContext) {
             }
             const offset = source.length - stemLength;
 
-            for (const result of jpDistributeFurigana(
+            for (const {text, furigana} of jpDistributeFurigana(
                 source.slice(0, offset === 0 ? source.length : source.length - offset),
-                reading.slice(0, offset === 0 ? reading.length : source.length + (reading.length - expression.length) - offset)
+                reading.slice(0, offset === 0 ? reading.length : reading.length - expression.length + stemLength)
             )) {
-                results.push(result);
+                term.push({text, reading: furigana || ''});
             }
 
             if (stemLength !== source.length) {
-                results.push({text: source.slice(stemLength)});
+                term.push({text: source.slice(stemLength)});
             }
 
             text = text.slice(source.length);
         } else {
-            results.push({text: text[0]});
+            term.push({text: text[0]});
             text = text.slice(1);
         }
+        results.push(term);
     }
     return results;
 }

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -85,10 +85,11 @@ async function apiTextParse(text, optionsContext) {
 
     const results = [];
     while (text) {
-        let [definitions, length] = await translator.findTerms(text, {}, options);
+        let [definitions, sourceLength] = await translator.findTerms(text, {}, options);
         if (definitions.length > 0) {
             definitions = dictTermsSort(definitions);
-            const {expression, source, reading} = definitions[0];
+            const {expression, reading} = definitions[0];
+            const source = text.slice(0, sourceLength);
 
             let stemLength = 0;
             const shortest = Math.min(source.length, expression.length);

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -90,9 +90,10 @@ async function apiTextParse(text, optionsContext) {
             definitions = dictTermsSort(definitions);
             const {expression, source, reading} = definitions[0];
 
-            let stemLength = source.length;
-            while (source[stemLength - 1] !== expression[stemLength - 1]) {
-                --stemLength;
+            let stemLength = 0;
+            const shortest = Math.min(source.length, expression.length);
+            while (stemLength < shortest && source[stemLength] === expression[stemLength]) {
+                ++stemLength;
             }
             const offset = source.length - stemLength;
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -180,6 +180,7 @@ Backend.messageHandlers = {
     optionsSet: ({changedOptions, optionsContext, source}) => apiOptionsSet(changedOptions, optionsContext, source),
     kanjiFind: ({text, optionsContext}) => apiKanjiFind(text, optionsContext),
     termsFind: ({text, details, optionsContext}) => apiTermsFind(text, details, optionsContext),
+    textParse: ({text, optionsContext}) => apiTextParse(text, optionsContext),
     definitionAdd: ({definition, mode, context, optionsContext}) => apiDefinitionAdd(definition, mode, context, optionsContext),
     definitionsAddable: ({definitions, modes, optionsContext}) => apiDefinitionsAddable(definitions, modes, optionsContext),
     noteView: ({noteId}) => apiNoteView(noteId),

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -101,6 +101,8 @@ class Backend {
 
         if (options.parsing.enableMecabParser) {
             this.mecab.startListener();
+        } else {
+            this.mecab.stopListener();
         }
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -98,6 +98,10 @@ class Backend {
         }
 
         this.anki = options.anki.enable ? new AnkiConnect(options.anki.server) : new AnkiNull();
+
+        if (options.parsing.enableMecabParser) {
+            this.mecab.startListener();
+        }
     }
 
     async getFullOptions() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -21,6 +21,7 @@ class Backend {
     constructor() {
         this.translator = new Translator();
         this.anki = new AnkiNull();
+        this.mecab = new Mecab();
         this.options = null;
         this.optionsContext = {
             depth: 0,
@@ -181,6 +182,7 @@ Backend.messageHandlers = {
     kanjiFind: ({text, optionsContext}) => apiKanjiFind(text, optionsContext),
     termsFind: ({text, details, optionsContext}) => apiTermsFind(text, details, optionsContext),
     textParse: ({text, optionsContext}) => apiTextParse(text, optionsContext),
+    textParseMecab: ({text, optionsContext}) => apiTextParseMecab(text, optionsContext),
     definitionAdd: ({definition, mode, context, optionsContext}) => apiDefinitionAdd(definition, mode, context, optionsContext),
     definitionsAddable: ({definitions, modes, optionsContext}) => apiDefinitionsAddable(definitions, modes, optionsContext),
     noteView: ({noteId}) => apiNoteView(noteId),

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -60,4 +60,4 @@ class Mecab {
     }
 }
 
-Mecab.timeout = 1000;
+Mecab.timeout = 5000;

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -34,15 +34,7 @@ class Mecab {
     startListener() {
         if (this.port !== null) { return; }
         this.port = chrome.runtime.connectNative('yomichan_mecab');
-        this.port.onMessage.addListener((message) => {
-            const {sequence, data} = message;
-            const {callback, timer} = this.listeners[sequence] || {};
-            if (timer) {
-                clearTimeout(timer);
-                delete this.listeners[sequence];
-                callback(data);
-            }
-        });
+        this.port.onMessage.addListener(this.onNativeMessage.bind(this));
     }
 
     stopListener() {
@@ -51,6 +43,15 @@ class Mecab {
         this.port = null;
         this.listeners = {};
         this.sequence = 0;
+    }
+
+    onNativeMessage({sequence, data}) {
+        if (this.listeners.hasOwnProperty(sequence)) {
+            const {callback, timer} = this.listeners[sequence];
+            clearTimeout(timer);
+            callback(data);
+            delete this.listeners[sequence];
+        }
     }
 
     invoke(action, params) {

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -25,7 +25,7 @@ class Mecab {
     }
 
     onError(error) {
-        logError(error, true);
+        logError(error, false);
     }
 
     async checkVersion() {

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -70,7 +70,7 @@ class Mecab {
 
     invoke(action, params) {
         if (this.port === null) {
-            return {};
+            return Promise.resolve({});
         }
         return new Promise((resolve, reject) => {
             const sequence = this.sequence++;

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -58,12 +58,10 @@ class Mecab {
             const sequence = this.sequence++;
 
             this.listeners[sequence] = {
-                callback: (data) => {
-                    resolve(data);
-                },
+                callback: resolve,
                 timer: setTimeout(() => {
                     delete this.listeners[sequence];
-                    reject(`Mecab invoke timed out in ${Mecab.timeout} ms`);
+                    reject(new Error(`Mecab invoke timed out in ${Mecab.timeout} ms`));
                 }, Mecab.timeout)
             }
 

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -52,7 +52,7 @@ class Mecab {
                 timer: setTimeout(() => {
                     delete this.listeners[sequence];
                     reject(`Mecab invoke timed out in ${Mecab.timeout} ms`);
-                }, 1000)
+                }, Mecab.timeout)
             }
 
             this.port.postMessage({action, params, sequence});

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -29,7 +29,7 @@ class Mecab {
     }
 
     startListener() {
-        this.port = chrome.runtime.connectNative('mecab');
+        this.port = chrome.runtime.connectNative('yomichan_mecab');
         this.port.onMessage.addListener((message) => {
             const {sequence, data} = message;
             const {callback, timer} = this.listeners[sequence] || {};

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -19,16 +19,20 @@
 
 class Mecab {
     constructor() {
+        this.port = null;
         this.listeners = {};
         this.sequence = 0;
-        this.startListener();
     }
 
     async parseText(text) {
+        if (this.port === null) {
+            return {};
+        }
         return await this.invoke('parse_text', {text});
     }
 
     startListener() {
+        if (this.port !== null) { return; }
         this.port = chrome.runtime.connectNative('yomichan_mecab');
         this.port.onMessage.addListener((message) => {
             const {sequence, data} = message;
@@ -39,6 +43,14 @@ class Mecab {
                 callback(data);
             }
         });
+    }
+
+    stopListener() {
+        if (this.port === null) { return; }
+        this.port.disconnect();
+        this.port = null;
+        this.listeners = {};
+        this.sequence = 0;
     }
 
     invoke(action, params) {

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class Mecab {
+    constructor() {
+        this.listeners = {};
+        this.sequence = 0;
+        this.startListener();
+    }
+
+    async parseText(text) {
+        return await this.invoke('parse_text', {text});
+    }
+
+    startListener() {
+        this.port = chrome.runtime.connectNative('mecab');
+        this.port.onMessage.addListener((message) => {
+            const {sequence, data} = message;
+            const {callback, timer} = this.listeners[sequence] || {};
+            if (timer) {
+                clearTimeout(timer);
+                delete this.listeners[sequence];
+                callback(data);
+            }
+        });
+    }
+
+    invoke(action, params) {
+        return new Promise((resolve, reject) => {
+            const sequence = this.sequence++;
+
+            this.listeners[sequence] = {
+                callback: (data) => {
+                    resolve(data);
+                },
+                timer: setTimeout(() => {
+                    delete this.listeners[sequence];
+                    reject(`Mecab invoke timed out in ${Mecab.timeout} ms`);
+                }, 1000)
+            }
+
+            this.port.postMessage({action, params, sequence});
+        });
+    }
+}
+
+Mecab.timeout = 1000;

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -314,7 +314,8 @@ function profileOptionsCreateDefaults() {
         parsing: {
             enableScanningParser: true,
             enableMecabParser: false,
-            selectedParser: null
+            selectedParser: null,
+            readingMode: 'hiragana'
         },
 
         anki: {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -314,7 +314,7 @@ function profileOptionsCreateDefaults() {
         parsing: {
             enableScanningParser: true,
             enableMecabParser: false,
-            selectedParser = null
+            selectedParser: null
         },
 
         anki: {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -313,7 +313,8 @@ function profileOptionsCreateDefaults() {
 
         parsing: {
             enableScanningParser: true,
-            enableMecabParser: false
+            enableMecabParser: false,
+            selectedParser = null
         },
 
         anki: {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -311,6 +311,11 @@ function profileOptionsCreateDefaults() {
 
         dictionaries: {},
 
+        parsing: {
+            enableScanningParser: true,
+            enableMecabParser: false
+        },
+
         anki: {
             enable: false,
             server: 'http://127.0.0.1:8765',

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -59,25 +59,39 @@ class QueryParser {
     }
 
     async setText(text) {
+        this.queryParser.innerHTML = '';
         this.search.setSpinnerVisible(true);
+
+        let previewText = text;
+        while (previewText) {
+            const tempText = previewText.slice(0, 2);
+            previewText = previewText.slice(2);
+
+            const tempRuby = document.createElement('ruby');
+            const tempFurigana = document.createElement('rt');
+            tempRuby.appendChild(document.createTextNode(tempText));
+            tempRuby.appendChild(tempFurigana);
+            this.queryParser.appendChild(tempRuby);
+        }
 
         const results = await apiTextParse(text, this.search.getOptionsContext());
 
-        const tempContainer = document.createElement('div');
+        const textContainer = document.createElement('div');
         for (const {text, furigana} of results) {
+            const rubyElement = document.createElement('ruby');
+            const furiganaElement = document.createElement('rt');
             if (furigana) {
-                const rubyElement = document.createElement('ruby');
-                const furiganaElement = document.createElement('rt');
                 furiganaElement.innerText = furigana;
                 rubyElement.appendChild(document.createTextNode(text));
                 rubyElement.appendChild(furiganaElement);
-                tempContainer.appendChild(rubyElement);
             } else {
-                tempContainer.appendChild(document.createTextNode(text));
+                rubyElement.appendChild(document.createTextNode(text));
+                rubyElement.appendChild(furiganaElement);
             }
+            textContainer.appendChild(rubyElement);
         }
         this.queryParser.innerHTML = '';
-        this.queryParser.appendChild(tempContainer);
+        this.queryParser.appendChild(textContainer);
 
         this.search.setSpinnerVisible(false);
     }

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -32,7 +32,8 @@ class QueryParser {
     }
 
     onClick(e) {
-        this.onTermLookup(e, {disableScroll: true, selectText: true});
+        const selectText = this.search.options.scanning.selectText;
+        this.onTermLookup(e, {disableScroll: true, selectText});
     }
 
     onMouseEnter(e) {
@@ -52,7 +53,8 @@ class QueryParser {
             return;
         }
 
-        this.onTermLookup(e, {disableScroll: true, selectText: true, disableHistory: true});
+        const selectText = this.search.options.scanning.selectText;
+        this.onTermLookup(e, {disableScroll: true, disableHistory: true, selectText});
     }
 
     onTermLookup(e, params) {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -24,6 +24,7 @@ class QueryParser {
         this.clickScanPrevent = false;
 
         this.parseResults = [];
+        this.selectedParser = null;
 
         this.queryParser = document.querySelector('#query-parser');
         this.queryParserSelect = document.querySelector('#query-parser-select');
@@ -85,14 +86,15 @@ class QueryParser {
         })();
     }
 
-    onParserChange(e) {
+    async onParserChange(e) {
         const selectedParser = e.target.value;
+        this.selectedParser = selectedParser;
         apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
         this.renderParseResult(this.getParseResult());
     }
 
     getParseResult() {
-        return this.parseResults.find(r => r.id === this.search.options.parsing.selectedParser);
+        return this.parseResults.find(r => r.id === this.selectedParser);
     }
 
     async setText(text) {
@@ -102,8 +104,12 @@ class QueryParser {
 
         this.parseResults = await this.parseText(text);
         if (this.parseResults.length > 0) {
-            if (this.search.options.parsing.selectedParser === null || !this.getParseResult()) {
+            if (this.selectedParser === null) {
+                this.selectedParser = this.search.options.parsing.selectedParser;
+            }
+            if (this.selectedParser === null || !this.getParseResult()) {
                 const selectedParser = this.parseResults[0].id;
+                this.selectedParser = selectedParser;
                 apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
             }
         }
@@ -162,7 +168,7 @@ class QueryParser {
                 const option = document.createElement('option');
                 option.value = parseResult.id;
                 option.innerText = parseResult.name;
-                option.defaultSelected = this.search.options.parsing.selectedParser === parseResult.id;
+                option.defaultSelected = this.selectedParser === parseResult.id;
                 select.appendChild(option);
             }
             select.addEventListener('change', this.onParserChange.bind(this));

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class QueryParser {
+    constructor(search) {
+        this.search = search;
+
+        this.queryParser = document.querySelector('#query-parser');
+
+        // TODO also enable for mouseover scanning
+        this.queryParser.addEventListener('click', (e) => this.onTermLookup(e));
+    }
+
+    onError(error) {
+        logError(error, false);
+    }
+
+    async onTermLookup(e) {
+        const {textSource} = await this.search.onTermLookup(e, {isQueryParser: true});
+        if (textSource) {
+            textSource.select();
+        }
+    }
+
+    setText(text) {
+        this.queryParser.innerText = text;
+    }
+}

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -36,7 +36,7 @@ class QueryParser {
         this.onTermLookup(e, {disableScroll: true, selectText});
     }
 
-    onMouseEnter(e) {
+    onMouseMove(e) {
         if (
             this.pendingLookup ||
             (e.buttons & 0x1) !== 0x0 // Left mouse button
@@ -112,11 +112,16 @@ class QueryParser {
     }
 
     activateScanning(element) {
-        element.addEventListener('mouseenter', (e) => {
-            e.target.dataset.timer = setTimeout(() => {
-                this.onMouseEnter(e);
-                delete e.target.dataset.timer;
-            }, this.search.options.scanning.delay);
+        element.addEventListener('mousemove', (e) => {
+            clearTimeout(e.target.dataset.timer);
+            if (this.search.options.scanning.modifier === 'none') {
+                e.target.dataset.timer = setTimeout(() => {
+                    this.onMouseMove(e);
+                    delete e.target.dataset.timer;
+                }, this.search.options.scanning.delay);
+            } else {
+                this.onMouseMove(e);
+            }
         });
         element.addEventListener('mouseleave', (e) => {
             clearTimeout(e.target.dataset.timer);

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -113,9 +113,9 @@ class QueryParser {
 
         this.queryParser.innerHTML = contents.join('<hr>');
 
-        this.queryParser.querySelectorAll('.query-parser-char').forEach((charElement) => {
+        for (const charElement of this.queryParser.querySelectorAll('.query-parser-char')) {
             this.activateScanning(charElement);
-        });
+        }
 
         this.search.setSpinnerVisible(false);
     }
@@ -133,9 +133,9 @@ class QueryParser {
             preview: true
         });
 
-        this.queryParser.querySelectorAll('.query-parser-char').forEach((charElement) => {
+        for (const charElement of this.queryParser.querySelectorAll('.query-parser-char')) {
             this.activateScanning(charElement);
-        });
+        }
     }
 
     activateScanning(element) {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -74,7 +74,8 @@ class QueryParser {
             preview: true
         });
 
-        const results = await apiTextParse(text, this.search.getOptionsContext());
+        // const results = await apiTextParse(text, this.search.getOptionsContext());
+        const results = await apiTextParseMecab(text, this.search.getOptionsContext());
 
         const content = await apiTemplateRender('query-parser.html', {
             terms: results.map((term) => {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -86,7 +86,7 @@ class QueryParser {
         })();
     }
 
-    async onParserChange(e) {
+    onParserChange(e) {
         const selectedParser = e.target.value;
         this.selectedParser = selectedParser;
         apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -122,7 +122,7 @@ class QueryParser {
 
     async setPreview(text) {
         const previewTerms = [];
-        while (text) {
+        while (text.length > 0) {
             const tempText = text.slice(0, 2);
             previewTerms.push([{text: Array.from(tempText)}]);
             text = text.slice(2);

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -93,16 +93,7 @@ class QueryParser {
         this.renderParseResult(this.getParseResult());
     }
 
-    getParseResult() {
-        return this.parseResults.find(r => r.id === this.selectedParser);
-    }
-
-    async setText(text) {
-        this.search.setSpinnerVisible(true);
-
-        await this.setPreview(text);
-
-        this.parseResults = await this.parseText(text);
+    refreshSelectedParser() {
         if (this.parseResults.length > 0) {
             if (this.selectedParser === null) {
                 this.selectedParser = this.search.options.parsing.selectedParser;
@@ -113,6 +104,19 @@ class QueryParser {
                 apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
             }
         }
+    }
+
+    getParseResult() {
+        return this.parseResults.find(r => r.id === this.selectedParser);
+    }
+
+    async setText(text) {
+        this.search.setSpinnerVisible(true);
+
+        await this.setPreview(text);
+
+        this.parseResults = await this.parseText(text);
+        this.refreshSelectedParser();
 
         this.renderParserSelect();
         await this.renderParseResult();

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -97,8 +97,8 @@ class QueryParser {
             }
         }
 
-        const contents = await Promise.all(Object.values(results).map(async result => {
-            return await apiTemplateRender('query-parser.html', {
+        const contents = await Promise.all(Object.values(results).map(result => {
+            return apiTemplateRender('query-parser.html', {
                 terms: result.map((term) => {
                     return term.filter(part => part.text.trim()).map((part) => {
                         return {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -154,19 +154,4 @@ class QueryParser {
             this.onMouseLeave(e);
         });
     }
-
-    async parseText(text) {
-        const results = [];
-        while (text) {
-            const {definitions, length} =  await apiTermsFind(text, {}, this.search.getOptionsContext());
-            if (length) {
-                results.push(definitions);
-                text = text.slice(length);
-            } else {
-                results.push(text[0]);
-                text = text.slice(1);
-            }
-        }
-        return results;
-    }
 }

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -34,7 +34,7 @@ class QueryParser {
     }
 
     onMouseDown(e) {
-        if (QueryParser.isMouseButton('primary', e)) {
+        if (Frontend.isMouseButton('primary', e)) {
             this.clickScanPrevent = false;
         }
     }
@@ -43,7 +43,7 @@ class QueryParser {
         if (
             this.search.options.scanning.clickGlossary &&
             !this.clickScanPrevent &&
-            QueryParser.isMouseButton('primary', e)
+            Frontend.isMouseButton('primary', e)
         ) {
             const selectText = this.search.options.scanning.selectText;
             this.onTermLookup(e, {disableScroll: true, selectText});
@@ -51,18 +51,15 @@ class QueryParser {
     }
 
     onMouseMove(e) {
-        if (
-            this.pendingLookup ||
-            QueryParser.isMouseButton('primary', e)
-        ) {
+        if (this.pendingLookup || Frontend.isMouseButton('primary', e)) {
             return;
         }
 
         const scanningOptions = this.search.options.scanning;
         const scanningModifier = scanningOptions.modifier;
         if (!(
-            QueryParser.isScanningModifierPressed(scanningModifier, e) ||
-            (scanningOptions.middleMouse && QueryParser.isMouseButton('auxiliary', e))
+            Frontend.isScanningModifierPressed(scanningModifier, e) ||
+            (scanningOptions.middleMouse && Frontend.isMouseButton('auxiliary', e))
         )) {
             return;
         }
@@ -161,32 +158,5 @@ class QueryParser {
             }
         }
         return results;
-    }
-
-    static isScanningModifierPressed(scanningModifier, mouseEvent) {
-        switch (scanningModifier) {
-            case 'alt': return mouseEvent.altKey;
-            case 'ctrl': return mouseEvent.ctrlKey;
-            case 'shift': return mouseEvent.shiftKey;
-            case 'none': return true;
-            default: return false;
-        }
-    }
-
-    static isMouseButton(button, mouseEvent) {
-        if (['mouseup', 'mousedown'].includes(mouseEvent.type)) {
-            switch (button) {
-                case 'primary': return mouseEvent.button === 0;
-                case 'secondary': return mouseEvent.button === 2;
-                case 'auxiliary': return mouseEvent.button === 1;
-                default: return false;
-            }
-        }
-        switch (button) {
-            case 'primary': return (mouseEvent.buttons & 0x1) !== 0x0;
-            case 'secondary': return (mouseEvent.buttons & 0x2) !== 0x0;
-            case 'auxiliary': return (mouseEvent.buttons & 0x4) !== 0x0;
-            default: return false;
-        }
     }
 }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -32,6 +32,8 @@ class DisplaySearch extends Display {
             url: window.location.href
         };
 
+        this.queryParser = new QueryParser(this);
+
         this.search = document.querySelector('#search');
         this.query = document.querySelector('#query');
         this.intro = document.querySelector('#intro');
@@ -72,11 +74,11 @@ class DisplaySearch extends Display {
                         const query = DisplaySearch.getSearchQueryFromLocation(window.location.href) || '';
                         if (e.target.checked) {
                             window.wanakana.bind(this.query);
-                            this.query.value = window.wanakana.toKana(query);
+                            this.setQuery(window.wanakana.toKana(query));
                             apiOptionsSet({general: {enableWanakana: true}}, this.getOptionsContext());
                         } else {
                             window.wanakana.unbind(this.query);
-                            this.query.value = query;
+                            this.setQuery(query);
                             apiOptionsSet({general: {enableWanakana: false}}, this.getOptionsContext());
                         }
                         this.onSearchQueryUpdated(this.query.value, false);
@@ -86,9 +88,9 @@ class DisplaySearch extends Display {
                 const query = DisplaySearch.getSearchQueryFromLocation(window.location.href);
                 if (query !== null) {
                     if (this.isWanakanaEnabled()) {
-                        this.query.value = window.wanakana.toKana(query);
+                        this.setQuery(window.wanakana.toKana(query));
                     } else {
-                        this.query.value = query;
+                        this.setQuery(query);
                     }
                     this.onSearchQueryUpdated(this.query.value, false);
                 }
@@ -159,6 +161,7 @@ class DisplaySearch extends Display {
         e.preventDefault();
 
         const query = this.query.value;
+        this.queryParser.setText(query);
         const queryString = query.length > 0 ? `?query=${encodeURIComponent(query)}` : '';
         window.history.pushState(null, '', `${window.location.pathname}${queryString}`);
         this.onSearchQueryUpdated(query, true);
@@ -168,9 +171,9 @@ class DisplaySearch extends Display {
         const query = DisplaySearch.getSearchQueryFromLocation(window.location.href) || '';
         if (this.query !== null) {
             if (this.isWanakanaEnabled()) {
-                this.query.value = window.wanakana.toKana(query);
+                this.setQuery(window.wanakana.toKana(query));
             } else {
-                this.query.value = query;
+                this.setQuery(query);
             }
         }
 
@@ -258,9 +261,9 @@ class DisplaySearch extends Display {
             }
             if (curText && (curText !== this.clipboardPrevText) && jpIsJapaneseText(curText)) {
                 if (this.isWanakanaEnabled()) {
-                    this.query.value = window.wanakana.toKana(curText);
+                    this.setQuery(window.wanakana.toKana(curText));
                 } else {
-                    this.query.value = curText;
+                    this.setQuery(curText);
                 }
 
                 const queryString = curText.length > 0 ? `?query=${encodeURIComponent(curText)}` : '';
@@ -285,6 +288,11 @@ class DisplaySearch extends Display {
 
     getOptionsContext() {
         return this.optionsContext;
+    }
+
+    setQuery(query) {
+        this.query.value = query;
+        this.queryParser.setText(query);
     }
 
     setIntroVisible(visible, animate) {

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -154,7 +154,6 @@ async function formWrite(options) {
 
 function formSetupEventListeners() {
     $('input, select, textarea').not('.anki-model').not('.ignore-form-changes *').change(utilAsync(onFormOptionsChanged));
-    $('#parsing-mecab-enable').change(onParseMecabChanged);
     $('.anki-model').change(utilAsync(onAnkiModelChanged));
 }
 
@@ -437,20 +436,6 @@ function onMessage({action, params}, sender, callback) {
         case 'getUrl':
             callback({url: window.location.href});
             break;
-    }
-}
-
-
-/*
- * Text parsing
- */
-
-function onParseMecabChanged(e) {
-    const mecab = utilBackend().mecab;
-    if (e.target.checked) {
-        mecab.startListener();
-    } else {
-        mecab.stopListener();
     }
 }
 

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -66,6 +66,7 @@ async function formRead(options) {
 
     options.parsing.enableScanningParser = $('#parsing-scan-enable').prop('checked');
     options.parsing.enableMecabParser = $('#parsing-mecab-enable').prop('checked');
+    options.parsing.readingMode = $('#parsing-reading-mode').val();
 
     const optionsAnkiEnableOld = options.anki.enable;
     options.anki.enable = $('#anki-enable').prop('checked');
@@ -131,6 +132,7 @@ async function formWrite(options) {
 
     $('#parsing-scan-enable').prop('checked', options.parsing.enableScanningParser);
     $('#parsing-mecab-enable').prop('checked', options.parsing.enableMecabParser);
+    $('#parsing-reading-mode').val(options.parsing.readingMode);
 
     $('#anki-enable').prop('checked', options.anki.enable);
     $('#card-tags').val(options.anki.tags.join(' '));

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -64,6 +64,9 @@ async function formRead(options) {
     options.scanning.modifier = $('#scan-modifier-key').val();
     options.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
 
+    options.parsing.enableScanningParser = $('#parsing-scan-enable').prop('checked');
+    options.parsing.enableMecabParser = $('#parsing-mecab-enable').prop('checked');
+
     const optionsAnkiEnableOld = options.anki.enable;
     options.anki.enable = $('#anki-enable').prop('checked');
     options.anki.tags = utilBackgroundIsolate($('#card-tags').val().split(/[,; ]+/));
@@ -125,6 +128,9 @@ async function formWrite(options) {
     $('#scan-length').val(options.scanning.length);
     $('#scan-modifier-key').val(options.scanning.modifier);
     $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
+
+    $('#parsing-scan-enable').prop('checked', options.parsing.enableScanningParser);
+    $('#parsing-mecab-enable').prop('checked', options.parsing.enableMecabParser);
 
     $('#anki-enable').prop('checked', options.anki.enable);
     $('#card-tags').val(options.anki.tags.join(' '));

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -154,6 +154,7 @@ async function formWrite(options) {
 
 function formSetupEventListeners() {
     $('input, select, textarea').not('.anki-model').not('.ignore-form-changes *').change(utilAsync(onFormOptionsChanged));
+    $('#parsing-mecab-enable').change(onParseMecabChanged);
     $('.anki-model').change(utilAsync(onAnkiModelChanged));
 }
 
@@ -436,6 +437,20 @@ function onMessage({action, params}, sender, callback) {
         case 'getUrl':
             callback({url: window.location.href});
             break;
+    }
+}
+
+
+/*
+ * Text parsing
+ */
+
+function onParseMecabChanged(e) {
+    const mecab = utilBackend().mecab;
+    if (e.target.checked) {
+        mecab.startListener();
+    } else {
+        mecab.stopListener();
     }
 }
 

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -163,6 +163,54 @@ templates['kanji.html'] = template({"1":function(container,depth0,helpers,partia
   }
 
 ,"useDecorators":true,"usePartial":true,"useData":true,"useDepths":true});
+templates['query-parser.html'] = template({"1":function(container,depth0,helpers,partials,data) {
+    var stack1, alias1=depth0 != null ? depth0 : (container.nullContext || {});
+
+  return ((stack1 = helpers["if"].call(alias1,(depth0 != null ? depth0.preview : depth0),{"name":"if","hash":{},"fn":container.program(2, data, 0),"inverse":container.program(4, data, 0),"data":data})) != null ? stack1 : "")
+    + ((stack1 = helpers.each.call(alias1,depth0,{"name":"each","hash":{},"fn":container.program(6, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
+    + "</span>";
+},"2":function(container,depth0,helpers,partials,data) {
+    return "<span class=\"query-parser-term-preview\">";
+},"4":function(container,depth0,helpers,partials,data) {
+    return "<span class=\"query-parser-term\">";
+},"6":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = container.invokePartial(partials.part,depth0,{"name":"part","data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+},"8":function(container,depth0,helpers,partials,data) {
+    var stack1;
+
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.raw : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "");
+},"9":function(container,depth0,helpers,partials,data) {
+    var helper;
+
+  return container.escapeExpression(((helper = (helper = helpers.text || (depth0 != null ? depth0.text : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"text","hash":{},"data":data}) : helper)));
+},"11":function(container,depth0,helpers,partials,data) {
+    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+
+  return "<ruby>"
+    + alias4(((helper = (helper = helpers.text || (depth0 != null ? depth0.text : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"text","hash":{},"data":data}) : helper)))
+    + "<rt>"
+    + alias4(((helper = (helper = helpers.reading || (depth0 != null ? depth0.reading : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"reading","hash":{},"data":data}) : helper)))
+    + "</rt></ruby>";
+},"13":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1;
+
+  return ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"preview":(depths[1] != null ? depths[1].preview : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
+},"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
+    var stack1;
+
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.terms : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
+
+  var decorators = container.decorators;
+
+  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(1, data, 0, blockParams, depths),"inverse":container.noop,"args":["term"],"data":data}) || fn;
+  fn = decorators.inline(fn,props,container,{"name":"inline","hash":{},"fn":container.program(8, data, 0, blockParams, depths),"inverse":container.noop,"args":["part"],"data":data}) || fn;
+  return fn;
+  }
+
+,"useDecorators":true,"usePartial":true,"useData":true,"useDepths":true});
 templates['terms.html'] = template({"1":function(container,depth0,helpers,partials,data) {
     var stack1, helper, options, alias1=depth0 != null ? depth0 : (container.nullContext || {}), buffer = 
   "<div class=\"dict-";

--- a/ext/bg/js/templates.js
+++ b/ext/bg/js/templates.js
@@ -180,27 +180,31 @@ templates['query-parser.html'] = template({"1":function(container,depth0,helpers
 },"8":function(container,depth0,helpers,partials,data) {
     var stack1;
 
-  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.raw : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(11, data, 0),"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers["if"].call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.raw : depth0),{"name":"if","hash":{},"fn":container.program(9, data, 0),"inverse":container.program(12, data, 0),"data":data})) != null ? stack1 : "");
 },"9":function(container,depth0,helpers,partials,data) {
-    var helper;
+    var stack1;
 
-  return container.escapeExpression(((helper = (helper = helpers.text || (depth0 != null ? depth0.text : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(depth0 != null ? depth0 : (container.nullContext || {}),{"name":"text","hash":{},"data":data}) : helper)));
-},"11":function(container,depth0,helpers,partials,data) {
-    var helper, alias1=depth0 != null ? depth0 : (container.nullContext || {}), alias2=helpers.helperMissing, alias3="function", alias4=container.escapeExpression;
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.text : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+},"10":function(container,depth0,helpers,partials,data) {
+    return "<span class=\"query-parser-char\">"
+    + container.escapeExpression(container.lambda(depth0, depth0))
+    + "</span>";
+},"12":function(container,depth0,helpers,partials,data) {
+    var stack1, helper, alias1=depth0 != null ? depth0 : (container.nullContext || {});
 
   return "<ruby>"
-    + alias4(((helper = (helper = helpers.text || (depth0 != null ? depth0.text : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"text","hash":{},"data":data}) : helper)))
+    + ((stack1 = helpers.each.call(alias1,(depth0 != null ? depth0.text : depth0),{"name":"each","hash":{},"fn":container.program(10, data, 0),"inverse":container.noop,"data":data})) != null ? stack1 : "")
     + "<rt>"
-    + alias4(((helper = (helper = helpers.reading || (depth0 != null ? depth0.reading : depth0)) != null ? helper : alias2),(typeof helper === alias3 ? helper.call(alias1,{"name":"reading","hash":{},"data":data}) : helper)))
+    + container.escapeExpression(((helper = (helper = helpers.reading || (depth0 != null ? depth0.reading : depth0)) != null ? helper : helpers.helperMissing),(typeof helper === "function" ? helper.call(alias1,{"name":"reading","hash":{},"data":data}) : helper)))
     + "</rt></ruby>";
-},"13":function(container,depth0,helpers,partials,data,blockParams,depths) {
+},"14":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
   return ((stack1 = container.invokePartial(partials.term,depth0,{"name":"term","hash":{"preview":(depths[1] != null ? depths[1].preview : depths[1])},"data":data,"helpers":helpers,"partials":partials,"decorators":container.decorators})) != null ? stack1 : "");
 },"compiler":[7,">= 4.0.0"],"main":function(container,depth0,helpers,partials,data,blockParams,depths) {
     var stack1;
 
-  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.terms : depth0),{"name":"each","hash":{},"fn":container.program(13, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
+  return ((stack1 = helpers.each.call(depth0 != null ? depth0 : (container.nullContext || {}),(depth0 != null ? depth0.terms : depth0),{"name":"each","hash":{},"fn":container.program(14, data, 0, blockParams, depths),"inverse":container.noop,"data":data})) != null ? stack1 : "");
 },"main_d":  function(fn, props, container, depth0, data, blockParams, depths) {
 
   var decorators = container.decorators;

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -47,7 +47,12 @@
                 <img src="/mixed/img/spinner.gif">
             </div>
 
-            <div id="query-parser" class="scan-disable"></div>
+            <div class="scan-disable">
+                <div id="query-parser-select" class="input-group"></div>
+                <div id="query-parser"></div>
+            </div>
+
+            <hr>
 
             <div id="content"></div>
         </div>

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -47,6 +47,8 @@
                 <img src="/mixed/img/spinner.gif">
             </div>
 
+            <div id="query-parser" class="scan-disable"></div>
+
             <div id="content"></div>
         </div>
 
@@ -67,6 +69,7 @@
         <script src="/mixed/js/japanese.js"></script>
         <script src="/mixed/js/scroll.js"></script>
 
+        <script src="/bg/js/search-query-parser.js"></script>
         <script src="/bg/js/search.js"></script>
         <script src="/bg/js/search-frontend.js"></script>
     </body>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -587,6 +587,35 @@
                 </div></div>
             </div>
 
+            <div id="text-parsing">
+                <h3>Text Parsing Options</h3>
+
+                <p class="help-block">
+                    Yomichan can attempt to parse entire sentences or longer text blocks on the search page,
+                    adding furigana above words and a small space between words.
+                </p>
+
+                <p class="help-block">
+                    Two types of parsers are supported. The first one, enabled by default, works using the built-in
+                    scanning functionality by automatically advancing in the sentence after a matching word.
+                </p>
+
+                <p class="help-block">
+                    The second type is an external program called <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener">MeCab</a>
+                    that uses its own dictionaries and a special parsing algorithm. To get it working, you must first
+                    install it and <a href="https://github.com/siikamiika/yomichan-mecab-installer" target="_blank" rel="noopener">a native messaging component</a>
+                    that acts as a bridge between the program and Yomichan.
+                </p>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="parsing-scan-enable"> Enable text parsing using installed dictionaries</label>
+                </div>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="parsing-mecab-enable"> Enable text parsing using MeCab</label>
+                </div>
+            </div>
+
             <div>
                 <div>
                     <img src="/mixed/img/spinner.gif" class="pull-right" id="anki-spinner" alt>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -437,6 +437,15 @@
                 <div class="checkbox">
                     <label><input type="checkbox" id="parsing-mecab-enable"> Enable text parsing using MeCab</label>
                 </div>
+
+                <div class="form-group">
+                    <label for="parsing-reading-mode">Reading mode</label>
+                    <select class="form-control" id="parsing-reading-mode">
+                        <option value="hiragana">ひらがな</option>
+                        <option value="katakana">カタカナ</option>
+                        <option value="romaji">Romaji</option>
+                    </select>
+                </div>
             </div>
 
             <div class="ignore-form-changes">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -410,6 +410,35 @@
                 </div>
             </div>
 
+            <div id="text-parsing">
+                <h3>Text Parsing Options</h3>
+
+                <p class="help-block">
+                    Yomichan can attempt to parse entire sentences or longer text blocks on the search page,
+                    adding furigana above words and a small space between words.
+                </p>
+
+                <p class="help-block">
+                    Two types of parsers are supported. The first one, enabled by default, works using the built-in
+                    scanning functionality by automatically advancing in the sentence after a matching word.
+                </p>
+
+                <p class="help-block">
+                    The second type is an external program called <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener">MeCab</a>
+                    that uses its own dictionaries and a special parsing algorithm. To get it working, you must first
+                    install it and <a href="https://github.com/siikamiika/yomichan-mecab-installer" target="_blank" rel="noopener">a native messaging component</a>
+                    that acts as a bridge between the program and Yomichan.
+                </p>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="parsing-scan-enable"> Enable text parsing using installed dictionaries</label>
+                </div>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="parsing-mecab-enable"> Enable text parsing using MeCab</label>
+                </div>
+            </div>
+
             <div class="ignore-form-changes">
                 <div>
                     <img src="/mixed/img/spinner.gif" class="pull-right" id="dict-spinner" alt>
@@ -585,35 +614,6 @@
                         prevent Chrome from deleting data.<sup><a href="https://bugs.chromium.org/p/chromium/issues/detail?id=680392#c15" target="_blank" rel="noopener">[1]</a></sup>
                     </p>
                 </div></div>
-            </div>
-
-            <div id="text-parsing">
-                <h3>Text Parsing Options</h3>
-
-                <p class="help-block">
-                    Yomichan can attempt to parse entire sentences or longer text blocks on the search page,
-                    adding furigana above words and a small space between words.
-                </p>
-
-                <p class="help-block">
-                    Two types of parsers are supported. The first one, enabled by default, works using the built-in
-                    scanning functionality by automatically advancing in the sentence after a matching word.
-                </p>
-
-                <p class="help-block">
-                    The second type is an external program called <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener">MeCab</a>
-                    that uses its own dictionaries and a special parsing algorithm. To get it working, you must first
-                    install it and <a href="https://github.com/siikamiika/yomichan-mecab-installer" target="_blank" rel="noopener">a native messaging component</a>
-                    that acts as a bridge between the program and Yomichan.
-                </p>
-
-                <div class="checkbox">
-                    <label><input type="checkbox" id="parsing-scan-enable"> Enable text parsing using installed dictionaries</label>
-                </div>
-
-                <div class="checkbox">
-                    <label><input type="checkbox" id="parsing-mecab-enable"> Enable text parsing using MeCab</label>
-                </div>
             </div>
 
             <div>

--- a/ext/fg/js/api.js
+++ b/ext/fg/js/api.js
@@ -29,6 +29,10 @@ function apiTermsFind(text, details, optionsContext) {
     return utilInvoke('termsFind', {text, details, optionsContext});
 }
 
+function apiTextParse(text, optionsContext) {
+    return utilInvoke('textParse', {text, optionsContext});
+}
+
 function apiKanjiFind(text, optionsContext) {
     return utilInvoke('kanjiFind', {text, optionsContext});
 }

--- a/ext/fg/js/api.js
+++ b/ext/fg/js/api.js
@@ -33,6 +33,10 @@ function apiTextParse(text, optionsContext) {
     return utilInvoke('textParse', {text, optionsContext});
 }
 
+function apiTextParseMecab(text, optionsContext) {
+    return utilInvoke('textParseMecab', {text, optionsContext});
+}
+
 function apiKanjiFind(text, optionsContext) {
     return utilInvoke('kanjiFind', {text, optionsContext});
 }

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -42,7 +42,8 @@
         "<all_urls>",
         "storage",
         "clipboardWrite",
-        "unlimitedStorage"
+        "unlimitedStorage",
+        "nativeMessaging"
     ],
     "optional_permissions": [
         "clipboardRead"

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -88,6 +88,15 @@ ol, ul {
     user-select: none;
 }
 
+#query-parser {
+    margin-top: 10px;
+    font-size: 24px;
+}
+
+.highlight {
+    background-color: lightblue;
+}
+
 
 /*
  * Entries

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -73,6 +73,10 @@ ol, ul {
 }
 
 
+html:root[data-yomichan-page=search] body {
+    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
+}
+
 /*
  * Search page
  */

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -93,13 +93,12 @@ ol, ul {
     font-size: 24px;
 }
 
-html:root[data-yomichan-page=search] body {
-    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
+.query-parser-term {
+    margin-right: 5px;
 }
 
-#query-parser {
-    margin-top: 10px;
-    font-size: 24px;
+html:root[data-yomichan-page=search] body {
+    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
 }
 
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -98,7 +98,7 @@ ol, ul {
 }
 
 html:root[data-yomichan-page=search] body {
-    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
+    overflow-y: scroll; /* always show scroll bar to avoid scanning problems */
 }
 
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -73,10 +73,6 @@ ol, ul {
 }
 
 
-html:root[data-yomichan-page=search] body {
-    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
-}
-
 /*
  * Search page
  */
@@ -97,8 +93,13 @@ html:root[data-yomichan-page=search] body {
     font-size: 24px;
 }
 
-.highlight {
-    background-color: lightblue;
+html:root[data-yomichan-page=search] body {
+    min-height: 101vh; /* always show scroll bar to avoid scanning problems */
+}
+
+#query-parser {
+    margin-top: 10px;
+    font-size: 24px;
 }
 
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -140,6 +140,8 @@ class Display {
             }
 
             this.setContentTerms(definitions, context);
+
+            return {textSource};
         } catch (error) {
             this.onError(error);
         }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -98,17 +98,62 @@ class Display {
         }
     }
 
-    async onTermLookup(e) {
+    async onTermLookup(e, {disableScroll, selectText, disableHistory}) {
+        const termLookupResults = await this.termLookup(e);
+        if (!termLookupResults) {
+            return false;
+        }
+
+        try {
+            const {textSource, definitions} = termLookupResults;
+
+            const scannedElement = e.target;
+            const sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
+
+            if (!disableScroll) {
+                this.windowScroll.toY(0);
+            }
+            let context;
+            if (disableHistory) {
+                const {url, source} = this.context || {};
+                context = {sentence, url, source, disableScroll};
+            } else {
+                context = {
+                    disableScroll,
+                    source: {
+                        definitions: this.definitions,
+                        index: this.entryIndexFind(scannedElement),
+                        scroll: this.windowScroll.y
+                    }
+                };
+
+                if (this.context) {
+                    context.sentence = sentence;
+                    context.url = this.context.url;
+                    context.source.source = this.context.source;
+                }
+            }
+
+            this.setContentTerms(definitions, context);
+
+            if (selectText) {
+                textSource.select();
+            }
+        } catch (error) {
+            this.onError(error);
+        }
+    }
+
+    async termLookup(e) {
         try {
             e.preventDefault();
 
-            const clickedElement = e.target;
             const textSource = docRangeFromPoint(e.clientX, e.clientY, this.options);
             if (textSource === null) {
                 return false;
             }
 
-            let definitions, length, sentence;
+            let definitions, length;
             try {
                 textSource.setEndOffset(this.options.scanning.length);
 
@@ -118,30 +163,11 @@ class Display {
                 }
 
                 textSource.setEndOffset(length);
-
-                sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
             } finally {
                 textSource.cleanup();
             }
 
-            this.windowScroll.toY(0);
-            const context = {
-                source: {
-                    definitions: this.definitions,
-                    index: this.entryIndexFind(clickedElement),
-                    scroll: this.windowScroll.y
-                }
-            };
-
-            if (this.context) {
-                context.sentence = sentence;
-                context.url = this.context.url;
-                context.source.source = this.context.source;
-            }
-
-            this.setContentTerms(definitions, context);
-
-            return {textSource};
+            return {textSource, definitions};
         } catch (error) {
             this.onError(error);
         }
@@ -338,8 +364,10 @@ class Display {
 
             const content = await apiTemplateRender('terms.html', params);
             this.container.innerHTML = content;
-            const {index, scroll} = context || {};
-            this.entryScrollIntoView(index || 0, scroll);
+            const {index, scroll, disableScroll} = context || {};
+            if (!disableScroll) {
+                this.entryScrollIntoView(index || 0, scroll);
+            }
 
             if (options.audio.enabled && options.audio.autoPlay) {
                 this.autoPlayAudio();

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -98,7 +98,7 @@ class Display {
         }
     }
 
-    async onTermLookup(e, {disableScroll, selectText, disableHistory}) {
+    async onTermLookup(e, {disableScroll, selectText, disableHistory}={}) {
         const termLookupResults = await this.termLookup(e);
         if (!termLookupResults) {
             return false;

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -102,11 +102,7 @@ function jpDistributeFuriganaInflected(expression, reading, source) {
     const shortest = Math.min(source.length, expression.length);
     const sourceHiragana = jpKatakanaToHiragana(source);
     const expressionHiragana = jpKatakanaToHiragana(expression);
-    while (
-        stemLength < shortest &&
-        // sometimes an expression can use a kanji that's different from the source
-        (!jpIsKana(source[stemLength]) || (sourceHiragana[stemLength] === expressionHiragana[stemLength]))
-    ) {
+    while (stemLength < shortest && sourceHiragana[stemLength] === expressionHiragana[stemLength]) {
         ++stemLength;
     }
     const offset = source.length - stemLength;

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -48,6 +48,43 @@ function jpKatakanaToHiragana(text) {
     return result;
 }
 
+function jpHiraganaToKatakana(text) {
+    let result = '';
+    for (const c of text) {
+        if (wanakana.isHiragana(c)) {
+            result += wanakana.toKatakana(c);
+        } else {
+            result += c;
+        }
+    }
+
+    return result;
+}
+
+function jpToRomaji(text) {
+    return wanakana.toRomaji(text);
+}
+
+function jpConvertReading(expressionFragment, readingFragment, readingMode) {
+    switch (readingMode) {
+        case 'hiragana':
+            return jpKatakanaToHiragana(readingFragment || '');
+        case 'katakana':
+            return jpHiraganaToKatakana(readingFragment || '');
+        case 'romaji':
+            if (readingFragment) {
+                return jpToRomaji(readingFragment);
+            } else {
+                if (jpIsKana(expressionFragment)) {
+                    return jpToRomaji(expressionFragment);
+                }
+            }
+            return readingFragment;
+        default:
+            return readingFragment;
+    }
+}
+
 function jpDistributeFurigana(expression, reading) {
     const fallback = [{furigana: reading, text: expression}];
     if (!reading) {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -107,10 +107,11 @@ function jpDistributeFuriganaInflected(expression, reading, source) {
     }
     const offset = source.length - stemLength;
 
-    for (const segment of jpDistributeFurigana(
-        source.slice(0, offset === 0 ? source.length : source.length - offset),
-        reading.slice(0, offset === 0 ? reading.length : reading.length - expression.length + stemLength)
-    )) {
+    const stemExpression = source.slice(0, source.length - offset);
+    const stemReading = reading.slice(
+        0, offset === 0 ? reading.length : reading.length - expression.length + stemLength
+    );
+    for (const segment of jpDistributeFurigana(stemExpression, stemReading)) {
         output.push(segment);
     }
 

--- a/tmpl/query-parser.html
+++ b/tmpl/query-parser.html
@@ -12,9 +12,13 @@
 
 {{~#*inline "part"~}}
 {{~#if raw~}}
-{{text}}
+{{~#each text~}}
+<span class="query-parser-char">{{this}}</span>
+{{~/each~}}
 {{~else~}}
-<ruby>{{text}}<rt>{{reading}}</rt></ruby>
+<ruby>{{~#each text~}}
+<span class="query-parser-char">{{this}}</span>
+{{~/each~}}<rt>{{reading}}</rt></ruby>
 {{~/if~}}
 {{~/inline~}}
 

--- a/tmpl/query-parser.html
+++ b/tmpl/query-parser.html
@@ -1,0 +1,23 @@
+{{~#*inline "term"~}}
+{{~#if preview~}}
+<span class="query-parser-term-preview">
+{{~else~}}
+<span class="query-parser-term">
+{{~/if~}}
+{{~#each this~}}
+{{> part }}
+{{~/each~}}
+</span>
+{{~/inline~}}
+
+{{~#*inline "part"~}}
+{{~#if raw~}}
+{{text}}
+{{~else~}}
+<ruby>{{text}}<rt>{{reading}}</rt></ruby>
+{{~/if~}}
+{{~/inline~}}
+
+{{~#each terms~}}
+{{> term preview=../preview }}
+{{~/each~}}


### PR DESCRIPTION
I'm opening a pull request because I need a few comments from other developers before I am ready to merge this.

This pull request adds a text parser to the search page that uses two different methods.

The first method that is enabled by default uses the built-in scanning so that it takes the longest result and matches readings from the best match using the score-based sorting and a new furigana function.

The other method is more problematic, as it uses native messaging to parse the text in an external application, MeCab. Here's a list of concerns:

- Should the protocol between the MeCab native host and Yomichan be versioned, and if it should, how? I'm planning to add part of speech highlighting in the future when I have investigated MeCab IPADIC part of speech tag names. I already have a working implementation in my previous project using my custom version of the Unidic dictionary.
- How should the native application be distributed? Currently I have a link on the settings page to https://github.com/siikamiika/yomichan-mecab-installer where I have installation instructions. I opted to bundle the Windows binary with the repository because I couldn't figure out how to otherwise add it to `%PATH%` safely, and I'm not sure if there's an "official" binary distribution of it for Windows where build environment setup is more difficult.

Few other questions about the code.

- Should `QueryParser` be a subclass of `Frontend`? It works quite dfiferently so I just copied the required functionality from other places of code.
- Are we transitioning away from Handlebars and should the text parsing view be implemented using `<template>` instead?