### PR TITLE
Eslint strengthening

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,14 @@
 {
+    "root": true,
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 8
+        "ecmaVersion": 8,
+        "sourceType": "script"
+    },
+    "env": {
+        "browser": true,
+        "es2017": true,
+        "webextensions": true
     },
     "ignorePatterns": [
         "/ext/mixed/lib/",
@@ -18,6 +25,7 @@
         "no-constant-condition": "off",
         "no-undef": "off",
         "no-unused-vars": ["error", {"vars": "local", "args": "after-used", "argsIgnorePattern": "^_", "caughtErrors": "none"}],
+        "no-unused-expressions": "error",
         "no-var": "error",
         "prefer-const": ["error", {"destructuring": "all"}],
         "quote-props": ["error", "consistent"],

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -49,6 +49,7 @@
                 "stringReverse": "readonly",
                 "promiseTimeout": "readonly",
                 "stringReplaceAsync": "readonly",
+                "parseUrl": "readonly",
                 "EventDispatcher": "readonly",
                 "EXTENSION_IS_BROWSER_EDGE": "readonly"
             }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -23,7 +23,8 @@
         "no-case-declarations": "error",
         "no-const-assign": "error",
         "no-constant-condition": "off",
-        "no-undef": "off",
+        "no-global-assign": "error",
+        "no-undef": "error",
         "no-unused-vars": ["error", {"vars": "local", "args": "after-used", "argsIgnorePattern": "^_", "caughtErrors": "none"}],
         "no-unused-expressions": "error",
         "no-var": "error",
@@ -32,5 +33,37 @@
         "quotes": ["error", "single", "avoid-escape"],
         "require-atomic-updates": "off",
         "semi": "error"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["*.js"],
+            "excludedFiles": ["ext/mixed/js/core.js"],
+            "globals": {
+                "yomichan": "readonly",
+                "errorToJson": "readonly",
+                "jsonToError": "readonly",
+                "logError": "readonly",
+                "isObject": "readonly",
+                "hasOwn": "readonly",
+                "toIterable": "readonly",
+                "stringReverse": "readonly",
+                "promiseTimeout": "readonly",
+                "stringReplaceAsync": "readonly",
+                "EventDispatcher": "readonly",
+                "EXTENSION_IS_BROWSER_EDGE": "readonly"
+            }
+        },
+        {
+            "files": ["ext/mixed/js/core.js"],
+            "globals": {
+                "chrome": "writable"
+            }
+        },
+        {
+            "files": ["ext/bg/js/settings/*.js"],
+            "env": {
+                "jquery": true
+            }
+        }
+    ]
 }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -65,6 +65,15 @@
             "env": {
                 "jquery": true
             }
+        },
+        {
+            "files": ["test/**/*.js"],
+            "env": {
+                "browser": false,
+                "es2017": false,
+                "webextensions": false,
+                "node": true
+            }
         }
     ]
 }

--- a/ext/bg/js/anki.js
+++ b/ext/bg/js/anki.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global requestJson*/
 
 /*
  * AnkiConnect

--- a/ext/bg/js/audio.js
+++ b/ext/bg/js/audio.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global jpIsStringEntirelyKana, audioGetFromSources*/
 
 const audioUrlBuilders = new Map([
     ['jpod101', async (definition) => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -16,6 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global optionsSave, utilIsolate
+conditionsTestValue, profileConditionsDescriptor, profileOptionsGetDefaultFieldTemplates
+handlebarsRenderDynamic, handlebarsRenderStatic
+requestText, requestJson, optionsLoad
+dictConfigured, dictTermsSort, dictEnabledSet, dictNoteFormat
+audioGetUrl, audioInject
+jpConvertReading, jpDistributeFuriganaInflected, jpKatakanaToHiragana
+Translator, AnkiConnect, AnkiNull, Mecab, BackendApiForwarder, JsonSchema*/
 
 class Backend {
     constructor() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -23,7 +23,7 @@ requestText, requestJson, optionsLoad
 dictConfigured, dictTermsSort, dictEnabledSet, dictNoteFormat
 audioGetUrl, audioInject
 jpConvertReading, jpDistributeFuriganaInflected, jpKatakanaToHiragana
-Translator, AnkiConnect, AnkiNull, Mecab, BackendApiForwarder, JsonSchema*/
+Translator, AnkiConnect, AnkiNull, Mecab, BackendApiForwarder, JsonSchema, ClipboardMonitor*/
 
 class Backend {
     constructor() {

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiClipboardGet, jpIsStringPartiallyJapanese*/
 
 class ClipboardMonitor {
     constructor() {

--- a/ext/bg/js/context.js
+++ b/ext/bg/js/context.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiCommandExec, apiGetEnvironmentInfo, apiOptionsGet*/
 
 function showExtensionInfo() {
     const node = document.getElementById('extension-info');

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global dictFieldSplit, dictTagSanitize, JSZip*/
 
 class Database {
     constructor() {

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global utilSetEqual, utilSetIntersection, apiTemplateRender*/
 
 function dictEnabledSet(options) {
     const dictionaries = {};

--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global jpIsCharCodeKanji, jpDistributeFurigana, Handlebars*/
 
 function handlebarsEscape(text) {
     return Handlebars.Utils.escapeExpression(text);

--- a/ext/bg/js/japanese.js
+++ b/ext/bg/js/japanese.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global wanakana*/
 
 const JP_HALFWIDTH_KATAKANA_MAPPING = new Map([
     ['ｦ', 'ヲヺ-'],

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global utilStringHashCode*/
 
 /*
  * Generic options functions

--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiOptionsGet*/
 
 async function searchFrontendSetup() {
     const optionsContext = {

--- a/ext/bg/js/search-query-parser-generator.js
+++ b/ext/bg/js/search-query-parser-generator.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiGetQueryParserTemplatesHtml, TemplateHandler*/
 
 class QueryParserGenerator {
     constructor() {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global apiTermsFind, apiOptionsSet, apiTextParse, apiTextParseMecab, apiTemplateRender, TextScanner, QueryParserGenerator*/
+/*global apiTermsFind, apiOptionsSet, apiTextParse, apiTextParseMecab, TextScanner, QueryParserGenerator*/
 
 class QueryParser extends TextScanner {
     constructor(search) {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global apiTermsFind, apiOptionsSet, apiTextParse, apiTextParseMecab, apiTemplateRender, TextScanner*/
+/*global apiTermsFind, apiOptionsSet, apiTextParse, apiTextParseMecab, apiTemplateRender, TextScanner, QueryParserGenerator*/
 
 class QueryParser extends TextScanner {
     constructor(search) {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiTermsFind, apiOptionsSet, apiTextParse, apiTextParseMecab, apiTemplateRender, TextScanner*/
 
 class QueryParser extends TextScanner {
     constructor(search) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -16,8 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global jpIsStringPartiallyJapanese, apiOptionsSet, apiTermsFind, apiClipboardGet, apiGetEnvironmentInfo
-Display, QueryParser, ClipboardMonitor*/
+/*global apiOptionsSet, apiTermsFind, Display, QueryParser, ClipboardMonitor*/
 
 class DisplaySearch extends Display {
     constructor() {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -17,7 +17,7 @@
  */
 
 /*global jpIsStringPartiallyJapanese, apiOptionsSet, apiTermsFind, apiClipboardGet, apiGetEnvironmentInfo
-Display, QueryParser*/
+Display, QueryParser, ClipboardMonitor*/
 
 class DisplaySearch extends Display {
     constructor() {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global jpIsStringPartiallyJapanese, apiOptionsSet, apiTermsFind, apiClipboardGet, apiGetEnvironmentInfo
+Display, QueryParser*/
+
 class DisplaySearch extends Display {
     constructor() {
         super(document.querySelector('#spinner'), document.querySelector('#content'));

--- a/ext/bg/js/settings/anki-templates.js
+++ b/ext/bg/js/settings/anki-templates.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsContext, getOptionsMutable, settingsSaveOptions
+profileOptionsGetDefaultFieldTemplates, ankiGetFieldMarkers, ankiGetFieldMarkersHtml, dictFieldFormat
+apiOptionsGet, apiTermsFind*/
 
 function onAnkiFieldTemplatesReset(e) {
     e.preventDefault();

--- a/ext/bg/js/settings/anki.js
+++ b/ext/bg/js/settings/anki.js
@@ -16,6 +16,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsContext, getOptionsMutable, settingsSaveOptions
+utilBackgroundIsolate, utilAnkiGetDeckNames, utilAnkiGetModelNames, utilAnkiGetModelFieldNames
+onFormOptionsChanged*/
 
 // Private
 

--- a/ext/bg/js/settings/audio-ui.js
+++ b/ext/bg/js/settings/audio-ui.js
@@ -16,8 +16,6 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global toIterable*/
-
 class AudioSourceUI {
     static instantiateTemplate(templateSelector) {
         const template = document.querySelector(templateSelector);

--- a/ext/bg/js/settings/audio-ui.js
+++ b/ext/bg/js/settings/audio-ui.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global toIterable*/
 
 class AudioSourceUI {
     static instantiateTemplate(templateSelector) {

--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -16,6 +16,8 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsContext, getOptionsMutable, settingsSaveOptions
+AudioSourceUI, audioGetTextToSpeechVoice*/
 
 let audioSourceUI = null;
 

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiOptionsGetFull, apiGetEnvironmentInfo
+utilBackend, utilIsolate, utilBackgroundIsolate, utilReadFileArrayBuffer
+optionsGetDefault, optionsUpdateVersion
+profileOptionsGetDefaultFieldTemplates*/
 
 // Exporting
 

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global conditionsNormalizeOptionValue*/
 
 class ConditionsUI {
     static instantiateTemplate(templateSelector) {

--- a/ext/bg/js/settings/dictionaries.js
+++ b/ext/bg/js/settings/dictionaries.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global getOptionsContext, getOptionsMutable, getOptionsFullMutable, settingsSaveOptions, apiOptionsGetFull
+/*global getOptionsContext, getOptionsMutable, getOptionsFullMutable, settingsSaveOptions, apiOptionsGetFull, apiOptionsGet
 utilBackgroundIsolate, utilDatabaseDeleteDictionary, utilDatabaseGetDictionaryInfo, utilDatabaseGetDictionaryCounts
 utilDatabasePurge, utilDatabaseImport
 storageUpdateStats, storageEstimate

--- a/ext/bg/js/settings/dictionaries.js
+++ b/ext/bg/js/settings/dictionaries.js
@@ -16,6 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsContext, getOptionsMutable, getOptionsFullMutable, settingsSaveOptions, apiOptionsGetFull
+utilBackgroundIsolate, utilDatabaseDeleteDictionary, utilDatabaseGetDictionaryInfo, utilDatabaseGetDictionaryCounts
+utilDatabasePurge, utilDatabaseImport
+storageUpdateStats, storageEstimate
+PageExitPrevention*/
 
 let dictionaryUI = null;
 

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -16,6 +16,14 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsContext, apiOptionsSave
+utilBackend, utilIsolate, utilBackgroundIsolate
+ankiErrorShown, ankiFieldsToDict
+ankiTemplatesUpdateValue, onAnkiOptionsChanged, onDictionaryOptionsChanged
+appearanceInitialize, audioSettingsInitialize, profileOptionsSetup, dictSettingsInitialize
+ankiInitialize, ankiTemplatesInitialize, storageInfoInitialize
+*/
+
 function getOptionsMutable(optionsContext) {
     return utilBackend().getOptions(
         utilBackgroundIsolate(optionsContext)

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiOptionsGet, Popup, PopupProxyHost, Frontend, TextSourceRange*/
 
 class SettingsPopupPreview {
     constructor() {

--- a/ext/bg/js/settings/profiles.js
+++ b/ext/bg/js/settings/profiles.js
@@ -16,6 +16,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global getOptionsMutable, getOptionsFullMutable, settingsSaveOptions, apiOptionsGetFull
+utilBackgroundIsolate, formWrite
+conditionsClearCaches, ConditionsUI, profileConditionsDescriptor*/
+
 let currentProfileIndex = 0;
 let profileConditionsContainer = null;
 

--- a/ext/bg/js/settings/storage.js
+++ b/ext/bg/js/settings/storage.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiGetEnvironmentInfo*/
 
 function storageBytesToLabeledString(size) {
     const base = 1000;

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -16,6 +16,12 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global requestJson
+dictTermsMergeBySequence, dictTagBuildSource, dictTermsMergeByGloss, dictTermsSort, dictTagsSort
+dictEnabledSet, dictTermsGroup, dictTermsCompressTags, dictTermsUndupe, dictTagSanitize
+jpDistributeFurigana, jpConvertHalfWidthKanaToFullWidth, jpConvertNumericTofullWidth
+jpConvertAlphabeticToKana, jpHiraganaToKatakana, jpKatakanaToHiragana, jpIsCharCodeJapanese
+Database, Deinflector*/
 
 class Translator {
     constructor() {

--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global TextSourceElement, TextSourceRange, DOM*/
 
 const REGEX_TRANSPARENT_COLOR = /rgba\s*\([^)]*,\s*0(?:\.0+)?\s*\)/;
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global popupNestedInitialize, Display*/
 
 class DisplayFloat extends Display {
     constructor() {

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global PopupProxyHost, PopupProxy, Frontend*/
 
 async function main() {
     const data = window.frontendInitializationData || {};

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiGetZoom, apiOptionsGet, apiTermsFind, apiKanjiFind, docSentenceExtract, TextScanner*/
 
 class Frontend extends TextScanner {
     constructor(popup, ignoreNodes) {

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiOptionsGet*/
 
 let popupNestedInitialized = false;
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiFrameInformationGet, FrontendApiReceiver, Popup*/
 
 class PopupProxyHost {
     constructor() {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global FrontendApiSender*/
 
 class PopupProxy {
     constructor(depth, parentId, parentFrameId, url) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiInjectStylesheet*/
 
 class Popup {
     constructor(id, depth, frameIdPromise) {

--- a/ext/mixed/js/audio.js
+++ b/ext/mixed/js/audio.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global apiAudioGetUrl*/
 
 class TextToSpeechAudio {
     constructor(text, voice) {

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+/*global apiGetDisplayTemplatesHtml*/
 
 class DisplayGenerator {
     constructor() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -16,6 +16,11 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global docRangeFromPoint, docSentenceExtract
+apiKanjiFind, apiTermsFind, apiNoteView, apiOptionsGet, apiDefinitionsAddable, apiDefinitionAdd
+apiScreenshotGet, apiForward
+audioPrepareTextToSpeech, audioGetFromSources
+DisplayGenerator, WindowScroll, DisplayContext, DOM*/
 
 class Display {
     constructor(spinner, container) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -16,6 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/*global docRangeFromPoint, TextSourceRange, DOM*/
 
 class TextScanner {
     constructor(node, ignoreNodes, ignoreElements, ignorePoints) {


### PR DESCRIPTION
Due to something I overlooked in https://github.com/FooSoft/yomichan/pull/338#discussion_r372594574 because it wasn't caught by eslint, I have gone through and updated the lint rules to be a bit more strict with regards to globals. Yomichan runs in the browser environment and uses `<script>` tags for loading scripts, so eslint doesn't check cross-file globals since `require` isn't used.

This change does require external globals to be defined at the top of the file to explicitly indicate that they are used. While this does add a bit of overhead, I think that it's a small trade-off for stronger code validity. Note that some of the global declarations I added are multi-line. This is primarily just to make it more readable. Functions on different lines are kind of grouped together with regard to similarity or source, but it's nothing formal.

After updating the lint rules, I checked the entire project and found one error (33e7f825e4497434fc3fd33d6ca3c35cc3aa2bf2) and one stylistic issue (ac5cf9b237f53e6e33934d9593125c2fca131b50) and resolved them.

---

One thing that comes up again relates to the discussion from #258, particularly point 2. Currently, all global functions must be explicitly declared. For example:
https://github.com/FooSoft/yomichan/blob/eaf46c4476160133810abf7f81e5fd512abf870b/ext/mixed/js/display.js#L19-L23
This can be somewhat repetitive when referring to functions which come from the same file. It could be potentially more simple if there was some object which contained all of these functions, such as `api.kanjiFind, api.termsFind`, and then only `api` has to be declared as global. This is a style similar to what most libraries do (jQuery, WanaKana).

I don't think it's mandatory to make such a change, but this style of declaring globals may be a point in favor of that.