### PR TITLE
Prefix wildcards

### DIFF
--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -332,8 +332,10 @@ class Database {
         return result;
     }
 
-    async importDictionary(archive, progressCallback, exceptions) {
+    async importDictionary(archive, progressCallback, exceptions, details) {
         this.validate();
+
+        const prefixWildcardsSupported = details.prefixWildcardsSupported;
 
         const maxTransactionLength = 1000;
         const bulkAdd = async (objectStoreName, items, total, current) => {
@@ -389,9 +391,7 @@ class Database {
                         rules,
                         score,
                         glossary,
-                        dictionary: summary.title,
-                        expressionReverse: stringReverse(expression),
-                        readingReverse: stringReverse(reading)
+                        dictionary: summary.title
                     });
                 }
             } else {
@@ -405,10 +405,15 @@ class Database {
                         glossary,
                         sequence,
                         termTags,
-                        dictionary: summary.title,
-                        expressionReverse: stringReverse(expression),
-                        readingReverse: stringReverse(reading)
+                        dictionary: summary.title
                     });
+                }
+            }
+
+            if (prefixWildcardsSupported) {
+                for (const row of rows) {
+                    row.expressionReverse = stringReverse(row.expression);
+                    row.readingReverse = stringReverse(row.reading);
                 }
             }
 

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -503,7 +503,8 @@ class Database {
             termMetaDataLoaded,
             kanjiDataLoaded,
             kanjiMetaDataLoaded,
-            tagDataLoaded
+            tagDataLoaded,
+            details
         );
     }
 
@@ -520,7 +521,8 @@ class Database {
         termMetaDataLoaded,
         kanjiDataLoaded,
         kanjiMetaDataLoaded,
-        tagDataLoaded
+        tagDataLoaded,
+        details
     ) {
         const zip = await JSZip.loadAsync(archive);
 
@@ -538,7 +540,8 @@ class Database {
             title: index.title,
             revision: index.revision,
             sequenced: index.sequenced,
-            version: index.format || index.version
+            version: index.format || index.version,
+            prefixWildcardsSupported: !!details.prefixWildcardsSupported
         };
 
         await indexDataLoaded(summary);

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -378,7 +378,15 @@ function profileOptionsUpdateVersion(options) {
  * ]
  */
 
-const optionsVersionUpdates = [];
+const optionsVersionUpdates = [
+    (options) => {
+        options.global = {
+            database: {
+                prefixWildcardsSupported: false
+            }
+        };
+    }
+];
 
 function optionsUpdateVersion(options, defaultProfileOptions) {
     // Ensure profiles is an array
@@ -421,6 +429,11 @@ function optionsUpdateVersion(options, defaultProfileOptions) {
             profile.conditionGroups = [];
         }
         profile.options = profileOptionsUpdateVersion(profile.options);
+    }
+
+    // Version
+    if (typeof options.version !== 'number') {
+        options.version = 0;
     }
 
     // Generic updates

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -207,10 +207,14 @@ class DisplaySearch extends Display {
     async onSearchQueryUpdated(query, animate) {
         try {
             const details = {};
-            const match = /[*\uff0a]+$/.exec(query);
+            const match = /^([*\uff0a]*)([\w\W]*?)([*\uff0a]*)$/.exec(query);
             if (match !== null) {
-                details.wildcard = true;
-                query = query.substring(0, query.length - match[0].length);
+                if (match[1]) {
+                    details.wildcard = 'prefix';
+                } else if (match[3]) {
+                    details.wildcard = 'suffix';
+                }
+                query = match[2];
             }
 
             const valid = (query.length > 0);

--- a/ext/bg/js/settings/dictionaries.js
+++ b/ext/bg/js/settings/dictionaries.js
@@ -189,6 +189,7 @@ class SettingsDictionaryEntryUI {
 
         this.content.querySelector('.dict-title').textContent = this.dictionaryInfo.title;
         this.content.querySelector('.dict-revision').textContent = `rev.${this.dictionaryInfo.revision}`;
+        this.content.querySelector('.dict-prefix-wildcard-searches-supported').checked = !!this.dictionaryInfo.prefixWildcardsSupported;
 
         this.applyValues();
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -230,7 +230,7 @@ class Translator {
         const titles = Object.keys(dictionaries);
         const deinflections = (
             details.wildcard ?
-            await this.findTermWildcard(text, titles) :
+            await this.findTermWildcard(text, titles, details.wildcard) :
             await this.findTermDeinflections(text, titles)
         );
 
@@ -268,8 +268,8 @@ class Translator {
         return [definitions, length];
     }
 
-    async findTermWildcard(text, titles) {
-        const definitions = await this.database.findTermsBulk([text], titles, true);
+    async findTermWildcard(text, titles, wildcard) {
+        const definitions = await this.database.findTermsBulk([text], titles, wildcard);
         if (definitions.length === 0) {
             return [];
         }
@@ -308,7 +308,7 @@ class Translator {
             deinflectionArray.push(deinflection);
         }
 
-        const definitions = await this.database.findTermsBulk(uniqueDeinflectionTerms, titles, false);
+        const definitions = await this.database.findTermsBulk(uniqueDeinflectionTerms, titles, null);
 
         for (const definition of definitions) {
             const definitionRules = Deinflector.rulesToRuleFlags(definition.rules);

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -94,13 +94,13 @@ function utilDatabaseDeleteDictionary(dictionaryName, onProgress) {
     return utilBackend().translator.database.deleteDictionary(dictionaryName, onProgress);
 }
 
-async function utilDatabaseImport(data, progress, exceptions) {
+async function utilDatabaseImport(data, progress, exceptions, details) {
     // Edge cannot read data on the background page due to the File object
     // being created from a different window. Read on the same page instead.
     if (EXTENSION_IS_BROWSER_EDGE) {
         data = await utilReadFile(data);
     }
-    return utilBackend().translator.database.importDictionary(data, progress, exceptions);
+    return utilBackend().translator.database.importDictionary(data, progress, exceptions, details);
 }
 
 function utilReadFile(file) {

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -491,6 +491,18 @@
                     <div hidden><input type="file" id="dict-file" accept=".zip,application/zip" multiple></div>
                 </div>
 
+                <div>
+                    <h3>Dictionary Options</h3>
+                </div>
+
+                <div class="checkbox">
+                    <label><input type="checkbox" id="database-enable-prefix-wildcard-searches"> Enable prefix wildcard searches</label>
+                    <p class="help-block">
+                        This option only applies to newly imported dictionaries.
+                        Enabling this option will also cause dictionary data to take up slightly more storage space.
+                    </p>
+                </div>
+
                 <div class="modal fade" tabindex="-1" role="dialog" id="dict-purge-modal">
                     <div class="modal-dialog modal-dialog-centered">
                         <div class="modal-content">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -550,6 +550,9 @@
                     <div class="checkbox options-advanced">
                         <label><input type="checkbox" class="dict-allow-secondary-searches"> Allow secondary searches</label>
                     </div>
+                    <div class="checkbox dict-prefix-wildcard-searches-supported-container">
+                        <label><input type="checkbox" class="dict-prefix-wildcard-searches-supported" disabled> Prefix wildcard searches supported</label>
+                    </div>
                     <div class="form-group options-advanced">
                         <label class="dict-result-priority-label">Result priority</label>
                         <input type="number" class="form-control dict-priority">

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -118,6 +118,10 @@ function toIterable(value) {
     throw new Error('Could not convert to iterable');
 }
 
+function stringReverse(string) {
+    return string.split('').reverse().join('').replace(/([\uDC00-\uDFFF])([\uD800-\uDBFF])/g, '$2$1');
+}
+
 
 /*
  * Async utilities


### PR DESCRIPTION
This change adds support for prefix wildcards. The new option must be enabled and dictionaries must be reimported before it works, since the database is required to store the reversed-string expression/readings for each entry.

This option is disabled by default due to the additional space used by storing reversed strings. Some numbers when using jmdict_english:
```
No dictionaries installed:
Firefox: 49.2KB
Chrome: 7.0KB

Old version:
Firefox: 147.0MB
Chrome: 72.1MB

With new database indices only:
Firefox: 147.0MB
Chrome: 72.1MB

With new databases and data:
Firefox: 182.9MB
Chrome: 78.5MB
```

Simultaneous prefix and suffix wildcards are not supported due to the limitations of IndexedDB.

This resolves #128 as much as is possible with IndexedDB.
Tracking issue: #270

---

![image](https://user-images.githubusercontent.com/11037431/69489647-74035b80-0e49-11ea-86f5-6c4e46f5f011.png)