### PR TITLE
Remove utilAsync

### DIFF
--- a/ext/bg/js/settings-profiles.js
+++ b/ext/bg/js/settings-profiles.js
@@ -35,16 +35,16 @@ async function profileOptionsSetup() {
 }
 
 function profileOptionsSetupEventListeners() {
-    $('#profile-target').change(utilAsync(onTargetProfileChanged));
+    $('#profile-target').change((e) => onTargetProfileChanged(e));
     $('#profile-name').change(onProfileNameChanged);
-    $('#profile-add').click(utilAsync(onProfileAdd));
-    $('#profile-remove').click(utilAsync(onProfileRemove));
-    $('#profile-remove-confirm').click(utilAsync(onProfileRemoveConfirm));
-    $('#profile-copy').click(utilAsync(onProfileCopy));
-    $('#profile-copy-confirm').click(utilAsync(onProfileCopyConfirm));
+    $('#profile-add').click((e) => onProfileAdd(e));
+    $('#profile-remove').click((e) => onProfileRemove(e));
+    $('#profile-remove-confirm').click((e) => onProfileRemoveConfirm(e));
+    $('#profile-copy').click((e) => onProfileCopy(e));
+    $('#profile-copy-confirm').click((e) => onProfileCopyConfirm(e));
     $('#profile-move-up').click(() => onProfileMove(-1));
     $('#profile-move-down').click(() => onProfileMove(1));
-    $('.profile-form').find('input, select, textarea').not('.profile-form-manual').change(utilAsync(onProfileOptionsChanged));
+    $('.profile-form').find('input, select, textarea').not('.profile-form-manual').change((e) => onProfileOptionsChanged(e));
 }
 
 function tryGetIntegerValue(selector, min, max) {

--- a/ext/bg/js/settings-profiles.js
+++ b/ext/bg/js/settings-profiles.js
@@ -36,7 +36,7 @@ async function profileOptionsSetup() {
 
 function profileOptionsSetupEventListeners() {
     $('#profile-target').change((e) => onTargetProfileChanged(e));
-    $('#profile-name').change(onProfileNameChanged);
+    $('#profile-name').change((e) => onProfileNameChanged(e));
     $('#profile-add').click((e) => onProfileAdd(e));
     $('#profile-remove').click((e) => onProfileRemove(e));
     $('#profile-remove-confirm').click((e) => onProfileRemoveConfirm(e));

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -583,7 +583,7 @@ async function ankiFieldsPopulate(element, options) {
     }
 
     tab.find('.anki-field-value').change((e) => onFormOptionsChanged(e));
-    tab.find('.marker-link').click(onAnkiMarkerClicked);
+    tab.find('.marker-link').click((e) => onAnkiMarkerClicked(e));
 }
 
 function onAnkiMarkerClicked(e) {
@@ -651,10 +651,10 @@ function ankiTemplatesInitialize() {
         node.addEventListener('click', onAnkiTemplateMarkerClicked, false);
     }
 
-    $('#field-templates').on('change', onAnkiTemplatesValidateCompile);
-    $('#field-template-render').on('click', onAnkiTemplateRender);
-    $('#field-templates-reset').on('click', onAnkiFieldTemplatesReset);
-    $('#field-templates-reset-confirm').on('click', onAnkiFieldTemplatesResetConfirm);
+    $('#field-templates').on('change', (e) => onAnkiTemplatesValidateCompile(e));
+    $('#field-template-render').on('click', (e) => onAnkiTemplateRender(e));
+    $('#field-templates-reset').on('click', (e) => onAnkiFieldTemplatesReset(e));
+    $('#field-templates-reset-confirm').on('click', (e) => onAnkiFieldTemplatesResetConfirm(e));
 }
 
 const ankiTemplatesValidateGetDefinition = (() => {

--- a/ext/bg/js/settings.js
+++ b/ext/bg/js/settings.js
@@ -155,8 +155,8 @@ async function formWrite(options) {
 }
 
 function formSetupEventListeners() {
-    $('input, select, textarea').not('.anki-model').not('.ignore-form-changes *').change(utilAsync(onFormOptionsChanged));
-    $('.anki-model').change(utilAsync(onAnkiModelChanged));
+    $('input, select, textarea').not('.anki-model').not('.ignore-form-changes *').change((e) => onFormOptionsChanged(e));
+    $('.anki-model').change((e) => onAnkiModelChanged(e));
 }
 
 function formUpdateVisibility(options) {
@@ -219,7 +219,7 @@ async function onReady() {
     chrome.runtime.onMessage.addListener(onMessage);
 }
 
-$(document).ready(utilAsync(onReady));
+$(document).ready(() => onReady());
 
 
 /*
@@ -582,7 +582,7 @@ async function ankiFieldsPopulate(element, options) {
         container.append($(html));
     }
 
-    tab.find('.anki-field-value').change(utilAsync(onFormOptionsChanged));
+    tab.find('.anki-field-value').change((e) => onFormOptionsChanged(e));
     tab.find('.marker-link').click(onAnkiMarkerClicked);
 }
 

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -16,12 +16,6 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-function utilAsync(func) {
-    return function(...args) {
-        func.apply(this, args);
-    };
-}
-
 function utilIsolate(data) {
     return JSON.parse(JSON.stringify(data));
 }

--- a/ext/fg/js/util.js
+++ b/ext/fg/js/util.js
@@ -17,12 +17,6 @@
  */
 
 
-function utilAsync(func) {
-    return function(...args) {
-        func.apply(this, args);
-    };
-}
-
 function utilInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
Creating this as a PR since there's some background info here, in case this ever has to be referenced again.

```utilAsync``` in the foreground is no longer used so it can be removed.
```utilAsync``` is used very infrequently and can easily be replaced by ```(e) => someFunction(e)```.

History:
```utilAsync``` was initially added in bdf231082f4b4ca7c4c90d8b0cd40b6c4201723d. Presumably this was to work around some issues with the version of jQuery being used (v3.2.1) where async functions are not detected correctly. This was most apparent with something like ```$(document).ready(async () => {})``` not working. This seems to be caused by the ```jQuery.type``` function returning invalid results for async functions.

https://github.com/jquery/jquery/blob/3.2.1/src/core.js#L269-L278
https://github.com/jquery/jquery/blob/3.2.1/src/core.js#L452-L456

```js
$.type(() => {}) === 'function';
$.type(async () => {}) === 'object';
// ...
toString.call(() => {}) === '[object Function]';
toString.call(async () => {}) === '[object AsyncFunction]';
```

Good work jQuery.