### PR TITLE
Fix tag double click

### DIFF
--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -251,6 +251,7 @@ button.action-button {
 
 .term-reasons>.term-reason+.term-reason-separator+.term-reason:before {
     content: " \00AB  "; /* The two spaces is not a typo */
+    white-space: pre-wrap;
     display: inline;
 }
 
@@ -403,7 +404,16 @@ button.action-button {
 }
 
 :root[data-compact-glossaries=true] .term-glossary-list>li:not(:first-child):before {
+    white-space: pre-wrap;
     content: " | ";
+    display: inline;
+}
+
+.term-glossary-separator,
+.term-reason-separator {
+    display: inline;
+    font-size: 0;
+    opacity: 0;
 }
 
 /*
@@ -467,14 +477,4 @@ button.action-button {
 .kanji-glossary-list:not([data-count="0"]):not([data-count="1"]) {
     padding-left: 1.4em;
     list-style-type: decimal;
-}
-
-.term-glossary-separator,
-.term-reason-separator {
-    display: inline-block;
-    width: 0;
-    height: 0;
-    font-size: 0;
-    opacity: 0;
-    white-space: pre;
 }

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -414,6 +414,7 @@ button.action-button {
     display: inline;
     font-size: 0;
     opacity: 0;
+    white-space: pre-wrap;
 }
 
 /*

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -249,7 +249,7 @@ button.action-button {
     display: inline-block;
 }
 
-.term-reasons>.term-reason+.term-reason:before {
+.term-reasons>.term-reason+.term-reason-separator+.term-reason:before {
     content: " \00AB  "; /* The two spaces is not a typo */
     display: inline;
 }
@@ -467,4 +467,14 @@ button.action-button {
 .kanji-glossary-list:not([data-count="0"]):not([data-count="1"]) {
     padding-left: 1.4em;
     list-style-type: decimal;
+}
+
+.term-glossary-separator,
+.term-reason-separator {
+    display: inline-block;
+    width: 0;
+    height: 0;
+    font-size: 0;
+    opacity: 0;
+    white-space: pre;
 }

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -208,15 +208,19 @@ button.action-button {
 }
 
 .tag {
-    display: inline;
+    display: inline-block;
     padding: 0.2em 0.6em 0.3em;
     font-size: 75%;
     font-weight: 700;
-    line-height: 1;
+    line-height: 1.25;
     text-align: center;
     white-space: nowrap;
     vertical-align: baseline;
     border-radius: 0.25em;
+}
+
+.tag-inner {
+    display: block;
 }
 
 .tag-list>.tag+.tag {

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -75,7 +75,7 @@
 <template id="kanji-glossary-item-template"><li class="kanji-glossary-item"><span class="kanji-glossary"></span></li></template>
 <template id="kanji-reading-template"><dd class="kanji-reading"></dd></template>
 
-<template id="tag-template"><span class="tag"></span></template>
-<template id="tag-frequency-template"><span class="tag" data-category="frequency"><span class="term-frequency-dictionary-name"></span><span class="term-frequency-separator"></span><span class="term-frequency-value"></span></template>
+<template id="tag-template"><span class="tag"><span class="tag-inner"></span></span></template>
+<template id="tag-frequency-template"><span class="tag" data-category="frequency"><span class="tag-inner"><span class="term-frequency-dictionary-name"></span><span class="term-frequency-separator"></span><span class="term-frequency-value"></span></span></template>
 
 </body></html>

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -31,8 +31,8 @@
     <ul class="term-glossary-list"></ul>
 </li></template>
 <template id="term-definition-only-template"><span class="term-definition-only"></span></template>
-<template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary"></span></li></template>
-<template id="term-reason-template"><span class="term-reason"></span></template>
+<template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary"></span><span class="term-glossary-separator">&#10;</span></li></template>
+<template id="term-reason-template"><span class="term-reason"></span><span class="term-reason-separator">&#10;</span></template>
 
 <template id="kanji-entry-template"><div class="entry" data-type="kanji">
     <div class="entry-header1">

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -31,8 +31,8 @@
     <ul class="term-glossary-list"></ul>
 </li></template>
 <template id="term-definition-only-template"><span class="term-definition-only"></span></template>
-<template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary"></span><span class="term-glossary-separator">&#10;</span></li></template>
-<template id="term-reason-template"><span class="term-reason"></span><span class="term-reason-separator">&#10;</span></template>
+<template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary-separator"> </span><span class="term-glossary"></span></li></template>
+<template id="term-reason-template"><span class="term-reason"></span><span class="term-reason-separator"> </span></template>
 
 <template id="kanji-entry-template"><div class="entry" data-type="kanji">
     <div class="entry-header1">

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -110,10 +110,11 @@ class DisplayGenerator {
     }
 
     createTermReason(reason) {
-        const node = DisplayGenerator._instantiateTemplate(this._termReasonTemplate);
+        const fragment = DisplayGenerator._instantiateTemplateFragment(this._termReasonTemplate);
+        const node = fragment.querySelector('.term-reason');
         node.textContent = reason;
         node.dataset.reason = reason;
-        return node;
+        return fragment;
     }
 
     createTermDefinitionItem(details) {
@@ -377,5 +378,9 @@ class DisplayGenerator {
 
     static _instantiateTemplate(template) {
         return document.importNode(template.content.firstChild, true);
+    }
+
+    static _instantiateTemplateFragment(template) {
+        return document.importNode(template.content, true);
     }
 }

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -252,8 +252,10 @@ class DisplayGenerator {
     createTag(details) {
         const node = DisplayGenerator._instantiateTemplate(this._tagTemplate);
 
+        const inner = node.querySelector('.tag-inner');
+
         node.title = details.notes;
-        node.textContent = details.name;
+        inner.textContent = details.name;
         node.dataset.category = details.category;
 
         return node;


### PR DESCRIPTION
Fixes #339 by changing display to `inline-block` and adding an inner `display: block` element. This also makes triple click work in case there are spaces. This change also improves the tag layout slightly. The vertical spacing is a bit better. [Old](https://user-images.githubusercontent.com/11037431/73411135-4962d280-42d2-11ea-82dd-1e9717fe3b08.png) vs [New](https://user-images.githubusercontent.com/11037431/73411137-4cf65980-42d2-11ea-834e-fc77d297fa48.png); Open in two new tabs and cycle between them.
