### PR TITLE
Settings import export

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -112,6 +112,18 @@ class Backend {
         return this.options;
     }
 
+    async setFullOptions(options) {
+        if (this.isPreparedPromise !== null) {
+            await this.isPreparedPromise;
+        }
+        try {
+            this.options = JsonSchema.getValidValueOrDefault(this.optionsSchema, utilIsolate(options));
+        } catch (e) {
+            // This shouldn't happen, but catch errors just in case of bugs
+            logError(e);
+        }
+    }
+
     async getOptions(optionsContext) {
         if (this.isPreparedPromise !== null) {
             await this.isPreparedPromise;

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -481,3 +481,7 @@ function optionsSave(options) {
         });
     });
 }
+
+function optionsGetDefault() {
+    return optionsUpdateVersion({}, {});
+}

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2019  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+
+// Exporting
+
+let _settingsExportToken = null;
+let _settingsExportRevoke = null;
+const SETTINGS_EXPORT_CURRENT_VERSION = 0;
+
+function _getSettingsExportDateString(date, dateSeparator, dateTimeSeparator, timeSeparator, resolution) {
+    const values = [
+        date.getUTCFullYear().toString(),
+        dateSeparator,
+        (date.getUTCMonth() + 1).toString().padStart(2, '0'),
+        dateSeparator,
+        date.getUTCDate().toString().padStart(2, '0'),
+        dateTimeSeparator,
+        date.getUTCHours().toString().padStart(2, '0'),
+        timeSeparator,
+        date.getUTCMinutes().toString().padStart(2, '0'),
+        timeSeparator,
+        date.getUTCSeconds().toString().padStart(2, '0')
+    ];
+    return values.slice(0, resolution * 2 - 1).join('');
+}
+
+async function _getSettingsExportData(date) {
+    const optionsFull = await apiOptionsGetFull();
+    const environment = await apiGetEnvironmentInfo();
+
+    const fieldTemplatesDefault = profileOptionsGetDefaultFieldTemplates();
+
+    // Format options
+    for (const {options} of optionsFull.profiles) {
+        if (options.anki.fieldTemplates === fieldTemplatesDefault || !options.anki.fieldTemplates) {
+            delete options.anki.fieldTemplates; // Default
+        }
+    }
+
+    const data = {
+        version: SETTINGS_EXPORT_CURRENT_VERSION,
+        date: _getSettingsExportDateString(date, '-', ' ', ':', 6),
+        url: chrome.runtime.getURL('/'),
+        manifest: chrome.runtime.getManifest(),
+        environment,
+        userAgent: navigator.userAgent,
+        options: optionsFull
+    };
+
+    return data;
+}
+
+function _saveBlob(blob, fileName) {
+    if (typeof navigator === 'object' && typeof navigator.msSaveBlob === 'function') {
+        if (navigator.msSaveBlob(blob)) {
+            return;
+        }
+    }
+
+    const blobUrl = URL.createObjectURL(blob);
+
+    const a = document.createElement('a');
+    a.href = blobUrl;
+    a.download = fileName;
+    a.rel = 'noopener';
+    a.target = '_blank';
+
+    const revoke = () => {
+        URL.revokeObjectURL(blobUrl);
+        a.href = '';
+        _settingsExportRevoke = null;
+    };
+    _settingsExportRevoke = revoke;
+
+    a.dispatchEvent(new MouseEvent('click'));
+    setTimeout(revoke, 60000);
+}
+
+async function _onSettingsExportClick() {
+    if (_settingsExportRevoke !== null) {
+        _settingsExportRevoke();
+        _settingsExportRevoke = null;
+    }
+
+    const date = new Date(Date.now());
+
+    const token = {};
+    _settingsExportToken = token;
+    const data = await _getSettingsExportData(date);
+    if (_settingsExportToken !== token) {
+        // A new export has been started
+        return;
+    }
+    _settingsExportToken = null;
+
+    const fileName = `yomichan-settings-${_getSettingsExportDateString(date, '-', '-', '-', 6)}.json`;
+    const blob = new Blob([JSON.stringify(data, null, 4)], {type: 'application/json'});
+    _saveBlob(blob, fileName);
+}
+
+
+// Setup
+
+window.addEventListener('DOMContentLoaded', () => {
+    document.querySelector('#settings-export').addEventListener('click', _onSettingsExportClick, false);
+}, false);

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -339,10 +339,32 @@ function _onSettingsImportFileChange(e) {
 }
 
 
+// Resetting
+
+function _onSettingsResetClick() {
+    $('#settings-reset-modal').modal('show');
+}
+
+async function _onSettingsResetConfirmClick() {
+    $('#settings-reset-modal').modal('hide');
+
+    // Get default options
+    const optionsFull = optionsGetDefault();
+
+    // Assign options
+    await _settingsImportSetOptionsFull(optionsFull);
+
+    // Reload settings page
+    window.location.reload();
+}
+
+
 // Setup
 
 window.addEventListener('DOMContentLoaded', () => {
     document.querySelector('#settings-export').addEventListener('click', _onSettingsExportClick, false);
     document.querySelector('#settings-import').addEventListener('click', _onSettingsImportClick, false);
     document.querySelector('#settings-import-file').addEventListener('change', _onSettingsImportFileChange, false);
+    document.querySelector('#settings-reset').addEventListener('click', _onSettingsResetClick, false);
+    document.querySelector('#settings-reset-modal-confirm').addEventListener('click', _onSettingsResetConfirmClick, false);
 }, false);

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -153,3 +153,12 @@ function utilReadFile(file) {
         reader.readAsBinaryString(file);
     });
 }
+
+function utilReadFileArrayBuffer(file) {
+    return new Promise((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => resolve(reader.result);
+        reader.onerror = () => reject(reader.error);
+        reader.readAsArrayBuffer(file);
+    });
+}

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -865,6 +865,7 @@
                 <div>
                     <button class="btn btn-default" id="settings-export">Export Settings</button>
                     <button class="btn btn-default" id="settings-import">Import Settings</button>
+                    <button class="btn btn-danger" id="settings-reset">Reset Default Settings</button>
                 </div>
 
                 <div hidden><input type="file" id="settings-import-file" accept=".json,application/json"></div>
@@ -910,6 +911,36 @@
                                 <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
                                 <button type="button" class="btn btn-danger settings-import-warning-modal-import-button">Import</button>
                                 <button type="button" class="btn btn-primary settings-import-warning-modal-import-button" data-import-sanitize="true">Sanitize and Import</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal fade" tabindex="-1" role="dialog" id="settings-reset-modal">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title">Settings Reset</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p class="text-danger">
+                                    You are about to reset all Yomichan settings back to their default values.
+                                    This will delete all custom profiles you may have created.
+                                    <strong>This action cannot be undone.</strong>
+                                </p>
+                                <p>
+                                    Consider making a backup using the "Export Settings" button before resetting
+                                    if you want to be able to revert.
+                                </p>
+                                <p>
+                                    Dictionary data will not be deleted, but any installed dictionaries
+                                    will need to be re-enabled.
+                                </p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-danger" id="settings-reset-modal-confirm">Reset All Settings</button>
                             </div>
                         </div>
                     </div>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -864,6 +864,55 @@
 
                 <div>
                     <button class="btn btn-default" id="settings-export">Export Settings</button>
+                    <button class="btn btn-default" id="settings-import">Import Settings</button>
+                </div>
+
+                <div hidden><input type="file" id="settings-import-file" accept=".json,application/json"></div>
+
+                <div class="modal fade" tabindex="-1" role="dialog" id="settings-import-error-modal">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title">Import Error</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>
+                                    An error occurred while trying to import the settings file:
+                                </p>
+                                <p class="text-danger" id="settings-import-error-modal-message"></p>
+                                <p>
+                                    Additional info can be found in the developer console.
+                                </p>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+
+                <div class="modal fade" tabindex="-1" role="dialog" id="settings-import-warning-modal">
+                    <div class="modal-dialog modal-dialog-centered">
+                        <div class="modal-content">
+                            <div class="modal-header">
+                                <button type="button" class="close" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                                <h4 class="modal-title">Import Security Warning</h4>
+                            </div>
+                            <div class="modal-body">
+                                <p>
+                                    Settings file contains settings which may pose a security risk.
+                                    Only import settings from sources you trust.
+                                </p>
+                                <ul class="text-danger" id="settings-import-warning-modal-message"></ul>
+                            </div>
+                            <div class="modal-footer">
+                                <button type="button" class="btn btn-default" data-dismiss="modal">Cancel</button>
+                                <button type="button" class="btn btn-danger settings-import-warning-modal-import-button">Import</button>
+                                <button type="button" class="btn btn-primary settings-import-warning-modal-import-button" data-import-sanitize="true">Sanitize and Import</button>
+                            </div>
+                        </div>
+                    </div>
                 </div>
             </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -851,6 +851,22 @@
                 </ul>
             </div>
 
+
+            <div>
+                <h3>Backup</h3>
+
+                <p class="help-block">
+                    Yomichan can import and export settings files which can be used to restore settings,
+                    share settings across devices, or help to debug problems.
+                    These files will only contain settings and will not contain dictionaries.
+                    Dictionaries must be imported separately.
+                </p>
+
+                <div>
+                    <button class="btn btn-default" id="settings-export">Export Settings</button>
+                </div>
+            </div>
+
             <div>
                 <h3>Support Development</h3>
 
@@ -899,6 +915,7 @@
         <script src="/bg/js/settings/anki-templates.js"></script>
         <script src="/bg/js/settings/audio.js"></script>
         <script src="/bg/js/settings/audio-ui.js"></script>
+        <script src="/bg/js/settings/backup.js"></script>
         <script src="/bg/js/settings/conditions-ui.js"></script>
         <script src="/bg/js/settings/dictionaries.js"></script>
         <script src="/bg/js/settings/popup-preview.js"></script>


### PR DESCRIPTION
Adds support for exporting settings, importing settings, and resetting all settings to default values.

**This commit is dependent on the features added in #309 and #310.** I am putting this up now because there are no code conflicts, but the features added in those PRs are required for this change to work.

* The export button exports to a .json file. The file includes the options and some additional metadata for debugging/informational purposes.
* The import button imports this file and overwrites the settings. Since certain options could be considered insecure if they are coming from an untrusted source, a warning will appear if these settings are considered suspicious. Currently this includes:
  * Non-default `anki.fieldTemplates`, since this value can effectively `eval` code.
  * `anki.server` values which are not localhost. Pointing to a remote server could potentially be dangerous.
  * `audio.customSourceUrl` values are not localhost, for the same reasons above.
* The reset button resets all settings to the default values. This removes all profiles, but does not clear dictionary data.

Resolves #112.
This is tracked in #296.