### PR TITLE
Deinflection variants

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -342,6 +342,7 @@
                                     "convertHalfWidthCharacters",
                                     "convertNumericCharacters",
                                     "convertAlphabeticCharacters",
+                                    "convertHiraganaToKatakana",
                                     "convertKatakanaToHiragana"
                                 ],
                                 "properties": {
@@ -356,6 +357,11 @@
                                         "default": "false"
                                     },
                                     "convertAlphabeticCharacters": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "false"
+                                    },
+                                    "convertHiraganaToKatakana": {
                                         "type": "string",
                                         "enum": ["false", "true", "variant"],
                                         "default": "false"

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -65,6 +65,7 @@
                             "general",
                             "audio",
                             "scanning",
+                            "translation",
                             "dictionaries",
                             "parsing",
                             "anki"
@@ -332,6 +333,37 @@
                                     "enableOnSearchPage": {
                                         "type": "boolean",
                                         "default": true
+                                    }
+                                }
+                            },
+                            "translation": {
+                                "type": "object",
+                                "required": [
+                                    "convertKatakanaToHiragana",
+                                    "convertHalfWidthCharacters",
+                                    "convertNumericCharacters",
+                                    "convertAlphabeticCharacters"
+                                ],
+                                "properties": {
+                                    "convertKatakanaToHiragana": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "variant"
+                                    },
+                                    "convertHalfWidthCharacters": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "false"
+                                    },
+                                    "convertNumericCharacters": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "false"
+                                    },
+                                    "convertAlphabeticCharacters": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "false"
                                     }
                                 }
                             },

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -339,17 +339,12 @@
                             "translation": {
                                 "type": "object",
                                 "required": [
-                                    "convertKatakanaToHiragana",
                                     "convertHalfWidthCharacters",
                                     "convertNumericCharacters",
-                                    "convertAlphabeticCharacters"
+                                    "convertAlphabeticCharacters",
+                                    "convertKatakanaToHiragana"
                                 ],
                                 "properties": {
-                                    "convertKatakanaToHiragana": {
-                                        "type": "string",
-                                        "enum": ["false", "true", "variant"],
-                                        "default": "variant"
-                                    },
                                     "convertHalfWidthCharacters": {
                                         "type": "string",
                                         "enum": ["false", "true", "variant"],
@@ -364,6 +359,11 @@
                                         "type": "string",
                                         "enum": ["false", "true", "variant"],
                                         "default": "false"
+                                    },
+                                    "convertKatakanaToHiragana": {
+                                        "type": "string",
+                                        "enum": ["false", "true", "variant"],
+                                        "default": "variant"
                                     }
                                 }
                             },

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -61,7 +61,7 @@ function handlebarsFuriganaPlain(options) {
 function handlebarsKanjiLinks(options) {
     let result = '';
     for (const c of options.fn(this)) {
-        if (jpIsKanji(c)) {
+        if (jpIsCharCodeKanji(c.charCodeAt(0))) {
             result += `<a href="#" class="kanji-link">${c}</a>`;
         } else {
             result += c;

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -320,6 +320,7 @@ function profileOptionsCreateDefaults() {
             convertHalfWidthCharacters: 'false',
             convertNumericCharacters: 'false',
             convertAlphabeticCharacters: 'false',
+            convertHiraganaToKatakana: 'false',
             convertKatakanaToHiragana: 'variant'
         },
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -316,6 +316,13 @@ function profileOptionsCreateDefaults() {
             enableOnSearchPage: true
         },
 
+        translation: {
+            convertKatakanaToHiragana: 'variant',
+            convertHalfWidthCharacters: 'false',
+            convertNumericCharacters: 'false',
+            convertAlphabeticCharacters: 'false'
+        },
+
         dictionaries: {},
 
         parsing: {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -317,10 +317,10 @@ function profileOptionsCreateDefaults() {
         },
 
         translation: {
-            convertKatakanaToHiragana: 'variant',
             convertHalfWidthCharacters: 'false',
             convertNumericCharacters: 'false',
-            convertAlphabeticCharacters: 'false'
+            convertAlphabeticCharacters: 'false',
+            convertKatakanaToHiragana: 'variant'
         },
 
         dictionaries: {},

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -260,7 +260,7 @@ class DisplaySearch extends Display {
                 text !== this.clipboardPreviousText
             ) {
                 this.clipboardPreviousText = text;
-                if (jpIsAnyCharacterJapanese(text)) {
+                if (jpIsStringPartiallyJapanese(text)) {
                     this.setQuery(this.isWanakanaEnabled() ? window.wanakana.toKana(text) : text);
                     window.history.pushState(null, '', `${window.location.pathname}?query=${encodeURIComponent(text)}`);
                     this.onSearchQueryUpdated(this.query.value, true);

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -260,7 +260,7 @@ class DisplaySearch extends Display {
                 text !== this.clipboardPreviousText
             ) {
                 this.clipboardPreviousText = text;
-                if (jpIsJapaneseText(text)) {
+                if (jpIsAnyCharacterJapanese(text)) {
                     this.setQuery(this.isWanakanaEnabled() ? window.wanakana.toKana(text) : text);
                     window.history.pushState(null, '', `${window.location.pathname}?query=${encodeURIComponent(text)}`);
                     this.onSearchQueryUpdated(this.query.value, true);

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -69,6 +69,11 @@ async function formRead(options) {
     options.scanning.modifier = $('#scan-modifier-key').val();
     options.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
 
+    options.translation.convertKatakanaToHiragana = $('#translation-convert-katakana-to-hiragana').val();
+    options.translation.convertHalfWidthCharacters = $('#translation-convert-half-width-characters').val();
+    options.translation.convertNumericCharacters = $('#translation-convert-numeric-characters').val();
+    options.translation.convertAlphabeticCharacters = $('#translation-convert-alphabetic-characters').val();
+
     options.parsing.enableScanningParser = $('#parsing-scan-enable').prop('checked');
     options.parsing.enableMecabParser = $('#parsing-mecab-enable').prop('checked');
     options.parsing.readingMode = $('#parsing-reading-mode').val();
@@ -133,6 +138,11 @@ async function formWrite(options) {
     $('#scan-length').val(options.scanning.length);
     $('#scan-modifier-key').val(options.scanning.modifier);
     $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
+
+    $('#translation-convert-katakana-to-hiragana').val(options.translation.convertKatakanaToHiragana);
+    $('#translation-convert-half-width-characters').val(options.translation.convertHalfWidthCharacters);
+    $('#translation-convert-numeric-characters').val(options.translation.convertNumericCharacters);
+    $('#translation-convert-alphabetic-characters').val(options.translation.convertAlphabeticCharacters);
 
     $('#parsing-scan-enable').prop('checked', options.parsing.enableScanningParser);
     $('#parsing-mecab-enable').prop('checked', options.parsing.enableMecabParser);

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -72,6 +72,7 @@ async function formRead(options) {
     options.translation.convertHalfWidthCharacters = $('#translation-convert-half-width-characters').val();
     options.translation.convertNumericCharacters = $('#translation-convert-numeric-characters').val();
     options.translation.convertAlphabeticCharacters = $('#translation-convert-alphabetic-characters').val();
+    options.translation.convertHiraganaToKatakana = $('#translation-convert-hiragana-to-katakana').val();
     options.translation.convertKatakanaToHiragana = $('#translation-convert-katakana-to-hiragana').val();
 
     options.parsing.enableScanningParser = $('#parsing-scan-enable').prop('checked');
@@ -142,6 +143,7 @@ async function formWrite(options) {
     $('#translation-convert-half-width-characters').val(options.translation.convertHalfWidthCharacters);
     $('#translation-convert-numeric-characters').val(options.translation.convertNumericCharacters);
     $('#translation-convert-alphabetic-characters').val(options.translation.convertAlphabeticCharacters);
+    $('#translation-convert-hiragana-to-katakana').val(options.translation.convertHiraganaToKatakana);
     $('#translation-convert-katakana-to-hiragana').val(options.translation.convertKatakanaToHiragana);
 
     $('#parsing-scan-enable').prop('checked', options.parsing.enableScanningParser);

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -69,10 +69,10 @@ async function formRead(options) {
     options.scanning.modifier = $('#scan-modifier-key').val();
     options.scanning.popupNestingMaxDepth = parseInt($('#popup-nesting-max-depth').val(), 10);
 
-    options.translation.convertKatakanaToHiragana = $('#translation-convert-katakana-to-hiragana').val();
     options.translation.convertHalfWidthCharacters = $('#translation-convert-half-width-characters').val();
     options.translation.convertNumericCharacters = $('#translation-convert-numeric-characters').val();
     options.translation.convertAlphabeticCharacters = $('#translation-convert-alphabetic-characters').val();
+    options.translation.convertKatakanaToHiragana = $('#translation-convert-katakana-to-hiragana').val();
 
     options.parsing.enableScanningParser = $('#parsing-scan-enable').prop('checked');
     options.parsing.enableMecabParser = $('#parsing-mecab-enable').prop('checked');
@@ -139,10 +139,10 @@ async function formWrite(options) {
     $('#scan-modifier-key').val(options.scanning.modifier);
     $('#popup-nesting-max-depth').val(options.scanning.popupNestingMaxDepth);
 
-    $('#translation-convert-katakana-to-hiragana').val(options.translation.convertKatakanaToHiragana);
     $('#translation-convert-half-width-characters').val(options.translation.convertHalfWidthCharacters);
     $('#translation-convert-numeric-characters').val(options.translation.convertNumericCharacters);
     $('#translation-convert-alphabetic-characters').val(options.translation.convertAlphabeticCharacters);
+    $('#translation-convert-katakana-to-hiragana').val(options.translation.convertKatakanaToHiragana);
 
     $('#parsing-scan-enable').prop('checked', options.parsing.enableScanningParser);
     $('#parsing-mecab-enable').prop('checked', options.parsing.enableMecabParser);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -157,7 +157,7 @@ class Translator {
     async findTermsGrouped(text, details, options) {
         const dictionaries = dictEnabledSet(options);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, details, options);
 
         const definitionsGrouped = dictTermsGroup(definitions, dictionaries);
         await this.buildTermFrequencies(definitionsGrouped, titles);
@@ -175,7 +175,7 @@ class Translator {
         const dictionaries = dictEnabledSet(options);
         const secondarySearchTitles = Object.keys(options.dictionaries).filter((dict) => options.dictionaries[dict].allowSecondarySearches);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, details, options);
         const {sequencedDefinitions, defaultDefinitions} = await this.getSequencedDefinitions(definitions, options.general.mainDictionary);
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
@@ -212,15 +212,15 @@ class Translator {
     async findTermsSplit(text, details, options) {
         const dictionaries = dictEnabledSet(options);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, details, options);
 
         await this.buildTermFrequencies(definitions, titles);
 
         return [definitions, length];
     }
 
-    async findTermsInternal(text, dictionaries, alphanumeric, details, options) {
-        if (!alphanumeric && text.length > 0) {
+    async findTermsInternal(text, dictionaries, details, options) {
+        if (!options.scanning.alphanumeric && text.length > 0) {
             const c = text[0];
             if (!jpIsKana(c) && !jpIsKanji(c)) {
                 return [[], 0];

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -325,27 +325,31 @@ class Translator {
     getAllDeinflections(text, options) {
         const translationOptions = options.translation;
         const textOptionVariantArray = [
-            Translator.getTextOptionEntryVariants(translationOptions.convertKatakanaToHiragana),
             Translator.getTextOptionEntryVariants(translationOptions.convertHalfWidthCharacters),
             Translator.getTextOptionEntryVariants(translationOptions.convertNumericCharacters),
-            Translator.getTextOptionEntryVariants(translationOptions.convertAlphabeticCharacters)
+            Translator.getTextOptionEntryVariants(translationOptions.convertAlphabeticCharacters),
+            Translator.getTextOptionEntryVariants(translationOptions.convertKatakanaToHiragana)
         ];
 
         const deinflections = [];
         const used = new Set();
-        for (const [hiragana, halfWidth, numeric, alphabetic] of Translator.getArrayVariants(textOptionVariantArray)) {
+        for (const [halfWidth, numeric, alphabetic, hiragana] of Translator.getArrayVariants(textOptionVariantArray)) {
             let text2 = text;
             let sourceMapping = null;
             if (halfWidth) {
                 if (sourceMapping === null) { sourceMapping = Translator.createTextSourceMapping(text2); }
                 text2 = jpConvertHalfWidthKanaToFullWidth(text2, sourceMapping);
             }
-            if (numeric) { text2 = jpConvertNumericTofullWidth(text2); }
+            if (numeric) {
+                text2 = jpConvertNumericTofullWidth(text2);
+            }
             if (alphabetic) {
                 if (sourceMapping === null) { sourceMapping = Translator.createTextSourceMapping(text2); }
                 text2 = jpConvertAlphabeticToKana(text2, sourceMapping);
             }
-            if (hiragana) { text2 = jpKatakanaToHiragana(text2); }
+            if (hiragana) {
+                text2 = jpKatakanaToHiragana(text2);
+            }
 
             for (let i = text2.length; i > 0; --i) {
                 const text2Substring = text2.substring(0, i);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -243,6 +243,7 @@ class Translator {
 
                 definitions.push({
                     source: deinflection.source,
+                    rawSource: deinflection.rawSource,
                     reasons: deinflection.reasons,
                     score: definition.score,
                     id: definition.id,
@@ -262,7 +263,7 @@ class Translator {
 
         let length = 0;
         for (const definition of definitions) {
-            length = Math.max(length, definition.source.length);
+            length = Math.max(length, definition.rawSource.length);
         }
 
         return [definitions, length];
@@ -276,6 +277,7 @@ class Translator {
 
         return [{
             source: text,
+            rawSource: text,
             term: text,
             rules: 0,
             definitions,
@@ -322,25 +324,69 @@ class Translator {
         return deinflections.filter((e) => e.definitions.length > 0);
     }
 
-    getAllDeinflections(text, _options) {
+    getAllDeinflections(text, options) {
+        const translationOptions = options.translation;
         const textOptionVariantArray = [
-            [false, true] // convert katakana to hiragana
+            Translator.getTextOptionEntryVariants(translationOptions.convertKatakanaToHiragana),
+            Translator.getTextOptionEntryVariants(translationOptions.convertHalfWidthCharacters),
+            Translator.getTextOptionEntryVariants(translationOptions.convertNumericCharacters),
+            Translator.getTextOptionEntryVariants(translationOptions.convertAlphabeticCharacters)
         ];
 
         const deinflections = [];
         const used = new Set();
-        for (const [hiragana] of Translator.getArrayVariants(textOptionVariantArray)) {
+        for (const [hiragana, halfWidth, numeric, alphabetic] of Translator.getArrayVariants(textOptionVariantArray)) {
             let text2 = text;
+            let sourceMapping = null;
+            if (halfWidth) {
+                if (sourceMapping === null) { sourceMapping = Translator.createTextSourceMapping(text2); }
+                text2 = jpConvertHalfWidthKanaToFullWidth(text2, sourceMapping);
+            }
+            if (numeric) { text2 = jpConvertNumericTofullWidth(text2); }
+            if (alphabetic) {
+                if (sourceMapping === null) { sourceMapping = Translator.createTextSourceMapping(text2); }
+                text2 = jpConvertAlphabeticToKana(text2, sourceMapping);
+            }
             if (hiragana) { text2 = jpKatakanaToHiragana(text2); }
 
             for (let i = text2.length; i > 0; --i) {
                 const text2Substring = text2.substring(0, i);
                 if (used.has(text2Substring)) { break; }
                 used.add(text2Substring);
-                deinflections.push(...this.deinflector.deinflect(text2Substring));
+                for (const deinflection of this.deinflector.deinflect(text2Substring)) {
+                    deinflection.rawSource = Translator.getDeinflectionRawSource(text, i, sourceMapping);
+                    deinflections.push(deinflection);
+                }
             }
         }
         return deinflections;
+    }
+
+    static getTextOptionEntryVariants(value) {
+        switch (value) {
+            case 'true': return [true];
+            case 'variant': return [false, true];
+            default: return [false];
+        }
+    }
+
+    static getDeinflectionRawSource(source, length, sourceMapping) {
+        if (sourceMapping === null) {
+            return source.substring(0, length);
+        }
+
+        let result = '';
+        let index = 0;
+        for (let i = 0; i < length; ++i) {
+            const c = sourceMapping[i];
+            result += source.substring(index, index + c);
+            index += c;
+        }
+        return result;
+    }
+
+    static createTextSourceMapping(text) {
+        return new Array(text.length).fill(1);
     }
 
     async findKanji(text, options) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -157,7 +157,7 @@ class Translator {
     async findTermsGrouped(text, details, options) {
         const dictionaries = dictEnabledSet(options);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
 
         const definitionsGrouped = dictTermsGroup(definitions, dictionaries);
         await this.buildTermFrequencies(definitionsGrouped, titles);
@@ -175,7 +175,7 @@ class Translator {
         const dictionaries = dictEnabledSet(options);
         const secondarySearchTitles = Object.keys(options.dictionaries).filter((dict) => options.dictionaries[dict].allowSecondarySearches);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
         const {sequencedDefinitions, defaultDefinitions} = await this.getSequencedDefinitions(definitions, options.general.mainDictionary);
         const definitionsMerged = [];
         const mergedByTermIndices = new Set();
@@ -212,14 +212,14 @@ class Translator {
     async findTermsSplit(text, details, options) {
         const dictionaries = dictEnabledSet(options);
         const titles = Object.keys(dictionaries);
-        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details);
+        const [definitions, length] = await this.findTermsInternal(text, dictionaries, options.scanning.alphanumeric, details, options);
 
         await this.buildTermFrequencies(definitions, titles);
 
         return [definitions, length];
     }
 
-    async findTermsInternal(text, dictionaries, alphanumeric, details) {
+    async findTermsInternal(text, dictionaries, alphanumeric, details, options) {
         if (!alphanumeric && text.length > 0) {
             const c = text[0];
             if (!jpIsKana(c) && !jpIsKanji(c)) {
@@ -231,7 +231,7 @@ class Translator {
         const deinflections = (
             details.wildcard ?
             await this.findTermWildcard(text, titles, details.wildcard) :
-            await this.findTermDeinflections(text, titles)
+            await this.findTermDeinflections(text, titles, options)
         );
 
         let definitions = [];
@@ -283,9 +283,8 @@ class Translator {
         }];
     }
 
-    async findTermDeinflections(text, titles) {
-        const text2 = jpKatakanaToHiragana(text);
-        const deinflections = (text === text2 ? this.getDeinflections(text) : this.getDeinflections2(text, text2));
+    async findTermDeinflections(text, titles, options) {
+        const deinflections = this.getAllDeinflections(text, options);
 
         if (deinflections.length === 0) {
             return [];
@@ -323,29 +322,24 @@ class Translator {
         return deinflections.filter((e) => e.definitions.length > 0);
     }
 
-    getDeinflections(text) {
+    getAllDeinflections(text, _options) {
+        const textOptionVariantArray = [
+            [false, true] // convert katakana to hiragana
+        ];
+
         const deinflections = [];
+        const used = new Set();
+        for (const [hiragana] of Translator.getArrayVariants(textOptionVariantArray)) {
+            let text2 = text;
+            if (hiragana) { text2 = jpKatakanaToHiragana(text2); }
 
-        for (let i = text.length; i > 0; --i) {
-            const textSubstring = text.substring(0, i);
-            deinflections.push(...this.deinflector.deinflect(textSubstring));
-        }
-
-        return deinflections;
-    }
-
-    getDeinflections2(text1, text2) {
-        const deinflections = [];
-
-        for (let i = text1.length; i > 0; --i) {
-            const text1Substring = text1.substring(0, i);
-            const text2Substring = text2.substring(0, i);
-            deinflections.push(...this.deinflector.deinflect(text1Substring));
-            if (text1Substring !== text2Substring) {
+            for (let i = text2.length; i > 0; --i) {
+                const text2Substring = text2.substring(0, i);
+                if (used.has(text2Substring)) { break; }
+                used.add(text2Substring);
                 deinflections.push(...this.deinflector.deinflect(text2Substring));
             }
         }
-
         return deinflections;
     }
 
@@ -517,5 +511,25 @@ class Translator {
     static getNameBase(name) {
         const pos = name.indexOf(':');
         return (pos >= 0 ? name.substring(0, pos) : name);
+    }
+
+    static *getArrayVariants(arrayVariants) {
+        const ii = arrayVariants.length;
+
+        let total = 1;
+        for (let i = 0; i < ii; ++i) {
+            total *= arrayVariants[i].length;
+        }
+
+        for (let a = 0; a < total; ++a) {
+            const variant = [];
+            let index = a;
+            for (let i = 0; i < ii; ++i) {
+                const entryVariants = arrayVariants[i];
+                variant.push(entryVariants[index % entryVariants.length]);
+                index = Math.floor(index / entryVariants.length);
+            }
+            yield variant;
+        }
     }
 }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -328,12 +328,13 @@ class Translator {
             Translator.getTextOptionEntryVariants(translationOptions.convertHalfWidthCharacters),
             Translator.getTextOptionEntryVariants(translationOptions.convertNumericCharacters),
             Translator.getTextOptionEntryVariants(translationOptions.convertAlphabeticCharacters),
+            Translator.getTextOptionEntryVariants(translationOptions.convertHiraganaToKatakana),
             Translator.getTextOptionEntryVariants(translationOptions.convertKatakanaToHiragana)
         ];
 
         const deinflections = [];
         const used = new Set();
-        for (const [halfWidth, numeric, alphabetic, hiragana] of Translator.getArrayVariants(textOptionVariantArray)) {
+        for (const [halfWidth, numeric, alphabetic, katakana, hiragana] of Translator.getArrayVariants(textOptionVariantArray)) {
             let text2 = text;
             let sourceMapping = null;
             if (halfWidth) {
@@ -346,6 +347,9 @@ class Translator {
             if (alphabetic) {
                 if (sourceMapping === null) { sourceMapping = Translator.createTextSourceMapping(text2); }
                 text2 = jpConvertAlphabeticToKana(text2, sourceMapping);
+            }
+            if (katakana) {
+                text2 = jpHiraganaToKatakana(text2);
             }
             if (hiragana) {
                 text2 = jpKatakanaToHiragana(text2);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -581,8 +581,7 @@ class Translator {
         if (!options.scanning.alphanumeric) {
             const ii = text.length;
             for (let i = 0; i < ii; ++i) {
-                const c = text[i];
-                if (!jpIsCharacterJapanese(c)) {
+                if (!jpIsCharCodeJapanese(text.charCodeAt(i))) {
                     text = text.substring(0, i);
                     break;
                 }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -220,11 +220,9 @@ class Translator {
     }
 
     async findTermsInternal(text, dictionaries, details, options) {
-        if (!options.scanning.alphanumeric && text.length > 0) {
-            const c = text[0];
-            if (!jpIsKana(c) && !jpIsKanji(c)) {
-                return [[], 0];
-            }
+        text = Translator.getSearchableText(text, options);
+        if (text.length === 0) {
+            return [[], 0];
         }
 
         const titles = Object.keys(dictionaries);
@@ -577,5 +575,20 @@ class Translator {
             }
             yield variant;
         }
+    }
+
+    static getSearchableText(text, options) {
+        if (!options.scanning.alphanumeric) {
+            const ii = text.length;
+            for (let i = 0; i < ii; ++i) {
+                const c = text[i];
+                if (!jpIsCharacterJapanese(c)) {
+                    text = text.substring(0, i);
+                    break;
+                }
+            }
+        }
+
+        return text;
     }
 }

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -384,6 +384,46 @@
                 </div>
             </div>
 
+            <div>
+                <h3>Translation Options</h3>
+
+                <div class="form-group">
+                    <label for="translation-convert-katakana-to-hiragana">Convert katakana to hiragana <span class="label-light">(ヨミチャン &rarr; よみちゃん)</span></label>
+                    <select class="form-control" id="translation-convert-katakana-to-hiragana">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="translation-convert-half-width-characters">Convert half width characters to full width <span class="label-light">(ﾖﾐﾁｬﾝ &rarr; ヨミチャン)</span></label>
+                    <select class="form-control" id="translation-convert-half-width-characters">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="translation-convert-numeric-characters">Convert numeric characters to full width <span class="label-light">(1234 &rarr; １２３４)</span></label>
+                    <select class="form-control" id="translation-convert-numeric-characters">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="translation-convert-alphabetic-characters">Convert alphabetic characters to hiragana <span class="label-light">(yomichan &rarr; よみちゃん)</span></label>
+                    <select class="form-control" id="translation-convert-alphabetic-characters">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+            </div>
+
             <div id="popup-content-scanning">
                 <h3>Popup Content Scanning Options</h3>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -387,6 +387,32 @@
             <div>
                 <h3>Translation Options</h3>
 
+                <p class="help-block">
+                    The following options can be used during the translation process to provide alternate versions of the input text to search for.
+                    This can be helpful when the input text doesn't exactly match the term or expression found in the database.
+                </p>
+
+                <p class="help-block">
+                    The conversion options below are listed in the order that the conversions are applied to the input text.
+                    Each conversion has three possible values:
+                </p>
+
+                <ul class="help-block">
+                    <li>
+                        <strong>Disabled</strong><br>
+                        This conversion will never be applied to the input text.
+                    </li>
+                    <li>
+                        <strong>Enabled</strong><br>
+                        This conversion will always be applied to the input text.
+                    </li>
+                    <li>
+                        <strong>Use both variants</strong><br>
+                        The translator will check the database for two variations: the raw input text and the converted input text.
+                        When multiple options use variants, the translator will search for combinations of the converted text.
+                    </li>
+                </ul>
+
                 <div class="form-group">
                     <label for="translation-convert-half-width-characters">Convert half width characters to full width <span class="label-light">(ﾖﾐﾁｬﾝ &rarr; ヨミチャン)</span></label>
                     <select class="form-control" id="translation-convert-half-width-characters">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -388,15 +388,6 @@
                 <h3>Translation Options</h3>
 
                 <div class="form-group">
-                    <label for="translation-convert-katakana-to-hiragana">Convert katakana to hiragana <span class="label-light">(ヨミチャン &rarr; よみちゃん)</span></label>
-                    <select class="form-control" id="translation-convert-katakana-to-hiragana">
-                        <option value="false">Disabled</option>
-                        <option value="true">Enabled</option>
-                        <option value="variant">Use both variants</option>
-                    </select>
-                </div>
-
-                <div class="form-group">
                     <label for="translation-convert-half-width-characters">Convert half width characters to full width <span class="label-light">(ﾖﾐﾁｬﾝ &rarr; ヨミチャン)</span></label>
                     <select class="form-control" id="translation-convert-half-width-characters">
                         <option value="false">Disabled</option>
@@ -417,6 +408,15 @@
                 <div class="form-group">
                     <label for="translation-convert-alphabetic-characters">Convert alphabetic characters to hiragana <span class="label-light">(yomichan &rarr; よみちゃん)</span></label>
                     <select class="form-control" id="translation-convert-alphabetic-characters">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
+                    <label for="translation-convert-katakana-to-hiragana">Convert katakana to hiragana <span class="label-light">(ヨミチャン &rarr; よみちゃん)</span></label>
+                    <select class="form-control" id="translation-convert-katakana-to-hiragana">
                         <option value="false">Disabled</option>
                         <option value="true">Enabled</option>
                         <option value="variant">Use both variants</option>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -415,6 +415,15 @@
                 </div>
 
                 <div class="form-group">
+                    <label for="translation-convert-hiragana-to-katakana">Convert hiragana to katakana <span class="label-light">(よみちゃん &rarr; ヨミチャン)</span></label>
+                    <select class="form-control" id="translation-convert-hiragana-to-katakana">
+                        <option value="false">Disabled</option>
+                        <option value="true">Enabled</option>
+                        <option value="variant">Use both variants</option>
+                    </select>
+                </div>
+
+                <div class="form-group">
                     <label for="translation-convert-katakana-to-hiragana">Convert katakana to hiragana <span class="label-light">(ヨミチャン &rarr; よみちゃん)</span></label>
                     <select class="form-control" id="translation-convert-katakana-to-hiragana">
                         <option value="false">Disabled</option>

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -76,6 +76,41 @@ const JP_HALFWIDTH_KATAKANA_MAPPING = new Map([
     ['ﾝ', 'ン--']
 ]);
 
+const JP_HIRAGANA_RANGE = [0x3040, 0x309f];
+const JP_KATAKANA_RANGE = [0x30a0, 0x30ff];
+const JP_KANA_RANGES = [JP_HIRAGANA_RANGE, JP_KATAKANA_RANGE];
+
+const JP_CJK_COMMON_RANGE = [0x4e00, 0x9fff];
+const JP_CJK_RARE_RANGE = [0x3400, 0x4dbf];
+const JP_CJK_RANGES = [JP_CJK_COMMON_RANGE, JP_CJK_RARE_RANGE];
+
+const JP_ITERATION_MARK_CHAR_CODE = 0x3005;
+
+// Japanese character ranges, roughly ordered in order of expected frequency
+const JP_JAPANESE_RANGES = [
+    JP_HIRAGANA_RANGE,
+    JP_KATAKANA_RANGE,
+
+    JP_CJK_COMMON_RANGE,
+    JP_CJK_RARE_RANGE,
+
+    [0xff66, 0xff9f], // Halfwidth katakana
+
+    [0x30fb, 0x30fc], // Katakana punctuation
+    [0xff61, 0xff65], // Kana punctuation
+    [0x3000, 0x303f], // CJK punctuation
+
+    [0xff10, 0xff19], // Fullwidth numbers
+    [0xff21, 0xff3a], // Fullwidth upper case Latin letters
+    [0xff41, 0xff5a], // Fullwidth lower case Latin letters
+
+    [0xff01, 0xff0f], // Fullwidth punctuation 1
+    [0xff1a, 0xff1f], // Fullwidth punctuation 2
+    [0xff3b, 0xff3f], // Fullwidth punctuation 3
+    [0xff5b, 0xff60], // Fullwidth punctuation 4
+    [0xffe0, 0xffee], // Currency markers
+];
+
 
 function jpIsKanji(c) {
     const code = c.charCodeAt(0);

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -78,11 +78,18 @@ const jpHalfWidthCharacterMapping = new Map([
 
 function jpIsKanji(c) {
     const code = c.charCodeAt(0);
-    return code >= 0x4e00 && code < 0x9fb0 || code >= 0x3400 && code < 0x4dc0;
+    return (
+        (code >= 0x4e00 && code < 0x9fb0) ||
+        (code >= 0x3400 && code < 0x4dc0)
+    );
 }
 
 function jpIsKana(c) {
-    return wanakana.isKana(c);
+    const code = c.charCodeAt(0);
+    return (
+        (code >= 0x3041 && code <= 0x3096) || // hiragana
+        (code >= 0x30a1 && code <= 0x30fc) // katakana
+    );
 }
 
 function jpIsJapaneseText(text) {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -17,6 +17,65 @@
  */
 
 
+const jpHalfWidthCharacterMapping = new Map([
+    ['ｦ', 'ヲヺ-'],
+    ['ｧ', 'ァ--'],
+    ['ｨ', 'ィ--'],
+    ['ｩ', 'ゥ--'],
+    ['ｪ', 'ェ--'],
+    ['ｫ', 'ォ--'],
+    ['ｬ', 'ャ--'],
+    ['ｭ', 'ュ--'],
+    ['ｮ', 'ョ--'],
+    ['ｯ', 'ッ--'],
+    ['ｰ', 'ー--'],
+    ['ｱ', 'ア--'],
+    ['ｲ', 'イ--'],
+    ['ｳ', 'ウヴ-'],
+    ['ｴ', 'エ--'],
+    ['ｵ', 'オ--'],
+    ['ｶ', 'カガ-'],
+    ['ｷ', 'キギ-'],
+    ['ｸ', 'クグ-'],
+    ['ｹ', 'ケゲ-'],
+    ['ｺ', 'コゴ-'],
+    ['ｻ', 'サザ-'],
+    ['ｼ', 'シジ-'],
+    ['ｽ', 'スズ-'],
+    ['ｾ', 'セゼ-'],
+    ['ｿ', 'ソゾ-'],
+    ['ﾀ', 'タダ-'],
+    ['ﾁ', 'チヂ-'],
+    ['ﾂ', 'ツヅ-'],
+    ['ﾃ', 'テデ-'],
+    ['ﾄ', 'トド-'],
+    ['ﾅ', 'ナ--'],
+    ['ﾆ', 'ニ--'],
+    ['ﾇ', 'ヌ--'],
+    ['ﾈ', 'ネ--'],
+    ['ﾉ', 'ノ--'],
+    ['ﾊ', 'ハバパ'],
+    ['ﾋ', 'ヒビピ'],
+    ['ﾌ', 'フブプ'],
+    ['ﾍ', 'ヘベペ'],
+    ['ﾎ', 'ホボポ'],
+    ['ﾏ', 'マ--'],
+    ['ﾐ', 'ミ--'],
+    ['ﾑ', 'ム--'],
+    ['ﾒ', 'メ--'],
+    ['ﾓ', 'モ--'],
+    ['ﾔ', 'ヤ--'],
+    ['ﾕ', 'ユ--'],
+    ['ﾖ', 'ヨ--'],
+    ['ﾗ', 'ラ--'],
+    ['ﾘ', 'リ--'],
+    ['ﾙ', 'ル--'],
+    ['ﾚ', 'レ--'],
+    ['ﾛ', 'ロ--'],
+    ['ﾜ', 'ワ--'],
+    ['ﾝ', 'ン--']
+]);
+
 function jpIsKanji(c) {
     const code = c.charCodeAt(0);
     return code >= 0x4e00 && code < 0x9fb0 || code >= 0x3400 && code < 0x4dc0;
@@ -174,4 +233,146 @@ function jpDistributeFuriganaInflected(expression, reading, source) {
     }
 
     return output;
+}
+
+function jpConvertHalfWidthKanaToFullWidth(text, sourceMapping) {
+    let result = '';
+    const ii = text.length;
+    const hasSourceMapping = Array.isArray(sourceMapping);
+
+    for (let i = 0; i < ii; ++i) {
+        const c = text[i];
+        const mapping = jpHalfWidthCharacterMapping.get(c);
+        if (typeof mapping !== 'string') {
+            result += c;
+            continue;
+        }
+
+        let index = 0;
+        switch (text.charCodeAt(i + 1)) {
+            case 0xff9e: // dakuten
+                index = 1;
+                break;
+            case 0xff9f: // handakuten
+                index = 2;
+                break;
+        }
+
+        let c2 = mapping[index];
+        if (index > 0) {
+            if (c2 === '-') { // invalid
+                index = 0;
+                c2 = mapping[0];
+            } else {
+                ++i;
+            }
+        }
+
+        if (hasSourceMapping && index > 0) {
+            index = result.length;
+            const v = sourceMapping.splice(index + 1, 1)[0];
+            sourceMapping[index] += v;
+        }
+        result += c2;
+    }
+
+    return result;
+}
+
+function jpConvertNumericTofullWidth(text) {
+    let result = '';
+    for (let i = 0, ii = text.length; i < ii; ++i) {
+        let c = text.charCodeAt(i);
+        if (c >= 0x30 && c <= 0x39) { // ['0', '9']
+            c += 0xff10 - 0x30; // 0xff10 = '0' full width
+            result += String.fromCharCode(c);
+        } else {
+            result += text[i];
+        }
+    }
+    return result;
+}
+
+function jpConvertAlphabeticToKana(text, sourceMapping) {
+    let part = '';
+    let result = '';
+    const ii = text.length;
+
+    if (sourceMapping.length === ii) {
+        sourceMapping.length = ii;
+        sourceMapping.fill(1);
+    }
+
+    for (let i = 0; i < ii; ++i) {
+        let c = text.charCodeAt(i);
+        if (c >= 0x41 && c <= 0x5a) { // ['A', 'Z']
+            c -= 0x41;
+        } else if (c >= 0x61 && c <= 0x7a) { // ['a', 'z']
+            c -= 0x61;
+        } else if (c >= 0xff21 && c <= 0xff3a) { // ['A', 'Z'] full width
+            c -= 0xff21;
+        } else if (c >= 0xff41 && c <= 0xff5a) { // ['a', 'z'] full width
+            c -= 0xff41;
+        } else {
+            if (part.length > 0) {
+                result += jpToHiragana(part, sourceMapping, result.length);
+                part = '';
+            }
+            result += text[i];
+            continue;
+        }
+        part += String.fromCharCode(c + 0x61); // + 'a'
+    }
+
+    if (part.length > 0) {
+        result += jpToHiragana(part, sourceMapping, result.length);
+    }
+    return result;
+}
+
+function jpToHiragana(text, sourceMapping, sourceMappingStart) {
+    const result = wanakana.toHiragana(text);
+
+    // Generate source mapping
+    if (Array.isArray(sourceMapping)) {
+        if (typeof sourceMappingStart !== 'number') { sourceMappingStart = 0; }
+        let i = 0;
+        let resultPos = 0;
+        const ii = text.length;
+        while (i < ii) {
+            // Find smallest matching substring
+            let iNext = i + 1;
+            let resultPosNext = result.length;
+            while (iNext < ii) {
+                const t = wanakana.toHiragana(text.substring(0, iNext));
+                if (t === result.substring(0, t.length)) {
+                    resultPosNext = t.length;
+                    break;
+                }
+                ++iNext;
+            }
+
+            // Merge characters
+            const removals = iNext - i - 1;
+            if (removals > 0) {
+                let sum = 0;
+                const vs = sourceMapping.splice(sourceMappingStart + 1, removals);
+                for (const v of vs) { sum += v; }
+                sourceMapping[sourceMappingStart] += sum;
+            }
+            ++sourceMappingStart;
+
+            // Empty elements
+            const additions = resultPosNext - resultPos - 1;
+            for (let j = 0; j < additions; ++j) {
+                sourceMapping.splice(sourceMappingStart, 0, 0);
+                ++sourceMappingStart;
+            }
+
+            i = iNext;
+            resultPos = resultPosNext;
+        }
+    }
+
+    return result;
 }

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -375,15 +375,16 @@ function jpConvertAlphabeticToKana(text, sourceMapping) {
     }
 
     for (let i = 0; i < ii; ++i) {
+        // Note: 0x61 is the character code for 'a'
         let c = text.charCodeAt(i);
         if (c >= 0x41 && c <= 0x5a) { // ['A', 'Z']
-            c -= 0x41;
+            c += (0x61 - 0x41);
         } else if (c >= 0x61 && c <= 0x7a) { // ['a', 'z']
-            c -= 0x61;
-        } else if (c >= 0xff21 && c <= 0xff3a) { // ['A', 'Z'] full width
-            c -= 0xff21;
-        } else if (c >= 0xff41 && c <= 0xff5a) { // ['a', 'z'] full width
-            c -= 0xff41;
+            // NOP; c += (0x61 - 0x61);
+        } else if (c >= 0xff21 && c <= 0xff3a) { // ['A', 'Z'] fullwidth
+            c += (0x61 - 0xff21);
+        } else if (c >= 0xff41 && c <= 0xff5a) { // ['a', 'z'] fullwidth
+            c += (0x61 - 0xff41);
         } else {
             if (part.length > 0) {
                 result += jpToHiragana(part, sourceMapping, result.length);
@@ -392,7 +393,7 @@ function jpConvertAlphabeticToKana(text, sourceMapping) {
             result += text[i];
             continue;
         }
-        part += String.fromCharCode(c + 0x61); // + 'a'
+        part += String.fromCharCode(c);
     }
 
     if (part.length > 0) {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -92,8 +92,22 @@ function jpIsKana(c) {
     );
 }
 
+function jpIsCharFullWidth(c) {
+    const code = c.charCodeAt(0);
+    return (
+        (code >= 0xff21 && code <= 0xff3a) || // full width upper case roman letters
+        (code >= 0xff41 && code <= 0xff3a) || // full width upper case roman letters
+        (code >= 0xff10 && code <= 0xff19) // full width numbers
+    );
+}
+
+function jpIsKanaHalfWidth(c) {
+    const code = c.charCodeAt(0);
+    return (code >= 0xff66 && code <= 0xff9f); // half width katakana
+}
+
 function jpIsCharacterJapanese(c) {
-    return jpIsKanji(c) || jpIsKana(c);
+    return jpIsKanji(c) || jpIsKana(c) || jpIsCharFullWidth(c) || jpIsKanaHalfWidth(c);
 }
 
 function jpIsAnyCharacterJapanese(text) {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -17,7 +17,7 @@
  */
 
 
-const jpHalfWidthCharacterMapping = new Map([
+const JP_HALFWIDTH_KATAKANA_MAPPING = new Map([
     ['ｦ', 'ヲヺ-'],
     ['ｧ', 'ァ--'],
     ['ｨ', 'ィ--'],
@@ -75,6 +75,7 @@ const jpHalfWidthCharacterMapping = new Map([
     ['ﾜ', 'ワ--'],
     ['ﾝ', 'ン--']
 ]);
+
 
 function jpIsKanji(c) {
     const code = c.charCodeAt(0);
@@ -267,7 +268,7 @@ function jpConvertHalfWidthKanaToFullWidth(text, sourceMapping) {
 
     for (let i = 0; i < ii; ++i) {
         const c = text[i];
-        const mapping = jpHalfWidthCharacterMapping.get(c);
+        const mapping = JP_HALFWIDTH_KATAKANA_MAPPING.get(c);
         if (typeof mapping !== 'string') {
             result += c;
             continue;

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -162,52 +162,6 @@ function jpIsStringPartiallyJapanese(str) {
 }
 
 
-// Old character/string testing functions
-
-function jpIsKanji(c) {
-    const code = c.charCodeAt(0);
-    return (
-        (code >= 0x4e00 && code < 0x9fb0) ||
-        (code >= 0x3400 && code < 0x4dc0)
-    );
-}
-
-function jpIsKana(c) {
-    const code = c.charCodeAt(0);
-    return (
-        (code >= 0x3041 && code <= 0x3096) || // hiragana
-        (code >= 0x30a1 && code <= 0x30fc) // katakana
-    );
-}
-
-function jpIsCharFullWidth(c) {
-    const code = c.charCodeAt(0);
-    return (
-        (code >= 0xff21 && code <= 0xff3a) || // full width upper case roman letters
-        (code >= 0xff41 && code <= 0xff3a) || // full width upper case roman letters
-        (code >= 0xff10 && code <= 0xff19) // full width numbers
-    );
-}
-
-function jpIsKanaHalfWidth(c) {
-    const code = c.charCodeAt(0);
-    return (code >= 0xff66 && code <= 0xff9f); // half width katakana
-}
-
-function jpIsCharacterJapanese(c) {
-    return jpIsKanji(c) || jpIsKana(c) || jpIsCharFullWidth(c) || jpIsKanaHalfWidth(c);
-}
-
-function jpIsAnyCharacterJapanese(text) {
-    for (const c of text) {
-        if (jpIsCharacterJapanese(c)) {
-            return true;
-        }
-    }
-    return false;
-}
-
-
 // Conversion functions
 
 function jpKatakanaToHiragana(text) {
@@ -250,7 +204,7 @@ function jpConvertReading(expressionFragment, readingFragment, readingMode) {
             if (readingFragment) {
                 return jpToRomaji(readingFragment);
             } else {
-                if (jpIsKana(expressionFragment)) {
+                if (jpIsStringEntirelyKana(expressionFragment)) {
                     return jpToRomaji(expressionFragment);
                 }
             }
@@ -307,7 +261,8 @@ function jpDistributeFurigana(expression, reading) {
     const groups = [];
     let modePrev = null;
     for (const c of expression) {
-        const modeCurr = jpIsKanji(c) || c.charCodeAt(0) === 0x3005 /* noma */ ? 'kanji' : 'kana';
+        const charCode = c.charCodeAt(0);
+        const modeCurr = jpIsCharCodeKanji(charCode) || charCode === JP_ITERATION_MARK_CHAR_CODE ? 'kanji' : 'kana';
         if (modeCurr === modePrev) {
             groups[groups.length - 1].text += c;
         } else {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -385,6 +385,8 @@ function jpConvertAlphabeticToKana(text, sourceMapping) {
             c += (0x61 - 0xff21);
         } else if (c >= 0xff41 && c <= 0xff5a) { // ['a', 'z'] fullwidth
             c += (0x61 - 0xff41);
+        } else if (c === 0x2d || c === 0xff0d) { // '-' or fullwidth dash
+            c = 0x2d; // '-'
         } else {
             if (part.length > 0) {
                 result += jpToHiragana(part, sourceMapping, result.length);

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -112,6 +112,58 @@ const JP_JAPANESE_RANGES = [
 ];
 
 
+// Helper functions
+
+function _jpIsCharCodeInRanges(charCode, ranges) {
+    for (const [min, max] of ranges) {
+        if (charCode >= min && charCode <= max) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+// Character code testing functions
+
+function jpIsCharCodeKanji(charCode) {
+    return _jpIsCharCodeInRanges(charCode, JP_CJK_RANGES);
+}
+
+function jpIsCharCodeKana(charCode) {
+    return _jpIsCharCodeInRanges(charCode, JP_KANA_RANGES);
+}
+
+function jpIsCharCodeJapanese(charCode) {
+    return _jpIsCharCodeInRanges(charCode, JP_JAPANESE_RANGES);
+}
+
+
+// String testing functions
+
+function jpIsStringEntirelyKana(str) {
+    if (str.length === 0) { return false; }
+    for (let i = 0, ii = str.length; i < ii; ++i) {
+        if (!jpIsCharCodeKana(str.charCodeAt(i))) {
+            return false;
+        }
+    }
+    return true;
+}
+
+function jpIsStringPartiallyJapanese(str) {
+    if (str.length === 0) { return false; }
+    for (let i = 0, ii = str.length; i < ii; ++i) {
+        if (jpIsCharCodeJapanese(str.charCodeAt(i))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+
+// Old character/string testing functions
+
 function jpIsKanji(c) {
     const code = c.charCodeAt(0);
     return (
@@ -154,6 +206,9 @@ function jpIsAnyCharacterJapanese(text) {
     }
     return false;
 }
+
+
+// Conversion functions
 
 function jpKatakanaToHiragana(text) {
     let result = '';

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -92,9 +92,13 @@ function jpIsKana(c) {
     );
 }
 
-function jpIsJapaneseText(text) {
+function jpIsCharacterJapanese(c) {
+    return jpIsKanji(c) || jpIsKana(c);
+}
+
+function jpIsAnyCharacterJapanese(text) {
     for (const c of text) {
-        if (jpIsKanji(c) || jpIsKana(c)) {
+        if (jpIsCharacterJapanese(c)) {
             return true;
         }
     }


### PR DESCRIPTION
This PR adds support for #313 and a few other things.

* Changed how deinflection variants are handled. This was previously only used for finding deinflections using both the raw text and the text source converted to hiragana, but has been extended with some additional options:
  * **Convert katakana to hiragana** (ヨミチャン → よみちゃん) _[default: true]_
  * **Convert half width characters to full width** (ﾖﾐﾁｬﾝ → ヨミチャン) _[default: false]_
  * **Convert numeric characters to full width** (1234 → １２３４) _[default: false]_
  * **Convert alphabetic characters to hiragana** (yomichan → よみちゃん) _[default: false]_
* Each of the above options has three possible values: `'false'`, `'true'`, `'variant'`.
  * `'false'` indicates that the conversion will not be performed.
  * `'true'` indicates that the conversion will always be performed.
  * `'variant'` indicates that both the converted and non-converted text will be searched.
* The above options mean that rōmaji can be scanned for the most part. Exceptions include:
  * Multi-word phrases, since words are separated by spaces when romanized.
  * Roman characters which convert to multiple Japanese characters (cha => ちゃ) can have misleading results. E.g. _yomichan_ => よみちゃん, which can come up with <ruby>夜道<rt>よみち</rt></ruby> as a result, but will highlight _yomicha_.
* Simplified the `jpIsKana` function and added `jpIsCharFullWidth` and `jpIsKanaHalfWidth`, which are also now used to classify whether text is Japanese or not. This makes the "Search alphanumeric text" option work in more cases, e.g. "１人" (full width 1).

One issue that had to be solved for this change was that the conversions had to be able to be mapped back to the source text in order to select the correct amount of characters. This is necessary when the number of pre-conversion characters does not match the number of post-conversion characters, which happens during romanization and with half width kana followed by diacritics. Therefore, I did not go the route of using [String.prototype.normalize](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize), since it does not provide this mapping.