### PR TITLE
use TextScanner in QueryParser

### DIFF
--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -17,73 +17,47 @@
  */
 
 
-class QueryParser {
+class QueryParser extends TextScanner {
     constructor(search) {
+        super(document.querySelector('#query-parser'), [], [], []);
         this.search = search;
-        this.pendingLookup = false;
-        this.clickScanPrevent = false;
 
         this.parseResults = [];
         this.selectedParser = null;
 
         this.queryParser = document.querySelector('#query-parser');
         this.queryParserSelect = document.querySelector('#query-parser-select');
-
-        this.queryParser.addEventListener('mousedown', (e) => this.onMouseDown(e));
-        this.queryParser.addEventListener('mouseup', (e) => this.onMouseUp(e));
     }
 
     onError(error) {
         logError(error, false);
     }
 
-    onMouseDown(e) {
-        if (DOM.isMouseButtonPressed(e, 'primary')) {
-            this.clickScanPrevent = false;
-        }
+    onClick(e) {
+        super.onClick(e);
+        this.searchAt(e.clientX, e.clientY, 'click');
     }
 
-    onMouseUp(e) {
-        if (
-            this.search.options.scanning.enablePopupSearch &&
-            !this.clickScanPrevent &&
-            DOM.isMouseButtonPressed(e, 'primary')
-        ) {
-            const selectText = this.search.options.scanning.selectText;
-            this.onTermLookup(e, {disableScroll: true, selectText});
-        }
-    }
+    async onSearchSource(textSource, cause) {
+        if (textSource === null) { return null; }
 
-    onMouseMove(e) {
-        if (this.pendingLookup || DOM.isMouseButtonDown(e, 'primary')) {
-            return;
-        }
+        this.setTextSourceScanLength(textSource, this.search.options.scanning.length);
+        const searchText = textSource.text();
+        if (searchText.length === 0) { return; }
 
-        const scanningOptions = this.search.options.scanning;
-        const scanningModifier = scanningOptions.modifier;
-        if (!(
-            TextScanner.isScanningModifierPressed(scanningModifier, e) ||
-            (scanningOptions.middleMouse && DOM.isMouseButtonDown(e, 'auxiliary'))
-        )) {
-            return;
-        }
+        const {definitions, length} = await apiTermsFind(searchText, {}, this.search.getOptionsContext());
+        if (definitions.length === 0) { return null; }
 
-        const selectText = this.search.options.scanning.selectText;
-        this.onTermLookup(e, {disableScroll: true, disableHistory: true, selectText});
-    }
+        textSource.setEndOffset(length);
 
-    onMouseLeave(e) {
-        this.clickScanPrevent = true;
-        clearTimeout(e.target.dataset.timer);
-        delete e.target.dataset.timer;
-    }
+        this.search.setContent('terms', {definitions, context: {
+            focus: false,
+            disableHistory: cause === 'mouse' ? true : false,
+            sentence: {text: searchText, offset: 0},
+            url: window.location.href
+        }});
 
-    onTermLookup(e, params) {
-        this.pendingLookup = true;
-        (async () => {
-            await this.search.onTermLookup(e, params);
-            this.pendingLookup = false;
-        })();
+        return {definitions, type: 'terms'};
     }
 
     onParserChange(e) {
@@ -91,6 +65,27 @@ class QueryParser {
         this.selectedParser = selectedParser;
         apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
         this.renderParseResult(this.getParseResult());
+    }
+
+    getMouseEventListeners() {
+        return [
+            [this.node, 'click', this.onClick.bind(this)],
+            [this.node, 'mousedown', this.onMouseDown.bind(this)],
+            [this.node, 'mousemove', this.onMouseMove.bind(this)],
+            [this.node, 'mouseover', this.onMouseOver.bind(this)],
+            [this.node, 'mouseout', this.onMouseOut.bind(this)]
+        ];
+    }
+
+    getTouchEventListeners() {
+        return [
+            [this.node, 'auxclick', this.onAuxClick.bind(this)],
+            [this.node, 'touchstart', this.onTouchStart.bind(this)],
+            [this.node, 'touchend', this.onTouchEnd.bind(this)],
+            [this.node, 'touchcancel', this.onTouchCancel.bind(this)],
+            [this.node, 'touchmove', this.onTouchMove.bind(this), {passive: false}],
+            [this.node, 'contextmenu', this.onContextMenu.bind(this)]
+        ];
     }
 
     refreshSelectedParser() {
@@ -156,10 +151,6 @@ class QueryParser {
             terms: previewTerms,
             preview: true
         });
-
-        for (const charElement of this.queryParser.querySelectorAll('.query-parser-char')) {
-            this.activateScanning(charElement);
-        }
     }
 
     renderParserSelect() {
@@ -190,27 +181,6 @@ class QueryParser {
             'query-parser.html',
             {terms: QueryParser.processParseResultForDisplay(parseResult.parsedText)}
         );
-
-        for (const charElement of this.queryParser.querySelectorAll('.query-parser-char')) {
-            this.activateScanning(charElement);
-        }
-    }
-
-    activateScanning(element) {
-        element.addEventListener('mousemove', (e) => {
-            clearTimeout(e.target.dataset.timer);
-            if (this.search.options.scanning.modifier === 'none') {
-                e.target.dataset.timer = setTimeout(() => {
-                    this.onMouseMove(e);
-                    delete e.target.dataset.timer;
-                }, this.search.options.scanning.delay);
-            } else {
-                this.onMouseMove(e);
-            }
-        });
-        element.addEventListener('mouseleave', (e) => {
-            this.onMouseLeave(e);
-        });
     }
 
     static processParseResultForDisplay(result) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -236,6 +236,11 @@ class DisplaySearch extends Display {
         }
     }
 
+    async updateOptions(options) {
+        await super.updateOptions(options);
+        this.queryParser.setOptions(this.options);
+    }
+
     initClipboardMonitor() {
         // ignore copy from search page
         window.addEventListener('copy', () => {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -90,9 +90,8 @@ class Frontend extends TextScanner {
     }
 
     async updateOptions() {
-        this.options = await apiOptionsGet(this.getOptionsContext());
+        this.setOptions(await apiOptionsGet(this.getOptionsContext()));
         await this.popup.setOptions(this.options);
-        this.setEnabled(this.options.general.enable);
     }
 
     async onSearchSource(textSource, cause) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -281,6 +281,7 @@ class TextScanner {
 
     setOptions(options) {
         this.options = options;
+        this.setEnabled(this.options.general.enable);
     }
 
     async searchAt(x, y, cause) {


### PR DESCRIPTION
Continuation of https://github.com/FooSoft/yomichan/pull/299.

Fixes blinking results in https://github.com/FooSoft/yomichan/pull/317 so that it can be merged and used to fix https://github.com/FooSoft/yomichan/issues/325.

Also enables scanning query parser text on touchscreen devices.

`TextScanner` could potentially be used in `Display` as well, but it's more work and has less benefits because it only uses click events.