### PR TITLE
Native popup windows

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -26,6 +26,7 @@
         <script src="/bg/js/mecab.js"></script>
         <script src="/bg/js/audio.js"></script>
         <script src="/bg/js/backend-api-forwarder.js"></script>
+        <script src="/bg/js/clipboard-monitor.js"></script>
         <script src="/bg/js/conditions.js"></script>
         <script src="/bg/js/database.js"></script>
         <script src="/bg/js/deinflector.js"></script>

--- a/ext/bg/css/settings.css
+++ b/ext/bg/css/settings.css
@@ -222,6 +222,20 @@ html:root[data-operating-system=openbsd] [data-show-for-operating-system~=openbs
     display: initial;
 }
 
+html:root[data-browser=edge] [data-hide-for-browser~=edge],
+html:root[data-browser=chrome] [data-hide-for-browser~=chrome],
+html:root[data-browser=firefox] [data-hide-for-browser~=firefox],
+html:root[data-browser=firefox-mobile] [data-hide-for-browser~=firefox-mobile],
+html:root[data-operating-system=mac] [data-hide-for-operating-system~=mac],
+html:root[data-operating-system=win] [data-hide-for-operating-system~=win],
+html:root[data-operating-system=android] [data-hide-for-operating-system~=android],
+html:root[data-operating-system=cros] [data-hide-for-operating-system~=cros],
+html:root[data-operating-system=linux] [data-hide-for-operating-system~=linux],
+html:root[data-operating-system=openbsd] [data-hide-for-operating-system~=openbsd] {
+    display: none;
+}
+
+
 @media screen and (max-width: 740px) {
     .col-xs-6 {
         float: none;

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -79,6 +79,7 @@
                                 "type": "object",
                                 "required": [
                                     "enable",
+                                    "enableClipboardPopups",
                                     "resultOutputMode",
                                     "debugInfo",
                                     "maxResults",
@@ -110,6 +111,10 @@
                                     "enable": {
                                         "type": "boolean",
                                         "default": true
+                                    },
+                                    "enableClipboardPopups": {
+                                        "type": "boolean",
+                                        "default": false
                                     },
                                     "resultOutputMode": {
                                         "type": "string",

--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -29,6 +29,10 @@ function apiGetDisplayTemplatesHtml() {
     return _apiInvoke('getDisplayTemplatesHtml');
 }
 
+function apiClipboardGet() {
+    return _apiInvoke('clipboardGet');
+}
+
 function _apiInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -629,6 +629,10 @@ class Backend {
                 chrome.tabs.create({url});
                 return;
             case 'popup':
+                if (!isObject(chrome.windows)) {
+                    // chrome.windows not supported (e.g. on Firefox mobile)
+                    return;
+                }
                 if (this.popupWindow !== null) {
                     const callback = () => this.checkLastError(chrome.runtime.lastError);
                     chrome.windows.remove(this.popupWindow.id, callback);

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -585,8 +585,7 @@ class Backend {
     async _onCommandSearch(params) {
         const {mode, query} = params || {};
 
-        const optionsContext = {depth: 0};
-        const options = await this.getOptions(optionsContext);
+        const options = await this.getOptions(this.optionsContext);
         const {popupWidth, popupHeight} = options.general;
 
         const baseUrl = chrome.runtime.getURL('/bg/search.html');

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -600,7 +600,7 @@ class Backend {
     // Command handlers
 
     async _onCommandSearch(params) {
-        const {mode, query} = params || {};
+        const {mode, query} = params || {mode: 'sameTab'};
 
         const options = await this.getOptions(this.optionsContext);
         const {popupWidth, popupHeight} = options.general;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -34,6 +34,9 @@ class Backend {
 
         this.clipboardPasteTarget = document.querySelector('#clipboard-paste-target');
         this.popupWindow = null;
+        this.clipboardPopupTimerId = null;
+        this.clipboardInterval = 250;
+        this.clipboardPreviousText = null;
 
         this.apiForwarder = new BackendApiForwarder();
     }
@@ -121,6 +124,20 @@ class Backend {
             this.mecab.startListener();
         } else {
             this.mecab.stopListener();
+        }
+
+        window.clearInterval(this.clipboardPopupTimerId);
+        if (options.general.enableClipboardPopups) {
+            this.clipboardPopupTimerId = setInterval(() => {
+                this._onApiClipboardGet()
+                .then((result) => {
+                    if (this.clipboardPreviousText === result) {
+                        return;
+                    }
+                    this._onCommandSearch({mode: 'popup', query: result});
+                    this.clipboardPreviousText = result;
+                });
+            }, this.clipboardInterval);
         }
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -619,7 +619,9 @@ class Backend {
             if (tab !== null) {
                 await Backend._focusTab(tab);
                 if (queryParams.query) {
-                    await new Promise((resolve) => chrome.tabs.update(tab.id, {url}, resolve));
+                    await new Promise((resolve) => chrome.tabs.sendMessage(
+                        tab.id, {action: 'searchQueryUpdate', params: {query: queryParams.query}}, resolve
+                    ));
                 }
                 return true;
             }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -630,10 +630,10 @@ class Backend {
                 if (this.popupWindow !== null) {
                     chrome.windows.remove(this.popupWindow.id);
                 }
-                chrome.windows.create(
+                this.popupWindow = await new Promise((resolve) => chrome.windows.create(
                     {url, width: popupWidth, height: popupHeight, type: 'popup'},
-                    (popupWindow) => { this.popupWindow = popupWindow; }
-                );
+                    resolve
+                ));
                 return;
         }
     }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -603,8 +603,10 @@ class Backend {
         const {popupWidth, popupHeight} = options.general;
 
         const baseUrl = chrome.runtime.getURL('/bg/search.html');
-        const queryString = (query && query.length > 0) ? `?query=${encodeURIComponent(query)}` : '';
-        const url = baseUrl + queryString;
+        const queryParams = {mode};
+        if (query && query.length > 0) { queryParams.query = query; }
+        const queryString = new URLSearchParams(queryParams).toString();
+        const url = `${baseUrl}?${queryString}`;
 
         switch (mode) {
             case 'sameTab':

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -628,7 +628,8 @@ class Backend {
                 return;
             case 'popup':
                 if (this.popupWindow !== null) {
-                    chrome.windows.remove(this.popupWindow.id);
+                    const callback = () => this.checkLastError(chrome.runtime.lastError);
+                    chrome.windows.remove(this.popupWindow.id, callback);
                 }
                 this.popupWindow = await new Promise((resolve) => chrome.windows.create(
                     {url, width: popupWidth, height: popupHeight, type: 'popup'},

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -608,14 +608,16 @@ class Backend {
         const queryString = new URLSearchParams(queryParams).toString();
         const url = `${baseUrl}?${queryString}`;
 
+        const isTabMatch = (url2) => {
+            if (url2 === null || !url2.startsWith(baseUrl)) { return false; }
+            const {baseUrl: baseUrl2, queryParams: queryParams2} = parseUrl(url2);
+            return baseUrl2 === baseUrl && (queryParams2.mode === mode || (!queryParams2.mode && mode === 'existingOrNewTab'));
+        };
+
         switch (mode) {
             case 'existingOrNewTab':
                 try {
-                    const tab = await Backend._findTab(1000, (url2) => (
-                        url2 !== null &&
-                        url2.startsWith(baseUrl) &&
-                        (url2.length === baseUrl.length || url2[baseUrl.length] === '?' || url2[baseUrl.length] === '#')
-                    ));
+                    const tab = await Backend._findTab(1000, isTabMatch);
                     if (tab !== null) {
                         await Backend._focusTab(tab);
                         if (queryParams.query) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -597,7 +597,7 @@ class Backend {
     // Command handlers
 
     async _onCommandSearch(params) {
-        const {mode, query} = params || {mode: 'existingOrNewTab'};
+        const {mode='existingOrNewTab', query} = params || {};
 
         const options = await this.getOptions(this.optionsContext);
         const {popupWidth, popupHeight} = options.general;
@@ -613,11 +613,14 @@ class Backend {
                 try {
                     const tab = await Backend._findTab(1000, (url2) => (
                         url2 !== null &&
-                        url2.startsWith(url) &&
-                        (url2.length === url.length || url2[url.length] === '?' || url2[url.length] === '#')
+                        url2.startsWith(baseUrl) &&
+                        (url2.length === baseUrl.length || url2[baseUrl.length] === '?' || url2[baseUrl.length] === '#')
                     ));
                     if (tab !== null) {
                         await Backend._focusTab(tab);
+                        if (queryParams.query) {
+                            await new Promise((resolve) => chrome.tabs.update(tab.id, {url}, resolve));
+                        }
                         return;
                     }
                 } catch (e) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -597,7 +597,7 @@ class Backend {
     // Command handlers
 
     async _onCommandSearch(params) {
-        const {mode, query} = params || {mode: 'sameTab'};
+        const {mode, query} = params || {mode: 'existingOrNewTab'};
 
         const options = await this.getOptions(this.optionsContext);
         const {popupWidth, popupHeight} = options.general;
@@ -609,7 +609,7 @@ class Backend {
         const url = `${baseUrl}?${queryString}`;
 
         switch (mode) {
-            case 'sameTab':
+            case 'existingOrNewTab':
                 try {
                     const tab = await Backend._findTab(1000, (url2) => (
                         url2 !== null &&

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -30,6 +30,8 @@ class ClipboardMonitor {
     }
 
     start() {
+        this.stop();
+
         // The token below is used as a unique identifier to ensure that a new clipboard monitor
         // hasn't been started during the await call. The check below the await apiClipboardGet()
         // call will exit early if the reference has changed.

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2020  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+class ClipboardMonitor {
+    constructor() {
+        this.timerId = null;
+        this.timerToken = null;
+        this.interval = 250;
+        this.previousText = null;
+    }
+
+    onClipboardText(_text) {
+        throw new Error('Override me');
+    }
+
+    start() {
+        // The token below is used as a unique identifier to ensure that a new clipboard monitor
+        // hasn't been started during the await call. The check below the await apiClipboardGet()
+        // call will exit early if the reference has changed.
+        const token = {};
+        const intervalCallback = async () => {
+            this.timerId = null;
+
+            let text = null;
+            try {
+                text = await apiClipboardGet();
+            } catch (e) {
+                // NOP
+            }
+            if (this.timerToken !== token) { return; }
+
+            if (
+                typeof text === 'string' &&
+                (text = text.trim()).length > 0 &&
+                text !== this.previousText
+            ) {
+                this.previousText = text;
+                if (jpIsStringPartiallyJapanese(text)) {
+                    this.onClipboardText(text);
+                }
+            }
+
+            this.timerId = setTimeout(intervalCallback, this.interval);
+        };
+
+        this.timerToken = token;
+
+        intervalCallback();
+    }
+
+    stop() {
+        this.timerToken = null;
+        if (this.timerId !== null) {
+            clearTimeout(this.timerId);
+            this.timerId = null;
+        }
+    }
+
+    setPreviousText(text) {
+        this.previousText = text;
+    }
+}

--- a/ext/bg/js/context.js
+++ b/ext/bg/js/context.js
@@ -30,12 +30,12 @@ function setupButtonEvents(selector, command, url) {
     for (const node of nodes) {
         node.addEventListener('click', (e) => {
             if (e.button !== 0) { return; }
-            apiCommandExec(command, {newTab: e.ctrlKey});
+            apiCommandExec(command, {mode: e.ctrlKey ? 'newTab' : 'sameTab'});
             e.preventDefault();
         }, false);
         node.addEventListener('auxclick', (e) => {
             if (e.button !== 1) { return; }
-            apiCommandExec(command, {newTab: true});
+            apiCommandExec(command, {mode: 'newTab'});
             e.preventDefault();
         }, false);
 

--- a/ext/bg/js/context.js
+++ b/ext/bg/js/context.js
@@ -30,7 +30,7 @@ function setupButtonEvents(selector, command, url) {
     for (const node of nodes) {
         node.addEventListener('click', (e) => {
             if (e.button !== 0) { return; }
-            apiCommandExec(command, {mode: e.ctrlKey ? 'newTab' : 'sameTab'});
+            apiCommandExec(command, {mode: e.ctrlKey ? 'newTab' : 'existingOrNewTab'});
             e.preventDefault();
         }, false);
         node.addEventListener('auxclick', (e) => {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -266,6 +266,7 @@ function profileOptionsCreateDefaults() {
     return {
         general: {
             enable: true,
+            enableClipboardPopups: false,
             resultOutputMode: 'group',
             debugInfo: false,
             maxResults: 32,

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -69,22 +69,17 @@ class DisplaySearch extends Display {
                         const {query=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
                         if (e.target.checked) {
                             window.wanakana.bind(this.query);
-                            this.setQuery(window.wanakana.toKana(query));
                             apiOptionsSet({general: {enableWanakana: true}}, this.getOptionsContext());
                         } else {
                             window.wanakana.unbind(this.query);
-                            this.setQuery(query);
                             apiOptionsSet({general: {enableWanakana: false}}, this.getOptionsContext());
                         }
+                        this.setQuery(query);
                         this.onSearchQueryUpdated(this.query.value, false);
                     });
                 }
 
-                if (this.isWanakanaEnabled()) {
-                    this.setQuery(window.wanakana.toKana(query));
-                } else {
-                    this.setQuery(query);
-                }
+                this.setQuery(query);
                 this.onSearchQueryUpdated(this.query.value, false);
             }
             if (this.clipboardMonitorEnable !== null && mode !== 'popup') {
@@ -164,12 +159,7 @@ class DisplaySearch extends Display {
     onPopState() {
         const {query='', mode=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
         document.documentElement.dataset.searchMode = mode;
-        if (this.isWanakanaEnabled()) {
-            this.setQuery(window.wanakana.toKana(query));
-        } else {
-            this.setQuery(query);
-        }
-
+        this.setQuery(query);
         this.onSearchQueryUpdated(this.query.value, false);
     }
 
@@ -203,7 +193,7 @@ class DisplaySearch extends Display {
     }
 
     onClipboardText(text) {
-        this.setQuery(this.isWanakanaEnabled() ? window.wanakana.toKana(text) : text);
+        this.setQuery(text);
         window.history.pushState(null, '', `${window.location.pathname}?query=${encodeURIComponent(text)}`);
         this.onSearchQueryUpdated(this.query.value, true);
     }
@@ -256,8 +246,9 @@ class DisplaySearch extends Display {
     }
 
     setQuery(query) {
-        this.query.value = query;
-        this.queryParser.setText(query);
+        const interpretedQuery = this.isWanakanaEnabled() ? window.wanakana.toKana(query) : query;
+        this.query.value = interpretedQuery;
+        this.queryParser.setText(interpretedQuery);
     }
 
     setIntroVisible(visible, animate) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -152,9 +152,13 @@ class DisplaySearch extends Display {
         e.preventDefault();
 
         const query = this.query.value;
+
         this.queryParser.setText(query);
-        const queryString = query.length > 0 ? `?query=${encodeURIComponent(query)}` : '';
-        window.history.pushState(null, '', `${window.location.pathname}${queryString}`);
+
+        const url = new URL(window.location.href);
+        url.searchParams.set('query', query);
+        window.history.pushState(null, '', url.toString());
+
         this.onSearchQueryUpdated(query, true);
     }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -49,11 +49,12 @@ class DisplaySearch extends Display {
         try {
             await this.initialize();
 
+            const {query='', mode=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
+
             if (this.search !== null) {
                 this.search.addEventListener('click', (e) => this.onSearch(e), false);
             }
             if (this.query !== null) {
-                const {query='', mode=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
                 document.documentElement.dataset.searchMode = mode;
                 this.query.addEventListener('input', () => this.onSearchInput(), false);
 
@@ -86,7 +87,7 @@ class DisplaySearch extends Display {
                 }
                 this.onSearchQueryUpdated(this.query.value, false);
             }
-            if (this.clipboardMonitorEnable !== null) {
+            if (this.clipboardMonitorEnable !== null && mode !== 'popup') {
                 if (this.options.general.enableClipboardMonitor === true) {
                     this.clipboardMonitorEnable.checked = true;
                     this.clipboardMonitor.start();

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -65,6 +65,7 @@ class DisplaySearch extends Display {
                         this.wanakanaEnable.checked = false;
                     }
                     this.wanakanaEnable.addEventListener('change', (e) => {
+                        const {query=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
                         if (e.target.checked) {
                             window.wanakana.bind(this.query);
                             this.setQuery(window.wanakana.toKana(query));

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -49,7 +49,7 @@ class DisplaySearch extends Display {
         try {
             await this.initialize();
 
-            const {query='', mode=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
+            const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
 
             if (this.search !== null) {
                 this.search.addEventListener('click', (e) => this.onSearch(e), false);
@@ -66,7 +66,7 @@ class DisplaySearch extends Display {
                         this.wanakanaEnable.checked = false;
                     }
                     this.wanakanaEnable.addEventListener('change', (e) => {
-                        const {query=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
+                        const {queryParams: {query=''}} = parseUrl(window.location.href);
                         if (e.target.checked) {
                             window.wanakana.bind(this.query);
                             apiOptionsSet({general: {enableWanakana: true}}, this.getOptionsContext());
@@ -157,7 +157,7 @@ class DisplaySearch extends Display {
     }
 
     onPopState() {
-        const {query='', mode=''} = DisplaySearch.parseQueryStringFromLocation(window.location.href);
+        const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
         document.documentElement.dataset.searchMode = mode;
         this.setQuery(query);
         this.onSearchQueryUpdated(this.query.value, false);
@@ -322,13 +322,6 @@ class DisplaySearch extends Display {
         } else {
             document.title = `${text} - Yomichan Search`;
         }
-    }
-
-    static parseQueryStringFromLocation(url) {
-        const parsedUrl = new URL(url);
-        const parsedSearch = new URLSearchParams(parsedUrl.search);
-        return Array.from(parsedSearch.entries())
-            .reduce((a, [k, v]) => Object.assign({}, a, {[k]: v}), {});
     }
 }
 

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -28,7 +28,22 @@ function getOptionsFullMutable() {
 
 async function formRead(options) {
     options.general.enable = $('#enable').prop('checked');
-    options.general.enableClipboardPopups = $('#enable-clipboard-popups').prop('checked');
+    const enableClipboardPopups = $('#enable-clipboard-popups').prop('checked');
+    if (enableClipboardPopups) {
+        options.general.enableClipboardPopups = await new Promise((resolve, _reject) => {
+            chrome.permissions.request(
+                {permissions: ['clipboardRead']},
+                (granted) => {
+                    if (!granted) {
+                        $('#enable-clipboard-popups').prop('checked', false);
+                    }
+                    resolve(granted);
+                }
+            );
+        });
+    } else {
+        options.general.enableClipboardPopups = false;
+    }
     options.general.showGuide = $('#show-usage-guide').prop('checked');
     options.general.compactTags = $('#compact-tags').prop('checked');
     options.general.compactGlossaries = $('#compact-glossaries').prop('checked');

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -28,6 +28,7 @@ function getOptionsFullMutable() {
 
 async function formRead(options) {
     options.general.enable = $('#enable').prop('checked');
+    options.general.enableClipboardPopups = $('#enable-clipboard-popups').prop('checked');
     options.general.showGuide = $('#show-usage-guide').prop('checked');
     options.general.compactTags = $('#compact-tags').prop('checked');
     options.general.compactGlossaries = $('#compact-glossaries').prop('checked');

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -105,6 +105,7 @@ async function formRead(options) {
 
 async function formWrite(options) {
     $('#enable').prop('checked', options.general.enable);
+    $('#enable-clipboard-popups').prop('checked', options.general.enableClipboardPopups);
     $('#show-usage-guide').prop('checked', options.general.showGuide);
     $('#compact-tags').prop('checked', options.general.compactTags);
     $('#compact-glossaries').prop('checked', options.general.compactGlossaries);

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -25,23 +25,25 @@
                 <p style="margin-bottom: 0;">Search your installed dictionaries by entering a Japanese expression into the field below.</p>
             </div>
 
-            <div class="input-group" style="padding-top: 20px;">
-                <span title="Enable kana input method" class="input-group-text">
-                    <input type="checkbox" id="wanakana-enable" class="icon-checkbox" />
-                    <label for="wanakana-enable" class="scan-disable">あ</label>
-                </span>
-                <span title="Enable clipboard monitor" class="input-group-text">
-                    <input type="checkbox" id="clipboard-monitor-enable" class="icon-checkbox" />
-                    <label for="clipboard-monitor-enable"><span class="glyphicon glyphicon-paste"></span></label>
-                </span>
-            </div>
+            <div class="search-input">
+                <div class="input-group" style="padding-top: 20px;">
+                    <span title="Enable kana input method" class="input-group-text">
+                        <input type="checkbox" id="wanakana-enable" class="icon-checkbox" />
+                        <label for="wanakana-enable" class="scan-disable">あ</label>
+                    </span>
+                    <span title="Enable clipboard monitor" class="input-group-text">
+                        <input type="checkbox" id="clipboard-monitor-enable" class="icon-checkbox" />
+                        <label for="clipboard-monitor-enable"><span class="glyphicon glyphicon-paste"></span></label>
+                    </span>
+                </div>
 
-            <form class="input-group">
-                <input type="text" class="form-control" placeholder="Search for..." id="query" autofocus>
-                <span class="input-group-btn">
-                    <input type="submit" class="btn btn-default form-control" id="search" value="Search">
-                </span>
-            </form>
+                <form class="input-group">
+                    <input type="text" class="form-control" placeholder="Search for..." id="query" autofocus>
+                    <span class="input-group-btn">
+                        <input type="submit" class="btn btn-default form-control" id="search" value="Search">
+                    </span>
+                </form>
+            </div>
 
             <div id="spinner" hidden><img src="/mixed/img/spinner.gif"></div>
 

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -87,6 +87,7 @@
         <script src="/mixed/js/text-scanner.js"></script>
 
         <script src="/bg/js/search-query-parser.js"></script>
+        <script src="/bg/js/clipboard-monitor.js"></script>
         <script src="/bg/js/search.js"></script>
         <script src="/bg/js/search-frontend.js"></script>
     </body>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -135,6 +135,10 @@
                 </div>
 
                 <div class="checkbox">
+                    <label><input type="checkbox" id="enable-clipboard-popups"> Enable native popups when copying Japanese text</label>
+                </div>
+
+                <div class="checkbox">
                     <label><input type="checkbox" id="show-usage-guide"> Show usage guide on startup</label>
                 </div>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -134,7 +134,7 @@
                     <label><input type="checkbox" id="enable"> Enable content scanning</label>
                 </div>
 
-                <div class="checkbox">
+                <div class="checkbox" data-hide-for-browser="firefox-mobile">
                     <label><input type="checkbox" id="enable-clipboard-popups"> Enable native popups when copying Japanese text</label>
                 </div>
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -136,6 +136,10 @@ html:root[data-yomichan-page=float] .navigation-header:not([hidden])~.navigation
     margin-right: 0.2em;
 }
 
+html:root[data-yomichan-page=search][data-search-mode=popup] .search-input {
+    display: none;
+}
+
 
 /*
  * Entries

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -128,6 +128,14 @@ function stringReverse(string) {
     return string.split('').reverse().join('').replace(/([\uDC00-\uDFFF])([\uD800-\uDBFF])/g, '$2$1');
 }
 
+function parseUrl(url) {
+    const parsedUrl = new URL(url);
+    const baseUrl = `${parsedUrl.origin}${parsedUrl.pathname}`;
+    const queryParams = Array.from(parsedUrl.searchParams.entries())
+        .reduce((a, [k, v]) => Object.assign({}, a, {[k]: v}), {});
+    return {baseUrl, queryParams};
+}
+
 
 /*
  * Async utilities


### PR DESCRIPTION
Uses clipboard as a text source for now, but adding this to the API discussed in #262 is going to be done in a separate PR later.

Refactoring a new class `ClipboardMonitor` out of `search.js` and `backend.js` is planned, but I'm opening a PR in case there are bigger problems to fix first.

Right now it works by opening the search page in a native popup window. It could make sense to hide text input and disable the regular clipboard monitor when the search page is opened in a popup, but query parser is useful even there.