### PR TITLE
Clipboard monitor refactor

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -12,7 +12,7 @@
         <link rel="icon" type="image/png" href="/mixed/img/icon128.png" sizes="128x128">
     </head>
     <body>
-        <div id="clipboard-paste-target" contenteditable="true"></div>
+        <textarea id="clipboard-paste-target" contenteditable="true"></textarea>
 
         <script src="/mixed/lib/handlebars.min.js"></script>
         <script src="/mixed/lib/jszip.min.js"></script>

--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -12,7 +12,7 @@
         <link rel="icon" type="image/png" href="/mixed/img/icon128.png" sizes="128x128">
     </head>
     <body>
-        <textarea id="clipboard-paste-target" contenteditable="true"></textarea>
+        <textarea id="clipboard-paste-target"></textarea>
 
         <script src="/mixed/lib/handlebars.min.js"></script>
         <script src="/mixed/lib/jszip.min.js"></script>

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -478,10 +478,12 @@ class Backend {
 
     async _onApiClipboardGet() {
         const clipboardPasteTarget = this.clipboardPasteTarget;
-        clipboardPasteTarget.innerText = '';
+        clipboardPasteTarget.value = '';
         clipboardPasteTarget.focus();
         document.execCommand('paste');
-        return clipboardPasteTarget.innerText;
+        const result = clipboardPasteTarget.value;
+        clipboardPasteTarget.value = '';
+        return result;
     }
 
     // Command handlers

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -244,6 +244,9 @@ class DisplaySearch extends Display {
     }
 
     startClipboardMonitor() {
+        // The token below is used as a unique identifier to ensure that a new clipboard monitor
+        // hasn't been started during the await call. The check below the await this.getClipboardText()
+        // call will exit early if the reference has changed.
         const token = {};
         const intervalCallback = async () => {
             this.clipboardMonitorTimerId = null;

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -286,8 +286,10 @@ class DisplaySearch extends Display {
     async getClipboardText() {
         /*
         Notes:
-            apiClipboardGet doesn't work on firefox because document.execCommand('paste') requires
-            user interaction. Therefore, navigator.clipboard.readText() is used.
+            apiClipboardGet doesn't work on Firefox because document.execCommand('paste')
+            results in an empty string on the web extension background page.
+            This may be a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1603985
+            Therefore, navigator.clipboard.readText() is used on Firefox.
 
             navigator.clipboard.readText() can't be used in Chrome for two reasons:
             * Requires page to be focused, else it rejects with an exception.


### PR DESCRIPTION
This addresses a few things:
* Improves performance while the page is focused. Increased delay from 100ms to 250ms. When the page is in the background, delays are typically throttled to minimum 1000ms anyways.
* Ensures there are no overlapping interval callbacks. The `async` delay isn't taken into account when starting the next delay, so technically it's possible for two callbacks to be running 'simultaneously'.
* Added some info about clipboard copying, removing a TODO.
* Improved Firefox browser detection.
* Improved clipboard paste process in the backend to only paste plaintext instead of rich text.