### PR TITLE
Options schema

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -31,6 +31,7 @@
         <script src="/bg/js/deinflector.js"></script>
         <script src="/bg/js/dictionary.js"></script>
         <script src="/bg/js/handlebars.js"></script>
+        <script src="/bg/js/json-schema.js"></script>
         <script src="/bg/js/options.js"></script>
         <script src="/bg/js/profile-conditions.js"></script>
         <script src="/bg/js/request.js"></script>

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -1,0 +1,533 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "version",
+        "profiles",
+        "profileCurrent",
+        "global"
+    ],
+    "properties": {
+        "version": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        "profiles": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "name",
+                    "conditionGroups",
+                    "options"
+                ],
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "default": "Default"
+                    },
+                    "conditionGroups": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "required": [
+                                "conditions"
+                            ],
+                            "properties": {
+                                "conditions": {
+                                    "type": "array",
+                                    "items": {
+                                        "type": "object",
+                                        "required": [
+                                            "type",
+                                            "operator",
+                                            "value"
+                                        ],
+                                        "properties": {
+                                            "type": {
+                                                "type": "string"
+                                            },
+                                            "operator": {
+                                                "type": "string"
+                                            },
+                                            "value": {}
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    "options": {
+                        "type": "object",
+                        "required": [
+                            "version",
+                            "general",
+                            "audio",
+                            "scanning",
+                            "dictionaries",
+                            "parsing",
+                            "anki"
+                        ],
+                        "properties": {
+                            "version": {
+                                "type": "integer",
+                                "minimum": 0
+                            },
+                            "general": {
+                                "type": "object",
+                                "required": [
+                                    "enable",
+                                    "resultOutputMode",
+                                    "debugInfo",
+                                    "maxResults",
+                                    "showAdvanced",
+                                    "popupDisplayMode",
+                                    "popupWidth",
+                                    "popupHeight",
+                                    "popupHorizontalOffset",
+                                    "popupVerticalOffset",
+                                    "popupHorizontalOffset2",
+                                    "popupVerticalOffset2",
+                                    "popupHorizontalTextPosition",
+                                    "popupVerticalTextPosition",
+                                    "showGuide",
+                                    "compactTags",
+                                    "compactGlossaries",
+                                    "mainDictionary",
+                                    "popupTheme",
+                                    "popupOuterTheme",
+                                    "customPopupCss",
+                                    "customPopupOuterCss",
+                                    "enableWanakana",
+                                    "enableClipboardMonitor"
+                                ],
+                                "properties": {
+                                    "enable": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "resultOutputMode": {
+                                        "type": "string",
+                                        "enum": ["group", "merge", "split"],
+                                        "default": "group"
+                                    },
+                                    "debugInfo": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "maxResults": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "default": 32
+                                    },
+                                    "showAdvanced": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "popupDisplayMode": {
+                                        "type": "string",
+                                        "enum": ["default", "full-width"],
+                                        "default": "default"
+                                    },
+                                    "popupWidth": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 400
+                                    },
+                                    "popupHeight": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 250
+                                    },
+                                    "popupHorizontalOffset": {
+                                        "type": "number",
+                                        "default": 0
+                                    },
+                                    "popupVerticalOffset": {
+                                        "type": "number",
+                                        "default": 10
+                                    },
+                                    "popupHorizontalOffset2": {
+                                        "type": "number",
+                                        "default": 10
+                                    },
+                                    "popupVerticalOffset2": {
+                                        "type": "number",
+                                        "default": 0
+                                    },
+                                    "popupHorizontalTextPosition": {
+                                        "type": "string",
+                                        "enum": ["below", "above"],
+                                        "default": "below"
+                                    },
+                                    "popupVerticalTextPosition": {
+                                        "type": "string",
+                                        "enum": ["default", "before", "after", "left", "right"],
+                                        "default": "before"
+                                    },
+                                    "showGuide": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "compactTags": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "compactGlossaries": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "mainDictionary": {
+                                        "type": "string"
+                                    },
+                                    "popupTheme": {
+                                        "type": "string",
+                                        "enum": ["default", "dark"],
+                                        "default": "default"
+                                    },
+                                    "popupOuterTheme": {
+                                        "type": "string",
+                                        "enum": ["default", "dark", "auto"],
+                                        "default": "default"
+                                    },
+                                    "customPopupCss": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "customPopupOuterCss": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "enableWanakana": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "enableClipboardMonitor": {
+                                        "type": "boolean",
+                                        "default": false
+                                    }
+                                }
+                            },
+                            "audio": {
+                                "type": "object",
+                                "required": [
+                                    "enabled",
+                                    "sources",
+                                    "volume",
+                                    "autoPlay",
+                                    "customSourceUrl",
+                                    "textToSpeechVoice"
+                                ],
+                                "properties": {
+                                    "enabled": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "sources": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string",
+                                            "enum": [
+                                                "jpod101",
+                                                "jpod101-alternate",
+                                                "jisho",
+                                                "text-to-speech",
+                                                "text-to-speech-reading",
+                                                "custom"
+                                            ],
+                                            "default": "jpod101"
+                                        }
+                                    },
+                                    "volume": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "maximum": 100,
+                                        "default": 100
+                                    },
+                                    "autoPlay": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "customSourceUrl": {
+                                        "type": "string",
+                                        "default": ""
+                                    },
+                                    "textToSpeechVoice": {
+                                        "type": "string",
+                                        "default": ""
+                                    }
+                                }
+                            },
+                            "scanning": {
+                                "type": "object",
+                                "required": [
+                                    "middleMouse",
+                                    "touchInputEnabled",
+                                    "selectText",
+                                    "alphanumeric",
+                                    "autoHideResults",
+                                    "delay",
+                                    "length",
+                                    "modifier",
+                                    "deepDomScan",
+                                    "popupNestingMaxDepth",
+                                    "enablePopupSearch",
+                                    "enableOnPopupExpressions",
+                                    "enableOnSearchPage"
+                                ],
+                                "properties": {
+                                    "middleMouse": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "touchInputEnabled": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "selectText": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "alphanumeric": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "autoHideResults": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "delay": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 20
+                                    },
+                                    "length": {
+                                        "type": "integer",
+                                        "minimum": 1,
+                                        "default": 10
+                                    },
+                                    "modifier": {
+                                        "type": "string",
+                                        "enum": ["none", "alt", "ctrl", "shift"],
+                                        "default": "shift"
+                                    },
+                                    "deepDomScan": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "popupNestingMaxDepth": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "default": 0
+                                    },
+                                    "enablePopupSearch": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "enableOnPopupExpressions": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "enableOnSearchPage": {
+                                        "type": "boolean",
+                                        "default": true
+                                    }
+                                }
+                            },
+                            "dictionaries": {
+                                "type": "object",
+                                "additionalProperties": {
+                                    "type": "object",
+                                    "required": [
+                                        "priority",
+                                        "enabled",
+                                        "allowSecondarySearches"
+                                    ],
+                                    "properties": {
+                                        "priority": {
+                                            "type": "number",
+                                            "default": 0
+                                        },
+                                        "enabled": {
+                                            "type": "boolean",
+                                            "default": true
+                                        },
+                                        "allowSecondarySearches": {
+                                            "type": "boolean",
+                                            "default": false
+                                        }
+                                    }
+                                }
+                            },
+                            "parsing": {
+                                "type": "object",
+                                "required": [
+                                    "enableScanningParser",
+                                    "enableMecabParser",
+                                    "selectedParser",
+                                    "readingMode"
+                                ],
+                                "properties": {
+                                    "enableScanningParser": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "enableMecabParser": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "selectedParser": {
+                                        "type": ["string", "null"],
+                                        "default": null
+                                    },
+                                    "readingMode": {
+                                        "type": "string",
+                                        "enum": ["hiragana", "katakana", "romaji"],
+                                        "default": "hiragana"
+                                    }
+                                }
+                            },
+                            "anki": {
+                                "type": "object",
+                                "required": [
+                                    "enable",
+                                    "server",
+                                    "tags",
+                                    "sentenceExt",
+                                    "screenshot",
+                                    "terms",
+                                    "kanji",
+                                    "fieldTemplates"
+                                ],
+                                "properties": {
+                                    "enable": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "server": {
+                                        "type": "string",
+                                        "default": "http://127.0.0.1:8765"
+                                    },
+                                    "tags": {
+                                        "type": "array",
+                                        "items": {
+                                            "type": "string"
+                                        },
+                                        "default": [
+                                            "yomichan"
+                                        ]
+                                    },
+                                    "sentenceExt": {
+                                        "type": "integer",
+                                        "minimum": 0,
+                                        "default": 200
+                                    },
+                                    "screenshot": {
+                                        "type": "object",
+                                        "required": [
+                                            "format",
+                                            "quality"
+                                        ],
+                                        "properties": {
+                                            "format": {
+                                                "type": "string",
+                                                "enum": ["png", "jpeg"],
+                                                "default": "png"
+                                            },
+                                            "quality": {
+                                                "type": "integer",
+                                                "minimum": 0,
+                                                "maximum": 100,
+                                                "default": 92
+                                            }
+                                        }
+                                    },
+                                    "terms": {
+                                        "type": "object",
+                                        "required": [
+                                            "deck",
+                                            "model",
+                                            "fields"
+                                        ],
+                                        "properties": {
+                                            "deck": {
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "fields": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string",
+                                                    "default": ""
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "kanji": {
+                                        "type": "object",
+                                        "required": [
+                                            "deck",
+                                            "model",
+                                            "fields"
+                                        ],
+                                        "properties": {
+                                            "deck": {
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "model": {
+                                                "type": "string",
+                                                "default": ""
+                                            },
+                                            "fields": {
+                                                "type": "object",
+                                                "additionalProperties": {
+                                                    "type": "string",
+                                                    "default": ""
+                                                }
+                                            }
+                                        }
+                                    },
+                                    "fieldTemplates": {
+                                        "type": ["string", "null"],
+                                        "default": null
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "profileCurrent": {
+            "type": "integer",
+            "minimum": 0,
+            "default": 0
+        },
+        "global": {
+            "type": "object",
+            "required": [
+                "database"
+            ],
+            "properties": {
+                "database": {
+                    "type": "object",
+                    "required": [
+                        "prefixWildcardsSupported"
+                    ],
+                    "properties": {
+                        "prefixWildcardsSupported": {
+                            "type": "boolean",
+                            "default": false
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -23,6 +23,7 @@ class Backend {
         this.anki = new AnkiNull();
         this.mecab = new Mecab();
         this.options = null;
+        this.optionsSchema = null;
         this.optionsContext = {
             depth: 0,
             url: window.location.href
@@ -38,7 +39,16 @@ class Backend {
 
     async prepare() {
         await this.translator.prepare();
+
+        this.optionsSchema = await requestJson(chrome.runtime.getURL('/bg/data/options-schema.json'), 'GET');
         this.options = await optionsLoad();
+        try {
+            this.options = JsonSchema.getValidValueOrDefault(this.optionsSchema, this.options);
+        } catch (e) {
+            // This shouldn't happen, but catch errors just in case of bugs
+            logError(e);
+        }
+
         this.onOptionsUpdated('background');
 
         if (chrome.commands !== null && typeof chrome.commands === 'object') {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -115,6 +115,13 @@ class Backend {
         }
     }
 
+    async getOptionsSchema() {
+        if (this.isPreparedPromise !== null) {
+            await this.isPreparedPromise;
+        }
+        return this.optionsSchema;
+    }
+
     async getFullOptions() {
         if (this.isPreparedPromise !== null) {
             await this.isPreparedPromise;
@@ -199,6 +206,10 @@ class Backend {
     }
 
     // Message handlers
+
+    _onApiOptionsSchemaGet() {
+        return this.getOptionsSchema();
+    }
 
     _onApiOptionsGet({optionsContext}) {
         return this.getOptions(optionsContext);
@@ -682,6 +693,7 @@ class Backend {
 }
 
 Backend._messageHandlers = new Map([
+    ['optionsSchemaGet', (self, ...args) => self._onApiOptionsSchemaGet(...args)],
     ['optionsGet', (self, ...args) => self._onApiOptionsGet(...args)],
     ['optionsGetFull', (self, ...args) => self._onApiOptionsGetFull(...args)],
     ['optionsSet', (self, ...args) => self._onApiOptionsSet(...args)],

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -1,0 +1,413 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+class JsonSchemaProxyHandler {
+    constructor(schema) {
+        this._schema = schema;
+    }
+
+    getPrototypeOf(target) {
+        return Object.getPrototypeOf(target);
+    }
+
+    setPrototypeOf() {
+        throw new Error('setPrototypeOf not supported');
+    }
+
+    isExtensible(target) {
+        return Object.isExtensible(target);
+    }
+
+    preventExtensions(target) {
+        Object.preventExtensions(target);
+        return true;
+    }
+
+    getOwnPropertyDescriptor(target, property) {
+        return Object.getOwnPropertyDescriptor(target, property);
+    }
+
+    defineProperty() {
+        throw new Error('defineProperty not supported');
+    }
+
+    has(target, property) {
+        return property in target;
+    }
+
+    get(target, property) {
+        if (typeof property === 'symbol') {
+            return target[property];
+        }
+
+        if (Array.isArray(target)) {
+            if (typeof property === 'string' && /^\d+$/.test(property)) {
+                property = parseInt(property, 10);
+            } else if (typeof property === 'string') {
+                return target[property];
+            }
+        }
+
+        const propertySchema = JsonSchemaProxyHandler.getPropertySchema(this._schema, property);
+        if (propertySchema === null) {
+            return;
+        }
+
+        const value = target[property];
+        return value !== null && typeof value === 'object' ? JsonSchema.createProxy(value, propertySchema) : value;
+    }
+
+    set(target, property, value) {
+        if (Array.isArray(target)) {
+            if (typeof property === 'string' && /^\d+$/.test(property)) {
+                property = parseInt(property, 10);
+                if (property > target.length) {
+                    throw new Error('Array index out of range');
+                }
+            } else if (typeof property === 'string') {
+                target[property] = value;
+                return true;
+            }
+        }
+
+        const propertySchema = JsonSchemaProxyHandler.getPropertySchema(this._schema, property);
+        if (propertySchema === null) {
+            throw new Error(`Property ${property} not supported`);
+        }
+
+        value = JsonSchema.isolate(value);
+
+        const error = JsonSchemaProxyHandler.validate(value, propertySchema);
+        if (error !== null) {
+            throw new Error(`Invalid value: ${error}`);
+        }
+
+        target[property] = value;
+        return true;
+    }
+
+    deleteProperty(target, property) {
+        const required = this._schema.required;
+        if (Array.isArray(required) && required.includes(property)) {
+            throw new Error(`${property} cannot be deleted`);
+        }
+        return Reflect.deleteProperty(target, property);
+    }
+
+    ownKeys(target) {
+        return Reflect.ownKeys(target);
+    }
+
+    apply() {
+        throw new Error('apply not supported');
+    }
+
+    construct() {
+        throw new Error('construct not supported');
+    }
+
+    static getPropertySchema(schema, property) {
+        const type = schema.type;
+        if (Array.isArray(type)) {
+            throw new Error(`Ambiguous property type for ${property}`);
+        }
+        switch (type) {
+            case 'object':
+            {
+                const properties = schema.properties;
+                if (properties !== null && typeof properties === 'object' && !Array.isArray(properties)) {
+                    if (Object.prototype.hasOwnProperty.call(properties, property)) {
+                        return properties[property];
+                    }
+                }
+
+                const additionalProperties = schema.additionalProperties;
+                return (additionalProperties !== null && typeof additionalProperties === 'object' && !Array.isArray(additionalProperties)) ? additionalProperties : null;
+            }
+            case 'array':
+            {
+                const items = schema.items;
+                return (items !== null && typeof items === 'object' && !Array.isArray(items)) ? items : null;
+            }
+            default:
+                return null;
+        }
+    }
+
+    static validate(value, schema) {
+        const type = JsonSchemaProxyHandler.getValueType(value);
+        const schemaType = schema.type;
+        if (!JsonSchemaProxyHandler.isValueTypeAny(value, type, schemaType)) {
+            return `Value type ${type} does not match schema type ${schemaType}`;
+        }
+
+        const schemaEnum = schema.enum;
+        if (Array.isArray(schemaEnum) && !JsonSchemaProxyHandler.valuesAreEqualAny(value, schemaEnum)) {
+            return 'Invalid enum value';
+        }
+
+        switch (type) {
+            case 'number':
+                return JsonSchemaProxyHandler.validateNumber(value, schema);
+            case 'string':
+                return JsonSchemaProxyHandler.validateString(value, schema);
+            case 'array':
+                return JsonSchemaProxyHandler.validateArray(value, schema);
+            case 'object':
+                return JsonSchemaProxyHandler.validateObject(value, schema);
+            default:
+                return null;
+        }
+    }
+
+    static validateNumber(value, schema) {
+        const multipleOf = schema.multipleOf;
+        if (typeof multipleOf === 'number' && Math.floor(value / multipleOf) * multipleOf !== value) {
+            return `Number is not a multiple of ${multipleOf}`;
+        }
+
+        const minimum = schema.minimum;
+        if (typeof minimum === 'number' && value < minimum) {
+            return `Number is less than ${minimum}`;
+        }
+
+        const exclusiveMinimum = schema.exclusiveMinimum;
+        if (typeof exclusiveMinimum === 'number' && value <= exclusiveMinimum) {
+            return `Number is less than or equal to ${exclusiveMinimum}`;
+        }
+
+        const maximum = schema.maximum;
+        if (typeof maximum === 'number' && value > maximum) {
+            return `Number is greater than ${maximum}`;
+        }
+
+        const exclusiveMaximum = schema.exclusiveMaximum;
+        if (typeof exclusiveMaximum === 'number' && value >= exclusiveMaximum) {
+            return `Number is greater than or equal to ${exclusiveMaximum}`;
+        }
+
+        return null;
+    }
+
+    static validateString(value, schema) {
+        const minLength = schema.minLength;
+        if (typeof minLength === 'number' && value.length < minLength) {
+            return 'String length too short';
+        }
+
+        const maxLength = schema.minLength;
+        if (typeof maxLength === 'number' && value.length > maxLength) {
+            return 'String length too long';
+        }
+
+        return null;
+    }
+
+    static validateArray(value, schema) {
+        const minItems = schema.minItems;
+        if (typeof minItems === 'number' && value.length < minItems) {
+            return 'Array length too short';
+        }
+
+        const maxItems = schema.maxItems;
+        if (typeof maxItems === 'number' && value.length > maxItems) {
+            return 'Array length too long';
+        }
+
+        return null;
+    }
+
+    static validateObject(value, schema) {
+        const properties = new Set(Object.getOwnPropertyNames(value));
+
+        const required = schema.required;
+        if (Array.isArray(required)) {
+            for (const property of required) {
+                if (!properties.has(property)) {
+                    return `Missing property ${property}`;
+                }
+            }
+        }
+
+        const minProperties = schema.minProperties;
+        if (typeof minProperties === 'number' && properties.length < minProperties) {
+            return 'Not enough object properties';
+        }
+
+        const maxProperties = schema.maxProperties;
+        if (typeof maxProperties === 'number' && properties.length > maxProperties) {
+            return 'Too many object properties';
+        }
+
+        for (const property of properties) {
+            const propertySchema = JsonSchemaProxyHandler.getPropertySchema(schema, property);
+            if (propertySchema === null) {
+                return `No schema found for ${property}`;
+            }
+            const error = JsonSchemaProxyHandler.validate(value[property], propertySchema);
+            if (error !== null) {
+                return error;
+            }
+        }
+
+        return null;
+    }
+
+    static isValueTypeAny(value, type, schemaTypes) {
+        if (typeof schemaTypes === 'string') {
+            return JsonSchemaProxyHandler.isValueType(value, type, schemaTypes);
+        } else if (Array.isArray(schemaTypes)) {
+            for (const schemaType of schemaTypes) {
+                if (JsonSchemaProxyHandler.isValueType(value, type, schemaType)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+
+    static isValueType(value, type, schemaType) {
+        return (
+            type === schemaType ||
+            (schemaType === 'integer' && Math.floor(value) === value)
+        );
+    }
+
+    static getValueType(value) {
+        const type = typeof value;
+        if (type === 'object') {
+            if (value === null) { return 'null'; }
+            if (Array.isArray(value)) { return 'array'; }
+        }
+        return type;
+    }
+
+    static valuesAreEqualAny(value1, valueList) {
+        for (const value2 of valueList) {
+            if (JsonSchemaProxyHandler.valuesAreEqual(value1, value2)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    static valuesAreEqual(value1, value2) {
+        return value1 === value2;
+    }
+
+    static getDefaultTypeValue(type) {
+        if (typeof type === 'string') {
+            switch (type) {
+                case 'null':
+                    return null;
+                case 'boolean':
+                    return false;
+                case 'number':
+                case 'integer':
+                    return 0;
+                case 'string':
+                    return '';
+                case 'array':
+                    return [];
+                case 'object':
+                    return {};
+            }
+        }
+        return null;
+    }
+
+    static getValidValueOrDefault(schema, value) {
+        let type = JsonSchemaProxyHandler.getValueType(value);
+        const schemaType = schema.type;
+        if (!JsonSchemaProxyHandler.isValueTypeAny(value, type, schemaType)) {
+            let assignDefault = true;
+
+            const schemaDefault = schema.default;
+            if (typeof schemaDefault !== 'undefined') {
+                value = JsonSchema.isolate(schemaDefault);
+                type = JsonSchemaProxyHandler.getValueType(value);
+                assignDefault = !JsonSchemaProxyHandler.isValueTypeAny(value, type, schemaType);
+            }
+
+            if (assignDefault) {
+                value = JsonSchemaProxyHandler.getDefaultTypeValue(schemaType);
+                type = JsonSchemaProxyHandler.getValueType(value);
+            }
+        }
+
+        if (type === 'object') {
+            value = JsonSchemaProxyHandler.populateObjectDefaults(value, schema);
+        }
+
+        return value;
+    }
+
+    static populateObjectDefaults(value, schema) {
+        const properties = new Set(Object.getOwnPropertyNames(value));
+
+        const required = schema.required;
+        if (Array.isArray(required)) {
+            for (const property of required) {
+                properties.delete(property);
+
+                const propertySchema = JsonSchemaProxyHandler.getPropertySchema(schema, property);
+                if (propertySchema === null) { continue; }
+                value[property] = JsonSchemaProxyHandler.getValidValueOrDefault(propertySchema, value[property]);
+            }
+        }
+
+        for (const property of properties) {
+            const propertySchema = JsonSchemaProxyHandler.getPropertySchema(schema, property);
+            if (propertySchema === null) {
+                Reflect.deleteProperty(value, property);
+            } else {
+                value[property] = JsonSchemaProxyHandler.getValidValueOrDefault(propertySchema, value[property]);
+            }
+        }
+
+        return value;
+    }
+}
+
+class JsonSchema {
+    static createProxy(target, schema) {
+        return new Proxy(target, new JsonSchemaProxyHandler(schema));
+    }
+
+    static getValidValueOrDefault(schema, value) {
+        return JsonSchemaProxyHandler.getValidValueOrDefault(schema, value);
+    }
+
+    static isolate(value) {
+        if (value === null) { return null; }
+
+        switch (typeof value) {
+            case 'boolean':
+            case 'number':
+            case 'string':
+            case 'bigint':
+            case 'symbol':
+                return value;
+        }
+
+        const stringValue = JSON.stringify(value);
+        return typeof stringValue === 'string' ? JSON.parse(stringValue) : null;
+    }
+}

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -17,6 +17,10 @@
  */
 
 
+function apiOptionsSchemaGet() {
+    return _apiInvoke('optionsSchemaGet');
+}
+
 function apiOptionsGet(optionsContext) {
     return _apiInvoke('optionsGet', {optionsContext});
 }


### PR DESCRIPTION
This change adds support for a JSON validation schema for the options. Currently based on https://json-schema.org/.

The scheme is not fully used yet; validation is currently only performed on extension startup. In the future, the proxy system will be applied to the entire settings object such that all modifications are validated. This will be done in a later commit, otherwise the settings page would be throwing exceptions it's not currently equipped to handle.

This is tracked in #296.