### PR TITLE
Cloze fixes

### DIFF
--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -640,7 +640,7 @@ class Display {
 
         if (source) {
             result.prefix = sentence.text.substring(0, sentence.offset).trim();
-            result.body = source.trim();
+            result.body = sentence.text.substring(sentence.offset, sentence.offset + source.length);
             result.suffix = sentence.text.substring(sentence.offset + source.length).trim();
         }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -633,18 +633,13 @@ class Display {
         return index >= 0 && index < entries.length ? entries[index] : null;
     }
 
-    static clozeBuild(sentence, source) {
-        const result = {
-            sentence: sentence.text.trim()
+    static clozeBuild({text, offset}, source) {
+        return {
+            sentence: text.trim(),
+            prefix: text.substring(0, offset).trim(),
+            body: text.substring(offset, offset + source.length),
+            suffix: text.substring(offset + source.length).trim()
         };
-
-        if (source) {
-            result.prefix = sentence.text.substring(0, sentence.offset).trim();
-            result.body = sentence.text.substring(sentence.offset, sentence.offset + source.length);
-            result.suffix = sentence.text.substring(sentence.offset + source.length).trim();
-        }
-
-        return result;
     }
 
     entryIndexFind(element) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -398,7 +398,7 @@ class Display {
             };
 
             for (const definition of definitions) {
-                definition.cloze = Display.clozeBuild(context.sentence);
+                definition.cloze = Display.clozeBuild(context.sentence, definition.character);
                 definition.url = context.url;
             }
 


### PR DESCRIPTION
Does this fix #58, specifically in afddec66eb749aa0a39c7e7142f929e68697995d? I'm not sure if there's something I'm overlooking, but my understanding is that ```text.substring(offset, offset + source.length)``` should equal ```source``` most of the time, with the only difference being the use of katakana vs hiragana.