### PR TITLE
Context isolation

### DIFF
--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -17,7 +17,9 @@
  */
 
 function getOptionsMutable(optionsContext) {
-    return utilBackend().getOptions(optionsContext);
+    return utilBackend().getOptions(
+        utilBackgroundIsolate(optionsContext)
+    );
 }
 
 function getOptionsFullMutable() {

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -107,11 +107,7 @@ function utilDatabaseDeleteDictionary(dictionaryName, onProgress) {
 }
 
 async function utilDatabaseImport(data, progress, details) {
-    // Edge cannot read data on the background page due to the File object
-    // being created from a different window. Read on the same page instead.
-    if (EXTENSION_IS_BROWSER_EDGE) {
-        data = await utilReadFile(data);
-    }
+    data = await utilReadFile(data);
     return utilBackend().translator.database.importDictionary(data, progress, details);
 }
 

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -91,11 +91,16 @@ function utilDatabaseGetDictionaryInfo() {
 }
 
 function utilDatabaseGetDictionaryCounts(dictionaryNames, getTotal) {
-    return utilBackend().translator.database.getDictionaryCounts(dictionaryNames, getTotal);
+    return utilBackend().translator.database.getDictionaryCounts(
+        utilBackgroundIsolate(dictionaryNames),
+        utilBackgroundIsolate(getTotal)
+    );
 }
 
 function utilAnkiGetModelFieldNames(modelName) {
-    return utilBackend().anki.getModelFieldNames(modelName);
+    return utilBackend().anki.getModelFieldNames(
+        utilBackgroundIsolate(modelName)
+    );
 }
 
 function utilDatabasePurge() {
@@ -103,12 +108,19 @@ function utilDatabasePurge() {
 }
 
 function utilDatabaseDeleteDictionary(dictionaryName, onProgress) {
-    return utilBackend().translator.database.deleteDictionary(dictionaryName, onProgress);
+    return utilBackend().translator.database.deleteDictionary(
+        utilBackgroundIsolate(dictionaryName),
+        onProgress
+    );
 }
 
 async function utilDatabaseImport(data, progress, details) {
     data = await utilReadFile(data);
-    return utilBackend().translator.database.importDictionary(data, progress, details);
+    return utilBackend().translator.database.importDictionary(
+        utilBackgroundIsolate(data),
+        progress,
+        utilBackgroundIsolate(details)
+    );
 }
 
 function utilReadFile(file) {

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -35,6 +35,7 @@ function utilIsolate(value) {
 function utilFunctionIsolate(func) {
     return function (...args) {
         try {
+            args = args.map((v) => utilIsolate(v));
             return func.call(this, ...args);
         } catch (e) {
             try {
@@ -99,49 +100,49 @@ function utilBackend() {
     return chrome.extension.getBackgroundPage().yomichan_backend;
 }
 
-function utilAnkiGetModelNames() {
-    return utilBackend().anki.getModelNames();
+async function utilAnkiGetModelNames() {
+    return utilIsolate(await utilBackend().anki.getModelNames());
 }
 
-function utilAnkiGetDeckNames() {
-    return utilBackend().anki.getDeckNames();
+async function utilAnkiGetDeckNames() {
+    return utilIsolate(await utilBackend().anki.getDeckNames());
 }
 
-function utilDatabaseGetDictionaryInfo() {
-    return utilBackend().translator.database.getDictionaryInfo();
+async function utilDatabaseGetDictionaryInfo() {
+    return utilIsolate(await utilBackend().translator.database.getDictionaryInfo());
 }
 
-function utilDatabaseGetDictionaryCounts(dictionaryNames, getTotal) {
-    return utilBackend().translator.database.getDictionaryCounts(
+async function utilDatabaseGetDictionaryCounts(dictionaryNames, getTotal) {
+    return utilIsolate(await utilBackend().translator.database.getDictionaryCounts(
         utilBackgroundIsolate(dictionaryNames),
         utilBackgroundIsolate(getTotal)
-    );
+    ));
 }
 
-function utilAnkiGetModelFieldNames(modelName) {
-    return utilBackend().anki.getModelFieldNames(
+async function utilAnkiGetModelFieldNames(modelName) {
+    return utilIsolate(await utilBackend().anki.getModelFieldNames(
         utilBackgroundIsolate(modelName)
-    );
+    ));
 }
 
-function utilDatabasePurge() {
-    return utilBackend().translator.purgeDatabase();
+async function utilDatabasePurge() {
+    return utilIsolate(await utilBackend().translator.purgeDatabase());
 }
 
-function utilDatabaseDeleteDictionary(dictionaryName, onProgress) {
-    return utilBackend().translator.database.deleteDictionary(
+async function utilDatabaseDeleteDictionary(dictionaryName, onProgress) {
+    return utilIsolate(await utilBackend().translator.database.deleteDictionary(
         utilBackgroundIsolate(dictionaryName),
         utilBackgroundFunctionIsolate(onProgress)
-    );
+    ));
 }
 
 async function utilDatabaseImport(data, onProgress, details) {
     data = await utilReadFile(data);
-    return utilBackend().translator.database.importDictionary(
+    return utilIsolate(await utilBackend().translator.database.importDictionary(
         utilBackgroundIsolate(data),
         utilBackgroundFunctionIsolate(onProgress),
         utilBackgroundIsolate(details)
-    );
+    ));
 }
 
 function utilReadFile(file) {


### PR DESCRIPTION
In combination with #306, this fixes #303. With the exception of how the settings page mutates the backend `options` object, all data should now belong to the window it is being used in.