### PR TITLE
Popup class private members

### DIFF
--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -166,7 +166,7 @@ class SettingsPopupPreview {
         this.textSource = source;
         await this.frontend.showContentCompleted();
 
-        if (this.frontend.popup.isVisible()) {
+        if (this.frontend.popup.isVisibleSync()) {
             this.popupShown = true;
         }
 

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -53,7 +53,7 @@ class SettingsPopupPreview {
         this.frontend.setEnabled = function () {};
         this.frontend.searchClear = function () {};
 
-        this.frontend.popup.childrenSupported = false;
+        this.frontend.popup.setChildrenSupported(false);
 
         await this.frontend.isPrepared();
 

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -54,7 +54,6 @@ class SettingsPopupPreview {
         this.frontend.searchClear = function () {};
 
         this.frontend.popup.childrenSupported = false;
-        this.frontend.popup.interactive = false;
 
         await this.frontend.isPrepared();
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -22,7 +22,7 @@ class Frontend extends TextScanner {
         super(
             window,
             ignoreNodes,
-            [popup.getContainer()],
+            popup.isProxy() ? [] : [popup.getContainer()],
             [(x, y) => this.popup.containsPoint(x, y)]
         );
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -200,6 +200,6 @@ Frontend._windowMessageHandlers = new Map([
 ]);
 
 Frontend._runtimeMessageHandlers = new Map([
-    ['optionsUpdate', (self) => self.updateOptions()],
-    ['popupSetVisibleOverride', (self, {visible}) => self.popup.setVisibleOverride(visible)]
+    ['optionsUpdate', (self) => { self.updateOptions(); }],
+    ['popupSetVisibleOverride', (self, {visible}) => { self.popup.setVisibleOverride(visible); }]
 ]);

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -22,7 +22,7 @@ class Frontend extends TextScanner {
         super(
             window,
             ignoreNodes,
-            [popup.container],
+            [popup.getContainer()],
             [(x, y) => this.popup.containsPoint(x, y)]
         );
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -67,7 +67,7 @@ class Frontend extends TextScanner {
 
     async onResize() {
         const textSource = this.textSourceCurrent;
-        if (textSource !== null && await this.popup.isVisibleAsync()) {
+        if (textSource !== null && await this.popup.isVisible()) {
             this._lastShowPromise = this.popup.showContent(
                 textSource.getRect(),
                 textSource.getWritingMode()

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -140,7 +140,7 @@ class PopupProxyHost {
     }
 
     static _popupCanShow(popup) {
-        return popup.parent === null || popup.parent.isVisible();
+        return popup.parent === null || popup.parent.isVisibleSync();
     }
 }
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -39,15 +39,15 @@ class PopupProxyHost {
         if (typeof frameId !== 'number') { return; }
 
         this.apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, new Map([
-            ['createNestedPopup', ({parentId}) => this.createNestedPopup(parentId)],
-            ['setOptions', ({id, options}) => this.setOptions(id, options)],
-            ['hide', ({id, changeFocus}) => this.hide(id, changeFocus)],
-            ['isVisibleAsync', ({id}) => this.isVisibleAsync(id)],
-            ['setVisibleOverride', ({id, visible}) => this.setVisibleOverride(id, visible)],
-            ['containsPoint', ({id, x, y}) => this.containsPoint(id, x, y)],
-            ['showContent', ({id, elementRect, writingMode, type, details}) => this.showContent(id, elementRect, writingMode, type, details)],
-            ['setCustomCss', ({id, css}) => this.setCustomCss(id, css)],
-            ['clearAutoPlayTimer', ({id}) => this.clearAutoPlayTimer(id)]
+            ['createNestedPopup', ({parentId}) => this._onApiCreateNestedPopup(parentId)],
+            ['setOptions', ({id, options}) => this._onApiSetOptions(id, options)],
+            ['hide', ({id, changeFocus}) => this._onApiHide(id, changeFocus)],
+            ['isVisibleAsync', ({id}) => this._onApiIsVisibleAsync(id)],
+            ['setVisibleOverride', ({id, visible}) => this._onApiSetVisibleOverride(id, visible)],
+            ['containsPoint', ({id, x, y}) => this._onApiContainsPoint(id, x, y)],
+            ['showContent', ({id, elementRect, writingMode, type, details}) => this._onApiShowContent(id, elementRect, writingMode, type, details)],
+            ['setCustomCss', ({id, css}) => this._onApiSetCustomCss(id, css)],
+            ['clearAutoPlayTimer', ({id}) => this._onApiClearAutoPlayTimer(id)]
         ]));
     }
 
@@ -69,48 +69,48 @@ class PopupProxyHost {
 
     // Message handlers
 
-    async createNestedPopup(parentId) {
+    async _onApiCreateNestedPopup(parentId) {
         return this.createPopup(parentId, 0).id;
     }
 
-    async setOptions(id, options) {
+    async _onApiSetOptions(id, options) {
         const popup = this._getPopup(id);
         return await popup.setOptions(options);
     }
 
-    async hide(id, changeFocus) {
+    async _onApiHide(id, changeFocus) {
         const popup = this._getPopup(id);
         return popup.hide(changeFocus);
     }
 
-    async isVisibleAsync(id) {
+    async _onApiIsVisibleAsync(id) {
         const popup = this._getPopup(id);
         return await popup.isVisibleAsync();
     }
 
-    async setVisibleOverride(id, visible) {
+    async _onApiSetVisibleOverride(id, visible) {
         const popup = this._getPopup(id);
         return await popup.setVisibleOverride(visible);
     }
 
-    async containsPoint(id, x, y) {
+    async _onApiContainsPoint(id, x, y) {
         const popup = this._getPopup(id);
         return await popup.containsPoint(x, y);
     }
 
-    async showContent(id, elementRect, writingMode, type, details) {
+    async _onApiShowContent(id, elementRect, writingMode, type, details) {
         const popup = this._getPopup(id);
         elementRect = PopupProxyHost._convertJsonRectToDOMRect(popup, elementRect);
         if (!PopupProxyHost._popupCanShow(popup)) { return Promise.resolve(false); }
         return await popup.showContent(elementRect, writingMode, type, details);
     }
 
-    async setCustomCss(id, css) {
+    async _onApiSetCustomCss(id, css) {
         const popup = this._getPopup(id);
         return popup.setCustomCss(css);
     }
 
-    async clearAutoPlayTimer(id) {
+    async _onApiClearAutoPlayTimer(id) {
         const popup = this._getPopup(id);
         return popup.clearAutoPlayTimer();
     }

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -19,10 +19,10 @@
 
 class PopupProxyHost {
     constructor() {
-        this.popups = new Map();
-        this.nextId = 0;
-        this.apiReceiver = null;
-        this.frameIdPromise = null;
+        this._popups = new Map();
+        this._nextId = 0;
+        this._apiReceiver = null;
+        this._frameIdPromise = null;
     }
 
     // Public functions
@@ -34,11 +34,11 @@ class PopupProxyHost {
     }
 
     async prepare() {
-        this.frameIdPromise = apiFrameInformationGet();
-        const {frameId} = await this.frameIdPromise;
+        this._frameIdPromise = apiFrameInformationGet();
+        const {frameId} = await this._frameIdPromise;
         if (typeof frameId !== 'number') { return; }
 
-        this.apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, new Map([
+        this._apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, new Map([
             ['createNestedPopup', ({parentId}) => this._onApiCreateNestedPopup(parentId)],
             ['setOptions', ({id, options}) => this._onApiSetOptions(id, options)],
             ['hide', ({id, changeFocus}) => this._onApiHide(id, changeFocus)],
@@ -52,18 +52,18 @@ class PopupProxyHost {
     }
 
     createPopup(parentId, depth) {
-        const parent = (typeof parentId === 'string' && this.popups.has(parentId) ? this.popups.get(parentId) : null);
-        const id = `${this.nextId}`;
+        const parent = (typeof parentId === 'string' && this._popups.has(parentId) ? this._popups.get(parentId) : null);
+        const id = `${this._nextId}`;
         if (parent !== null) {
             depth = parent.depth + 1;
         }
-        ++this.nextId;
-        const popup = new Popup(id, depth, this.frameIdPromise);
+        ++this._nextId;
+        const popup = new Popup(id, depth, this._frameIdPromise);
         if (parent !== null) {
             popup.parent = parent;
             parent.child = popup;
         }
-        this.popups.set(id, popup);
+        this._popups.set(id, popup);
         return popup;
     }
 
@@ -118,7 +118,7 @@ class PopupProxyHost {
     // Private functions
 
     _getPopup(id) {
-        const popup = this.popups.get(id);
+        const popup = this._popups.get(id);
         if (typeof popup === 'undefined') {
             throw new Error('Invalid popup ID');
         }

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -114,8 +114,7 @@ class PopupProxyHost {
         ++this._nextId;
         const popup = new Popup(id, depth, this._frameIdPromise);
         if (parent !== null) {
-            popup.parent = parent;
-            parent.child = popup;
+            popup.setParent(parent);
         }
         this._popups.set(id, popup);
         return {popup, id};

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -101,7 +101,7 @@ class PopupProxyHost {
     async _onApiShowContent(id, elementRect, writingMode, type, details) {
         const popup = this._getPopup(id);
         elementRect = PopupProxyHost._convertJsonRectToDOMRect(popup, elementRect);
-        if (!PopupProxyHost._popupCanShow(popup)) { return Promise.resolve(false); }
+        if (!PopupProxyHost._popupCanShow(popup)) { return; }
         return await popup.showContent(elementRect, writingMode, type, details);
     }
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -73,17 +73,6 @@ class PopupProxyHost {
         return popup;
     }
 
-    jsonRectToDOMRect(popup, jsonRect) {
-        let x = jsonRect.x;
-        let y = jsonRect.y;
-        if (popup.parent !== null) {
-            const popupRect = popup.parent.container.getBoundingClientRect();
-            x += popupRect.x;
-            y += popupRect.y;
-        }
-        return new DOMRect(x, y, jsonRect.width, jsonRect.height);
-    }
-
     // Message handlers
 
     async createNestedPopup(parentId) {
@@ -117,7 +106,7 @@ class PopupProxyHost {
 
     async showContent(id, elementRect, writingMode, type, details) {
         const popup = this.getPopup(id);
-        elementRect = this.jsonRectToDOMRect(popup, elementRect);
+        elementRect = PopupProxyHost.convertJsonRectToDOMRect(popup, elementRect);
         if (!PopupProxyHost.popupCanShow(popup)) { return Promise.resolve(false); }
         return await popup.showContent(elementRect, writingMode, type, details);
     }
@@ -130,6 +119,17 @@ class PopupProxyHost {
     async clearAutoPlayTimer(id) {
         const popup = this.getPopup(id);
         return popup.clearAutoPlayTimer();
+    }
+
+    static convertJsonRectToDOMRect(popup, jsonRect) {
+        let x = jsonRect.x;
+        let y = jsonRect.y;
+        if (popup.parent !== null) {
+            const popupRect = popup.parent.container.getBoundingClientRect();
+            x += popupRect.x;
+            y += popupRect.y;
+        }
+        return new DOMRect(x, y, jsonRect.width, jsonRect.height);
     }
 
     static popupCanShow(popup) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -52,25 +52,13 @@ class PopupProxyHost {
     }
 
     createPopup(parentId, depth) {
-        const parent = (typeof parentId === 'string' && this._popups.has(parentId) ? this._popups.get(parentId) : null);
-        const id = `${this._nextId}`;
-        if (parent !== null) {
-            depth = parent.depth + 1;
-        }
-        ++this._nextId;
-        const popup = new Popup(id, depth, this._frameIdPromise);
-        if (parent !== null) {
-            popup.parent = parent;
-            parent.child = popup;
-        }
-        this._popups.set(id, popup);
-        return popup;
+        return this._createPopupInternal(parentId, depth).popup;
     }
 
     // Message handlers
 
     async _onApiCreateNestedPopup(parentId) {
-        return this.createPopup(parentId, 0).id;
+        return this._createPopupInternal(parentId, 0).id;
     }
 
     async _onApiSetOptions(id, options) {
@@ -116,6 +104,22 @@ class PopupProxyHost {
     }
 
     // Private functions
+
+    _createPopupInternal(parentId, depth) {
+        const parent = (typeof parentId === 'string' && this._popups.has(parentId) ? this._popups.get(parentId) : null);
+        const id = `${this._nextId}`;
+        if (parent !== null) {
+            depth = parent.depth + 1;
+        }
+        ++this._nextId;
+        const popup = new Popup(id, depth, this._frameIdPromise);
+        if (parent !== null) {
+            popup.parent = parent;
+            parent.child = popup;
+        }
+        this._popups.set(id, popup);
+        return {popup, id};
+    }
 
     _getPopup(id) {
         const popup = this._popups.get(id);

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -19,7 +19,7 @@
 
 class PopupProxyHost {
     constructor() {
-        this.popups = {};
+        this.popups = new Map();
         this.nextId = 0;
         this.apiReceiver = null;
         this.frameIdPromise = null;
@@ -50,7 +50,7 @@ class PopupProxyHost {
     }
 
     createPopup(parentId, depth) {
-        const parent = (typeof parentId === 'string' && hasOwn(this.popups, parentId) ? this.popups[parentId] : null);
+        const parent = (typeof parentId === 'string' && this.popups.has(parentId) ? this.popups.get(parentId) : null);
         const id = `${this.nextId}`;
         if (parent !== null) {
             depth = parent.depth + 1;
@@ -61,7 +61,7 @@ class PopupProxyHost {
             popup.parent = parent;
             parent.child = popup;
         }
-        this.popups[id] = popup;
+        this.popups.set(id, popup);
         return popup;
     }
 
@@ -70,11 +70,11 @@ class PopupProxyHost {
     }
 
     getPopup(id) {
-        if (!hasOwn(this.popups, id)) {
+        const popup = this.popups.get(id);
+        if (typeof popup === 'undefined') {
             throw new Error('Invalid popup ID');
         }
-
-        return this.popups[id];
+        return popup;
     }
 
     jsonRectToDOMRect(popup, jsonRect) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -42,7 +42,7 @@ class PopupProxyHost {
             ['createNestedPopup', ({parentId}) => this._onApiCreateNestedPopup(parentId)],
             ['setOptions', ({id, options}) => this._onApiSetOptions(id, options)],
             ['hide', ({id, changeFocus}) => this._onApiHide(id, changeFocus)],
-            ['isVisibleAsync', ({id}) => this._onApiIsVisibleAsync(id)],
+            ['isVisible', ({id}) => this._onApiIsVisibleAsync(id)],
             ['setVisibleOverride', ({id, visible}) => this._onApiSetVisibleOverride(id, visible)],
             ['containsPoint', ({id, x, y}) => this._onApiContainsPoint(id, x, y)],
             ['showContent', ({id, elementRect, writingMode, type, details}) => this._onApiShowContent(id, elementRect, writingMode, type, details)],
@@ -73,7 +73,7 @@ class PopupProxyHost {
 
     async _onApiIsVisibleAsync(id) {
         const popup = this._getPopup(id);
-        return await popup.isVisibleAsync();
+        return await popup.isVisible();
     }
 
     async _onApiSetVisibleOverride(id, visible) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -25,6 +25,8 @@ class PopupProxyHost {
         this.frameIdPromise = null;
     }
 
+    // Public functions
+
     static create() {
         const popupProxyHost = new PopupProxyHost();
         popupProxyHost.prepare();
@@ -65,14 +67,6 @@ class PopupProxyHost {
         return popup;
     }
 
-    getPopup(id) {
-        const popup = this.popups.get(id);
-        if (typeof popup === 'undefined') {
-            throw new Error('Invalid popup ID');
-        }
-        return popup;
-    }
-
     // Message handlers
 
     async createNestedPopup(parentId) {
@@ -80,48 +74,58 @@ class PopupProxyHost {
     }
 
     async setOptions(id, options) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return await popup.setOptions(options);
     }
 
     async hide(id, changeFocus) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return popup.hide(changeFocus);
     }
 
     async isVisibleAsync(id) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return await popup.isVisibleAsync();
     }
 
     async setVisibleOverride(id, visible) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return await popup.setVisibleOverride(visible);
     }
 
     async containsPoint(id, x, y) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return await popup.containsPoint(x, y);
     }
 
     async showContent(id, elementRect, writingMode, type, details) {
-        const popup = this.getPopup(id);
-        elementRect = PopupProxyHost.convertJsonRectToDOMRect(popup, elementRect);
-        if (!PopupProxyHost.popupCanShow(popup)) { return Promise.resolve(false); }
+        const popup = this._getPopup(id);
+        elementRect = PopupProxyHost._convertJsonRectToDOMRect(popup, elementRect);
+        if (!PopupProxyHost._popupCanShow(popup)) { return Promise.resolve(false); }
         return await popup.showContent(elementRect, writingMode, type, details);
     }
 
     async setCustomCss(id, css) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return popup.setCustomCss(css);
     }
 
     async clearAutoPlayTimer(id) {
-        const popup = this.getPopup(id);
+        const popup = this._getPopup(id);
         return popup.clearAutoPlayTimer();
     }
 
-    static convertJsonRectToDOMRect(popup, jsonRect) {
+    // Private functions
+
+    _getPopup(id) {
+        const popup = this.popups.get(id);
+        if (typeof popup === 'undefined') {
+            throw new Error('Invalid popup ID');
+        }
+        return popup;
+    }
+
+    static _convertJsonRectToDOMRect(popup, jsonRect) {
         let x = jsonRect.x;
         let y = jsonRect.y;
         if (popup.parent !== null) {
@@ -132,7 +136,7 @@ class PopupProxyHost {
         return new DOMRect(x, y, jsonRect.width, jsonRect.height);
     }
 
-    static popupCanShow(popup) {
+    static _popupCanShow(popup) {
         return popup.parent === null || popup.parent.isVisible();
     }
 }

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -65,10 +65,6 @@ class PopupProxyHost {
         return popup;
     }
 
-    async createNestedPopup(parentId) {
-        return this.createPopup(parentId, 0).id;
-    }
-
     getPopup(id) {
         const popup = this.popups.get(id);
         if (typeof popup === 'undefined') {
@@ -86,6 +82,12 @@ class PopupProxyHost {
             y += popupRect.y;
         }
         return new DOMRect(x, y, jsonRect.width, jsonRect.height);
+    }
+
+    // Message handlers
+
+    async createNestedPopup(parentId) {
+        return this.createPopup(parentId, 0).id;
     }
 
     async setOptions(id, options) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -129,7 +129,7 @@ class PopupProxyHost {
         let x = jsonRect.x;
         let y = jsonRect.y;
         if (popup.parent !== null) {
-            const popupRect = popup.parent.container.getBoundingClientRect();
+            const popupRect = popup.parent.getContainerRect();
             x += popupRect.x;
             y += popupRect.y;
         }

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -19,19 +19,34 @@
 
 class PopupProxy {
     constructor(depth, parentId, parentFrameId, url) {
-        this.parentId = parentId;
-        this.parentFrameId = parentFrameId;
-        this.id = null;
-        this.idPromise = null;
-        this.parent = null;
-        this.child = null;
-        this.depth = depth;
-        this.url = url;
-
-        this.container = null;
-
-        this.apiSender = new FrontendApiSender();
+        this._parentId = parentId;
+        this._parentFrameId = parentFrameId;
+        this._id = null;
+        this._idPromise = null;
+        this._depth = depth;
+        this._url = url;
+        this._apiSender = new FrontendApiSender();
     }
+
+    // Public properties
+
+    get parent() {
+        return null;
+    }
+
+    get child() {
+        return null;
+    }
+
+    get depth() {
+        return this._depth;
+    }
+
+    get url() {
+        return this._url;
+    }
+
+    // Public functions
 
     async setOptions(options) {
         const id = await this._getPopupId();
@@ -39,10 +54,10 @@ class PopupProxy {
     }
 
     async hide(changeFocus) {
-        if (this.id === null) {
+        if (this._id === null) {
             return;
         }
-        return await this._invokeHostApi('hide', {id: this.id, changeFocus});
+        return await this._invokeHostApi('hide', {id: this._id, changeFocus});
     }
 
     async isVisibleAsync() {
@@ -56,10 +71,10 @@ class PopupProxy {
     }
 
     async containsPoint(x, y) {
-        if (this.id === null) {
+        if (this._id === null) {
             return false;
         }
-        return await this._invokeHostApi('containsPoint', {id: this.id, x, y});
+        return await this._invokeHostApi('containsPoint', {id: this._id, x, y});
     }
 
     async showContent(elementRect, writingMode, type=null, details=null) {
@@ -74,32 +89,32 @@ class PopupProxy {
     }
 
     async clearAutoPlayTimer() {
-        if (this.id === null) {
+        if (this._id === null) {
             return;
         }
-        return await this._invokeHostApi('clearAutoPlayTimer', {id: this.id});
+        return await this._invokeHostApi('clearAutoPlayTimer', {id: this._id});
     }
 
     // Private
 
     _getPopupId() {
-        if (this.idPromise === null) {
-            this.idPromise = this._getPopupIdAsync();
+        if (this._idPromise === null) {
+            this._idPromise = this._getPopupIdAsync();
         }
-        return this.idPromise;
+        return this._idPromise;
     }
 
     async _getPopupIdAsync() {
-        const id = await this._invokeHostApi('createNestedPopup', {parentId: this.parentId});
-        this.id = id;
+        const id = await this._invokeHostApi('createNestedPopup', {parentId: this._parentId});
+        this._id = id;
         return id;
     }
 
     _invokeHostApi(action, params={}) {
-        if (typeof this.parentFrameId !== 'number') {
+        if (typeof this._parentFrameId !== 'number') {
             return Promise.reject(new Error('Invalid frame'));
         }
-        return this.apiSender.invoke(action, params, `popup-proxy-host#${this.parentFrameId}`);
+        return this._apiSender.invoke(action, params, `popup-proxy-host#${this._parentFrameId}`);
     }
 
     static _convertDOMRectToJson(domRect) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -33,74 +33,76 @@ class PopupProxy {
         this.apiSender = new FrontendApiSender();
     }
 
-    getPopupId() {
-        if (this.idPromise === null) {
-            this.idPromise = this.getPopupIdAsync();
-        }
-        return this.idPromise;
-    }
-
-    async getPopupIdAsync() {
-        const id = await this.invokeHostApi('createNestedPopup', {parentId: this.parentId});
-        this.id = id;
-        return id;
-    }
-
     async setOptions(options) {
-        const id = await this.getPopupId();
-        return await this.invokeHostApi('setOptions', {id, options});
+        const id = await this._getPopupId();
+        return await this._invokeHostApi('setOptions', {id, options});
     }
 
     async hide(changeFocus) {
         if (this.id === null) {
             return;
         }
-        return await this.invokeHostApi('hide', {id: this.id, changeFocus});
+        return await this._invokeHostApi('hide', {id: this.id, changeFocus});
     }
 
     async isVisibleAsync() {
-        const id = await this.getPopupId();
-        return await this.invokeHostApi('isVisibleAsync', {id});
+        const id = await this._getPopupId();
+        return await this._invokeHostApi('isVisibleAsync', {id});
     }
 
     async setVisibleOverride(visible) {
-        const id = await this.getPopupId();
-        return await this.invokeHostApi('setVisibleOverride', {id, visible});
+        const id = await this._getPopupId();
+        return await this._invokeHostApi('setVisibleOverride', {id, visible});
     }
 
     async containsPoint(x, y) {
         if (this.id === null) {
             return false;
         }
-        return await this.invokeHostApi('containsPoint', {id: this.id, x, y});
+        return await this._invokeHostApi('containsPoint', {id: this.id, x, y});
     }
 
     async showContent(elementRect, writingMode, type=null, details=null) {
-        const id = await this.getPopupId();
-        elementRect = PopupProxy.DOMRectToJson(elementRect);
-        return await this.invokeHostApi('showContent', {id, elementRect, writingMode, type, details});
+        const id = await this._getPopupId();
+        elementRect = PopupProxy._convertDOMRectToJson(elementRect);
+        return await this._invokeHostApi('showContent', {id, elementRect, writingMode, type, details});
     }
 
     async setCustomCss(css) {
-        const id = await this.getPopupId();
-        return await this.invokeHostApi('setCustomCss', {id, css});
+        const id = await this._getPopupId();
+        return await this._invokeHostApi('setCustomCss', {id, css});
     }
 
     async clearAutoPlayTimer() {
         if (this.id === null) {
             return;
         }
-        return await this.invokeHostApi('clearAutoPlayTimer', {id: this.id});
+        return await this._invokeHostApi('clearAutoPlayTimer', {id: this.id});
     }
 
-    invokeHostApi(action, params={}) {
+    // Private
+
+    _getPopupId() {
+        if (this.idPromise === null) {
+            this.idPromise = this._getPopupIdAsync();
+        }
+        return this.idPromise;
+    }
+
+    async _getPopupIdAsync() {
+        const id = await this._invokeHostApi('createNestedPopup', {parentId: this.parentId});
+        this.id = id;
+        return id;
+    }
+
+    _invokeHostApi(action, params={}) {
         if (typeof this.parentFrameId !== 'number') {
             return Promise.reject(new Error('Invalid frame'));
         }
         return this.apiSender.invoke(action, params, `popup-proxy-host#${this.parentFrameId}`);
     }
 
-    static DOMRectToJson(domRect) {
+    static _convertDOMRectToJson(domRect) {
         return {
             x: domRect.x,
             y: domRect.y,

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -34,10 +34,6 @@ class PopupProxy {
         return null;
     }
 
-    get child() {
-        return null;
-    }
-
     get depth() {
         return this._depth;
     }

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -48,6 +48,10 @@ class PopupProxy {
 
     // Public functions
 
+    isProxy() {
+        return true;
+    }
+
     async setOptions(options) {
         const id = await this._getPopupId();
         return await this._invokeHostApi('setOptions', {id, options});

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -53,11 +53,11 @@ class PopupProxy {
         return await this._invokeHostApi('setOptions', {id, options});
     }
 
-    async hide(changeFocus) {
+    hide(changeFocus) {
         if (this._id === null) {
             return;
         }
-        return await this._invokeHostApi('hide', {id: this._id, changeFocus});
+        this._invokeHostApi('hide', {id: this._id, changeFocus});
     }
 
     async isVisible() {
@@ -65,9 +65,11 @@ class PopupProxy {
         return await this._invokeHostApi('isVisible', {id});
     }
 
-    async setVisibleOverride(visible) {
-        const id = await this._getPopupId();
-        return await this._invokeHostApi('setVisibleOverride', {id, visible});
+    setVisibleOverride(visible) {
+        if (this._id === null) {
+            return;
+        }
+        this._invokeHostApi('setVisibleOverride', {id, visible});
     }
 
     async containsPoint(x, y) {
@@ -88,11 +90,11 @@ class PopupProxy {
         return await this._invokeHostApi('setCustomCss', {id, css});
     }
 
-    async clearAutoPlayTimer() {
+    clearAutoPlayTimer() {
         if (this._id === null) {
             return;
         }
-        return await this._invokeHostApi('clearAutoPlayTimer', {id: this._id});
+        this._invokeHostApi('clearAutoPlayTimer', {id: this._id});
     }
 
     // Private

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -60,9 +60,9 @@ class PopupProxy {
         return await this._invokeHostApi('hide', {id: this._id, changeFocus});
     }
 
-    async isVisibleAsync() {
+    async isVisible() {
         const id = await this._getPopupId();
-        return await this._invokeHostApi('isVisibleAsync', {id});
+        return await this._invokeHostApi('isVisible', {id});
     }
 
     async setVisibleOverride(visible) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -135,6 +135,10 @@ class Popup {
         }
     }
 
+    getContainerRect() {
+        return this.container.getBoundingClientRect();
+    }
+
     static injectOuterStylesheet(css) {
         if (Popup.outerStylesheet === null) {
             if (!css) { return; }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -285,7 +285,7 @@ class Popup {
     _focusParent() {
         if (this._parent !== null) {
             // Chrome doesn't like focusing iframe without contentWindow.
-            const contentWindow = this._parent.container.contentWindow;
+            const contentWindow = this._parent._container.contentWindow;
             if (contentWindow !== null) {
                 contentWindow.focus();
             }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -52,6 +52,10 @@ class Popup {
 
     // Public functions
 
+    isProxy() {
+        return false;
+    }
+
     async setOptions(options) {
         this.options = options;
         this.updateTheme();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -113,6 +113,20 @@ class Popup {
 
     // Popup-only public functions
 
+    setParent(parent) {
+        if (parent === null) {
+            throw new Error('Cannot set popup parent to null');
+        }
+        if (this.parent !== null) {
+            throw new Error('Popup already has a parent');
+        }
+        if (parent.child !== null) {
+            throw new Error('Cannot parent popup to another popup which already has a child');
+        }
+        this.parent = parent;
+        parent.child = this;
+    }
+
     isVisible() {
         return this.isInjected && (this.visibleOverride !== null ? this.visibleOverride : this.visible);
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -70,7 +70,7 @@ class Popup {
     }
 
     hide(changeFocus) {
-        if (!this.isVisible()) {
+        if (!this.isVisibleSync()) {
             return;
         }
 
@@ -84,7 +84,7 @@ class Popup {
     }
 
     async isVisibleAsync() {
-        return this.isVisible();
+        return this.isVisibleSync();
     }
 
     setVisibleOverride(visible) {
@@ -93,7 +93,7 @@ class Popup {
     }
 
     async containsPoint(x, y) {
-        for (let popup = this; popup !== null && popup.isVisible(); popup = popup._child) {
+        for (let popup = this; popup !== null && popup.isVisibleSync(); popup = popup._child) {
             const rect = popup._container.getBoundingClientRect();
             if (x >= rect.left && y >= rect.top && x < rect.right && y < rect.bottom) {
                 return true;
@@ -135,7 +135,7 @@ class Popup {
         parent._child = this;
     }
 
-    isVisible() {
+    isVisibleSync() {
         return this._isInjected && (this._visibleOverride !== null ? this._visibleOverride : this._visible);
     }
 
@@ -279,7 +279,7 @@ class Popup {
     }
 
     _updateVisibility() {
-        this._container.style.setProperty('visibility', this.isVisible() ? 'visible' : 'hidden', 'important');
+        this._container.style.setProperty('visibility', this.isVisibleSync() ? 'visible' : 'hidden', 'important');
     }
 
     _focusParent() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -83,7 +83,7 @@ class Popup {
         }
     }
 
-    async isVisibleAsync() {
+    async isVisible() {
         return this.isVisibleSync();
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -50,10 +50,6 @@ class Popup {
         return this._parent;
     }
 
-    get child() {
-        return this._child;
-    }
-
     get depth() {
         return this._depth;
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -42,6 +42,12 @@ class Popup {
         this.updateVisibility();
     }
 
+    // Public properties
+
+    get url() {
+        return window.location.href;
+    }
+
     inject() {
         if (this.injectPromise === null) {
             this.injectPromise = this.createInjectPromise();
@@ -382,10 +388,6 @@ class Popup {
         if (parent !== null && this.container.parentNode !== parent) {
             parent.appendChild(this.container);
         }
-    }
-
-    get url() {
-        return window.location.href;
     }
 
     static isOnExtensionPage() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -135,6 +135,10 @@ class Popup {
         }
     }
 
+    getContainer() {
+        return this.container;
+    }
+
     getContainerRect() {
         return this.container.getBoundingClientRect();
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -26,6 +26,13 @@ class Popup {
         this.parent = null;
         this.child = null;
         this.childrenSupported = true;
+        this.injectPromise = null;
+        this.isInjected = false;
+        this.visible = false;
+        this.visibleOverride = null;
+        this.options = null;
+        this.stylesheetInjectedViaApi = false;
+
         this.container = document.createElement('iframe');
         this.container.className = 'yomichan-float';
         this.container.addEventListener('mousedown', (e) => e.stopPropagation());
@@ -33,12 +40,7 @@ class Popup {
         this.container.setAttribute('src', chrome.runtime.getURL('/fg/float.html'));
         this.container.style.width = '0px';
         this.container.style.height = '0px';
-        this.injectPromise = null;
-        this.isInjected = false;
-        this.visible = false;
-        this.visibleOverride = null;
-        this.options = null;
-        this.stylesheetInjectedViaApi = false;
+
         this._updateVisibility();
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -135,6 +135,10 @@ class Popup {
         }
     }
 
+    setChildrenSupported(value) {
+        this.childrenSupported = value;
+    }
+
     getContainer() {
         return this.container;
     }


### PR DESCRIPTION
Flag internally used functions/fields with underscore prefix to indicate that they should be treated as private. The intent is to make it more clear what is referenced in other files, since it's not easy to search for references since Javascript isn't a strongly typed language. The `_` prefix helps indicate that you would only need to search within the current file.

This should help me address a few issues with the popup class.

Previous discussion: #258