### PR TITLE
Sentence scanning updates

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -156,8 +156,10 @@ function docSentenceExtract(source, extent) {
 
     const sourceLocal = source.clone();
     sourceLocal.setEndOffset(extent);
-    const position = sourceLocal.setStartOffset(extent);
+    const content0 = sourceLocal.text();
+    sourceLocal.setStartOffset(extent);
     const content = sourceLocal.text();
+    const position = content.length - content0.length;
 
     let quoteStack = [];
 

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -229,7 +229,7 @@ function isPointInRange(x, y, range) {
     const nodePre = range.endContainer;
     const offsetPre = range.endOffset;
     try {
-        const {node, offset, content} = TextSourceRange.seekForward(range.endContainer, range.endOffset, 1);
+        const {node, offset, content} = TextSourceRange.seek(range.endContainer, range.endOffset, 1);
         range.setEnd(node, offset);
 
         if (!isWhitespace(content) && DOM.isPointInAnyRect(x, y, range.getClientRects())) {
@@ -240,7 +240,7 @@ function isPointInRange(x, y, range) {
     }
 
     // Scan backward
-    const {node, offset, content} = TextSourceRange.seekBackward(range.startContainer, range.startOffset, 1);
+    const {node, offset, content} = TextSourceRange.seek(range.startContainer, range.startOffset, -1);
     range.setStart(node, offset);
 
     if (!isWhitespace(content) && DOM.isPointInAnyRect(x, y, range.getClientRects())) {

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -368,5 +368,14 @@ function isElementTransparent(element) {
 }
 
 function isColorTransparent(cssColor) {
-    return REGEX_TRANSPARENT_COLOR.test(cssColor);
+    return typeof cssColor === 'string' && REGEX_TRANSPARENT_COLOR.test(cssColor);
+}
+
+function isStyleSelectable(style) {
+    return !(
+        style.userSelect === 'none' ||
+        style.webkitUserSelect === 'none' ||
+        style.MozUserSelect === 'none' ||
+        style.msUserSelect === 'none'
+    );
 }

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -155,8 +155,8 @@ function docSentenceExtract(source, extent) {
     const terminators = '…。．.？?！!';
 
     const sourceLocal = source.clone();
+    sourceLocal.setEndOffset(extent);
     const position = sourceLocal.setStartOffset(extent);
-    sourceLocal.setEndOffset(position + extent);
     const content = sourceLocal.text();
 
     let quoteStack = [];

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -15,7 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global isStyleSelectable isColorTransparent*/
+/* global
+ * isColorTransparent
+ * isStyleSelectable
+ */
 
 // \u200c (Zero-width non-joiner) appears on Google Docs from Chrome 76 onwards
 const REGEX_IGNORE_CHARACTER = /\u200c/;

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -57,7 +57,7 @@ class TextSourceRange {
         const state = TextSourceRange.seek(this.range.startContainer, this.range.startOffset, -length);
         this.range.setStart(state.node, state.offset);
         this.rangeStartOffset = this.range.startOffset;
-        this.content = state.content;
+        this.content = `${state.content}${this.content}`;
         return length - state.remainder;
     }
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -66,7 +66,7 @@ class TextSourceRange {
     }
 
     getWritingMode() {
-        return TextSourceRange.getElementWritingMode(TextSourceRange.getParentElement(this.range.startContainer));
+        return TextSourceRange._getElementWritingMode(TextSourceRange._getParentElement(this.range.startContainer));
     }
 
     select() {
@@ -98,7 +98,7 @@ class TextSourceRange {
         }
     }
 
-    static shouldEnter(node) {
+    static _shouldEnter(node) {
         switch (node.nodeName.toUpperCase()) {
             case 'RT':
             case 'SCRIPT':
@@ -113,8 +113,8 @@ class TextSourceRange {
             parseFloat(style.fontSize) === 0);
     }
 
-    static getRubyElement(node) {
-        node = TextSourceRange.getParentElement(node);
+    static _getRubyElement(node) {
+        node = TextSourceRange._getParentElement(node);
         if (node !== null && node.nodeName.toUpperCase() === 'RT') {
             node = node.parentNode;
             return (node !== null && node.nodeName.toUpperCase() === 'RUBY') ? node : null;
@@ -132,7 +132,7 @@ class TextSourceRange {
         const ELEMENT_NODE = Node.ELEMENT_NODE;
         let resetOffset = false;
 
-        const ruby = TextSourceRange.getRubyElement(node);
+        const ruby = TextSourceRange._getRubyElement(node);
         if (ruby !== null) {
             node = ruby;
             resetOffset = true;
@@ -144,21 +144,21 @@ class TextSourceRange {
 
             if (nodeType === TEXT_NODE) {
                 state.node = node;
-                if (TextSourceRange.seekForwardTextNode(state, resetOffset)) {
+                if (TextSourceRange._seekForwardTextNode(state, resetOffset)) {
                     break;
                 }
                 resetOffset = true;
             } else if (nodeType === ELEMENT_NODE) {
-                visitChildren = TextSourceRange.shouldEnter(node);
+                visitChildren = TextSourceRange._shouldEnter(node);
             }
 
-            node = TextSourceRange.getNextNode(node, visitChildren);
+            node = TextSourceRange._getNextNode(node, visitChildren);
         }
 
         return state;
     }
 
-    static seekForwardTextNode(state, resetOffset) {
+    static _seekForwardTextNode(state, resetOffset) {
         const nodeValue = state.node.nodeValue;
         const nodeValueLength = nodeValue.length;
         let content = state.content;
@@ -194,7 +194,7 @@ class TextSourceRange {
         const ELEMENT_NODE = Node.ELEMENT_NODE;
         let resetOffset = false;
 
-        const ruby = TextSourceRange.getRubyElement(node);
+        const ruby = TextSourceRange._getRubyElement(node);
         if (ruby !== null) {
             node = ruby;
             resetOffset = true;
@@ -206,21 +206,21 @@ class TextSourceRange {
 
             if (nodeType === TEXT_NODE) {
                 state.node = node;
-                if (TextSourceRange.seekBackwardTextNode(state, resetOffset)) {
+                if (TextSourceRange._seekBackwardTextNode(state, resetOffset)) {
                     break;
                 }
                 resetOffset = true;
             } else if (nodeType === ELEMENT_NODE) {
-                visitChildren = TextSourceRange.shouldEnter(node);
+                visitChildren = TextSourceRange._shouldEnter(node);
             }
 
-            node = TextSourceRange.getPreviousNode(node, visitChildren);
+            node = TextSourceRange._getPreviousNode(node, visitChildren);
         }
 
         return state;
     }
 
-    static seekBackwardTextNode(state, resetOffset) {
+    static _seekBackwardTextNode(state, resetOffset) {
         const nodeValue = state.node.nodeValue;
         let content = state.content;
         let offset = resetOffset ? nodeValue.length : state.offset;
@@ -245,25 +245,25 @@ class TextSourceRange {
         return result;
     }
 
-    static getParentElement(node) {
+    static _getParentElement(node) {
         while (node !== null && node.nodeType !== Node.ELEMENT_NODE) {
             node = node.parentNode;
         }
         return node;
     }
 
-    static getElementWritingMode(element) {
+    static _getElementWritingMode(element) {
         if (element !== null) {
             const style = window.getComputedStyle(element);
             const writingMode = style.writingMode;
             if (typeof writingMode === 'string') {
-                return TextSourceRange.normalizeWritingMode(writingMode);
+                return TextSourceRange._normalizeWritingMode(writingMode);
             }
         }
         return 'horizontal-tb';
     }
 
-    static normalizeWritingMode(writingMode) {
+    static _normalizeWritingMode(writingMode) {
         switch (writingMode) {
             case 'lr':
             case 'lr-tb':
@@ -281,14 +281,14 @@ class TextSourceRange {
     static getNodesInRange(range) {
         const end = range.endContainer;
         const nodes = [];
-        for (let node = range.startContainer; node !== null; node = TextSourceRange.getNextNode(node, true)) {
+        for (let node = range.startContainer; node !== null; node = TextSourceRange._getNextNode(node, true)) {
             nodes.push(node);
             if (node === end) { break; }
         }
         return nodes;
     }
 
-    static getNextNode(node, visitChildren) {
+    static _getNextNode(node, visitChildren) {
         let next = visitChildren ? node.firstChild : null;
         if (next === null) {
             while (true) {
@@ -304,7 +304,7 @@ class TextSourceRange {
         return next;
     }
 
-    static getPreviousNode(node, visitChildren) {
+    static _getPreviousNode(node, visitChildren) {
         let next = visitChildren ? node.lastChild : null;
         if (next === null) {
             while (true) {

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -51,7 +51,6 @@ class TextSourceRange {
         const state = TextSourceRange.seek(this.range.startContainer, this.range.startOffset, length);
         this.range.setEnd(state.node, state.offset);
         this.content = state.content;
-        return length - state.remainder;
     }
 
     setStartOffset(length) {
@@ -59,7 +58,6 @@ class TextSourceRange {
         this.range.setStart(state.node, state.offset);
         this.rangeStartOffset = this.range.startOffset;
         this.content = `${state.content}${this.content}`;
-        return length - state.remainder;
     }
 
     getRect() {
@@ -407,12 +405,10 @@ class TextSourceElement {
         }
 
         this.content = content;
-
-        return this.content.length;
     }
 
     setStartOffset() {
-        return 0;
+        // NOP
     }
 
     getRect() {

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -200,15 +200,16 @@ class TextSourceRange {
         let remainder = state.remainder;
         let result = false;
 
-        for (; offset < nodeValueLength; ++offset) {
+        while (offset < nodeValueLength) {
             const c = nodeValue[offset];
-            if (!IGNORE_TEXT_PATTERN.test(c)) {
-                content += c;
-                if (--remainder <= 0) {
-                    result = true;
-                    ++offset;
-                    break;
-                }
+            ++offset;
+            if (IGNORE_TEXT_PATTERN.test(c)) { continue; }
+
+            content += c;
+
+            if (--remainder <= 0) {
+                result = true;
+                break;
             }
         }
 
@@ -225,15 +226,16 @@ class TextSourceRange {
         let remainder = state.remainder;
         let result = false;
 
-        for (; offset > 0; --offset) {
-            const c = nodeValue[offset - 1];
-            if (!IGNORE_TEXT_PATTERN.test(c)) {
-                content = c + content;
-                if (--remainder <= 0) {
-                    result = true;
-                    --offset;
-                    break;
-                }
+        while (offset > 0) {
+            --offset;
+            const c = nodeValue[offset];
+            if (IGNORE_TEXT_PATTERN.test(c)) { continue; }
+
+            content = c + content;
+
+            if (--remainder <= 0) {
+                result = true;
+                break;
             }
         }
 

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -16,7 +16,7 @@
  */
 
 // \u200c (Zero-width non-joiner) appears on Google Docs from Chrome 76 onwards
-const IGNORE_TEXT_PATTERN = /\u200c/;
+const REGEX_IGNORE_CHARACTER = /\u200c/;
 const REGEX_DISPLAY = /^\s*([\w\-]+)/;
 
 
@@ -221,7 +221,7 @@ class TextSourceRange {
         while (offset < nodeValueLength) {
             let c = nodeValue[offset];
             ++offset;
-            if (IGNORE_TEXT_PATTERN.test(c)) { continue; }
+            if (REGEX_IGNORE_CHARACTER.test(c)) { continue; }
 
             if (c === '\n') {
                 if (!lineBreaksDetected) { lineBreaks = TextSourceRange._getLineBreakMode(node); }
@@ -256,7 +256,7 @@ class TextSourceRange {
         while (offset > 0) {
             --offset;
             let c = nodeValue[offset];
-            if (IGNORE_TEXT_PATTERN.test(c)) { continue; }
+            if (REGEX_IGNORE_CHARACTER.test(c)) { continue; }
 
             if (c === '\n') {
                 if (!lineBreaksDetected) { lineBreaks = TextSourceRange._getLineBreakMode(node); }
@@ -467,7 +467,7 @@ class TextSourceElement {
         for (const currentChar of this.content || '') {
             if (consumed >= length) {
                 break;
-            } else if (!currentChar.match(IGNORE_TEXT_PATTERN)) {
+            } else if (!currentChar.match(REGEX_IGNORE_CHARACTER)) {
                 consumed++;
                 content += currentChar;
             }

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -147,6 +147,8 @@ class TextSourceRange {
                     if (seekTextNode(state)) {
                         break;
                     }
+                } else {
+                    state.offset = forward ? 0 : node.nodeValue.length;
                 }
                 resetOffset = true;
             } else if (nodeType === ELEMENT_NODE) {

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -118,12 +118,12 @@ class TextSourceRange {
         const shouldSeekTextNode = TextSourceRange._shouldSeekTextNode;
         const addLineBreak = TextSourceRange._addLineBreak;
 
-        let resetOffset = false;
+        let first = true;
 
         const ruby = TextSourceRange._getRubyElement(node);
         if (ruby !== null) {
             node = ruby;
-            resetOffset = true;
+            first = false;
         }
 
         let lineBreak = false;
@@ -134,12 +134,12 @@ class TextSourceRange {
 
             if (nodeType === TEXT_NODE) {
                 state.node = node;
-                if (!resetOffset || shouldSeekTextNode(node)) {
-                    if (resetOffset) {
+                if (first || shouldSeekTextNode(node)) {
+                    if (!first) {
                         state.offset = forward ? 0 : node.nodeValue.length;
                     }
                     if (lineBreak) {
-                        if (resetOffset && addLineBreak(state, forward)) {
+                        if (addLineBreak(state, forward)) {
                             break;
                         }
                         lineBreak = false;
@@ -150,7 +150,6 @@ class TextSourceRange {
                 } else {
                     state.offset = forward ? 0 : node.nodeValue.length;
                 }
-                resetOffset = true;
             } else if (nodeType === ELEMENT_NODE) {
                 [visitChildren, lineBreak2] = getElementSeekInfo(node);
                 if (lineBreak2) { lineBreak = true; }
@@ -168,6 +167,8 @@ class TextSourceRange {
                     }
                 }
             }
+
+            first = false;
         }
 
         return state;

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -15,6 +15,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global isStyleSelectable isColorTransparent*/
+
 // \u200c (Zero-width non-joiner) appears on Google Docs from Chrome 76 onwards
 const REGEX_IGNORE_CHARACTER = /\u200c/;
 const REGEX_DISPLAY = /^\s*([\w-]+)/;

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -17,7 +17,7 @@
 
 // \u200c (Zero-width non-joiner) appears on Google Docs from Chrome 76 onwards
 const REGEX_IGNORE_CHARACTER = /\u200c/;
-const REGEX_DISPLAY = /^\s*([\w\-]+)/;
+const REGEX_DISPLAY = /^\s*([\w-]+)/;
 
 
 /*
@@ -224,7 +224,10 @@ class TextSourceRange {
             if (REGEX_IGNORE_CHARACTER.test(c)) { continue; }
 
             if (c === '\n') {
-                if (!lineBreaksDetected) { lineBreaks = TextSourceRange._getLineBreakMode(node); }
+                if (!lineBreaksDetected) {
+                    lineBreaks = TextSourceRange._getLineBreakMode(node);
+                    lineBreaksDetected = true;
+                }
                 if (!lineBreaks) { c = ' '; }
             }
 
@@ -259,7 +262,10 @@ class TextSourceRange {
             if (REGEX_IGNORE_CHARACTER.test(c)) { continue; }
 
             if (c === '\n') {
-                if (!lineBreaksDetected) { lineBreaks = TextSourceRange._getLineBreakMode(node); }
+                if (!lineBreaksDetected) {
+                    lineBreaks = TextSourceRange._getLineBreakMode(node);
+                    lineBreaksDetected = true;
+                }
                 if (!lineBreaks) { c = ' '; }
             }
 

--- a/test/data/html/test-document1.html
+++ b/test/data/html/test-document1.html
@@ -212,5 +212,42 @@
 </span><span>trailing content</span>
     </div>
 
+    <div
+        class="test"
+        data-test-type="text-source-range-seek"
+        data-seek-node-selector="span:nth-of-type(1)"
+        data-seek-node-is-text="true"
+        data-seek-offset="0"
+        data-seek-length="61"
+        data-expected-result-node-selector="span:nth-of-type(1)"
+        data-expected-result-node-is-text="true"
+        data-expected-result-offset="61"
+        data-expected-result-content="
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+"
+    >
+<span style="white-space: pre;">
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+</span><span>trailing content</span>
+    </div>
+
 </body>
 </html>

--- a/test/data/html/test-document1.html
+++ b/test/data/html/test-document1.html
@@ -114,36 +114,24 @@
         data-seek-node-selector="span:nth-of-type(1)"
         data-seek-node-is-text="true"
         data-seek-offset="0"
-        data-seek-length="149"
-        data-seek-direction="forward"
+        data-seek-length="61"
         data-expected-result-node-selector="span:nth-of-type(1)"
         data-expected-result-node-is-text="true"
-        data-expected-result-offset="149"
-        data-expected-result-content="
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        "
+        data-expected-result-offset="61"
+        data-expected-result-content=" あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも や&#x3000;ゆ&#x3000;よ らりるれろ わゐ&#x3000;ゑを "
     >
-        <span>
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        </span><span>trailing content</span>
+<span>
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+</span><span>trailing content</span>
     </div>
 
     <div
@@ -151,37 +139,25 @@
         data-test-type="text-source-range-seek"
         data-seek-node-selector="span:nth-of-type(1)"
         data-seek-node-is-text="true"
-        data-seek-offset="149"
-        data-seek-length="149"
-        data-seek-direction="backward"
+        data-seek-offset="61"
+        data-seek-length="-61"
         data-expected-result-node-selector="span:nth-of-type(1)"
         data-expected-result-node-is-text="true"
         data-expected-result-offset="0"
-        data-expected-result-content="
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        "
+        data-expected-result-content=" あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも や&#x3000;ゆ&#x3000;よ らりるれろ わゐ&#x3000;ゑを "
     >
-        <span>
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        </span><span>trailing content</span>
+<span>
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+</span><span>trailing content</span>
     </div>
 
     <div
@@ -190,36 +166,24 @@
         data-seek-node-selector="span:nth-of-type(1)"
         data-seek-node-is-text="true"
         data-seek-offset="0"
-        data-seek-length="150"
-        data-seek-direction="forward"
+        data-seek-length="62"
         data-expected-result-node-selector="span:nth-of-type(2)"
         data-expected-result-node-is-text="true"
         data-expected-result-offset="1"
-        data-expected-result-content="
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        t"
+        data-expected-result-content=" あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも や&#x3000;ゆ&#x3000;よ らりるれろ わゐ&#x3000;ゑを t"
     >
-        <span>
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        </span><span>trailing content</span>
+<span>
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+</span><span>trailing content</span>
     </div>
 
     <div
@@ -228,36 +192,24 @@
         data-seek-node-selector="span:nth-of-type(2)"
         data-seek-node-is-text="true"
         data-seek-offset="1"
-        data-seek-length="150"
-        data-seek-direction="backward"
+        data-seek-length="-62"
         data-expected-result-node-selector="span:nth-of-type(1)"
         data-expected-result-node-is-text="true"
         data-expected-result-offset="0"
-        data-expected-result-content="
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        t"
+        data-expected-result-content=" あいうえお かきくけこ さしすせそ たちつてと なにぬねの はひふへほ まみむめも や&#x3000;ゆ&#x3000;よ らりるれろ わゐ&#x3000;ゑを t"
     >
-        <span>
-        あいうえお
-        かきくけこ
-        さしすせそ
-        たちつてと
-        なにぬねの
-        はひふへほ
-        まみむめも
-        や&#x3000;ゆ&#x3000;よ
-        らりるれろ
-        わゐ&#x3000;ゑを
-        </span><span>trailing content</span>
+<span>
+あいうえお
+かきくけこ
+さしすせそ
+たちつてと
+なにぬねの
+はひふへほ
+まみむめも
+や&#x3000;ゆ&#x3000;よ
+らりるれろ
+わゐ&#x3000;ゑを
+</span><span>trailing content</span>
     </div>
 
 </body>

--- a/test/test-document.js
+++ b/test/test-document.js
@@ -197,7 +197,6 @@ async function testTextSourceRangeSeekFunctions(dom, {TextSourceRange}) {
             seekNodeIsText,
             seekOffset,
             seekLength,
-            seekDirection,
             expectedResultNodeSelector,
             expectedResultNodeIsText,
             expectedResultOffset,
@@ -218,11 +217,7 @@ async function testTextSourceRangeSeekFunctions(dom, {TextSourceRange}) {
             expectedResultNode = expectedResultNode.firstChild;
         }
 
-        const {node, offset, content} = (
-            seekDirection === 'forward' ?
-            TextSourceRange.seekForward(seekNode, seekOffset, seekLength) :
-            TextSourceRange.seekBackward(seekNode, seekOffset, seekLength)
-        );
+        const {node, offset, content} = TextSourceRange.seek(seekNode, seekOffset, seekLength);
 
         assert.strictEqual(node, expectedResultNode);
         assert.strictEqual(offset, expectedResultOffset);


### PR DESCRIPTION
Due to some recent comments related to sentence scanning, I have tried to make sentence scanning more consistent. The changes are mostly made to ```TextSourceRange```, and the sentence extraction feature is mostly the same. This change also includes some refactoring to reduce redundant code.

A few things to note:
* Newlines in [```Text```](https://developer.mozilla.org/en-US/docs/Web/API/Text) nodes are now only treated as newlines if the CSS [```white-space```](https://developer.mozilla.org/en-US/docs/Web/CSS/white-space) mode lets newline characters break text.
* Element boundaries which cause line breaks add newline characters to the text. This causes sentence detection to more correctly stop when it encounters a newline, since the newlines in the returned text are more accurate.
* This does change the behaviour of how sentence scanning works. IMO it is likely to feel more consistent, but there are potentially some situations where the old method would return more text than the current method.
* This also "fixes" a potential issue which used to exist where text split across lines were scanned as a single term since there was no separation text. For example:
  ```html
  <div><div>小ぢん</div>まり</div>
  <div>小ぢん<div>まり</div></div>
  ```
  Scanning starting at ```小``` would always detect the full word ```小ぢんまり``` despite there being a line break. This example is contrived, but I've seen this happen to two text nodes which only incidentally form a larger phrase.
* This change also includes an optimization where sentence scanning used to scan ```docSentenceExtract.extent``` 3x instead of 2x (only once forward and once backward should be necessary).

There is potentially another improvement that can be done to sentence extraction. Currently the algorithm will terminate a sentence at newline characters, which leads to partial phrases being detected at ```<br>``` elements or line breaks in elements with ```white-space=pre || pre-wrap || pre-line || break-spaces```. This can potentially be improved by only terminating when there are two sequential newline characters, combined with forcing element boundaries to be treated as ```'\n\n'``` rather than just ```'\n'```. I have not yet made this change as I first wanted to get the base changes out of the way.

This addresses #221, #273, #276.