### PR TITLE
Pitch accents

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -87,6 +87,8 @@
                 "stringReverse": "readonly",
                 "promiseTimeout": "readonly",
                 "parseUrl": "readonly",
+                "areSetsEqual": "readonly",
+                "getSetIntersection": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly",
                 "EXTENSION_IS_BROWSER_EDGE": "readonly"

--- a/ext/bg/data/dictionary-term-meta-bank-v3-schema.json
+++ b/ext/bg/data/dictionary-term-meta-bank-v3-schema.json
@@ -13,12 +13,70 @@
             },
             {
                 "type": "string",
-                "enum": ["freq"],
-                "description": "Type of data. \"freq\" corresponds to frequency information."
+                "enum": ["freq", "pitch"],
+                "description": "Type of data. \"freq\" corresponds to frequency information; \"pitch\" corresponds to pitch information."
             },
             {
-                "type": ["string", "number"],
                 "description": "Data for the term/expression."
+            }
+        ],
+        "oneOf": [
+            {
+                "items": [
+                    {},
+                    {"enum": ["freq"]},
+                    {
+                        "type": ["string", "number"],
+                        "description": "Frequency information for the term or expression."
+                    }
+                ]
+            },
+            {
+                "items": [
+                    {},
+                    {"enum": ["pitch"]},
+                    {
+                        "type": ["object"],
+                        "description": "Pitch accent information for the term or expression.",
+                        "required": [
+                            "reading",
+                            "pitches"
+                        ],
+                        "additionalProperties": false,
+                        "properties": {
+                            "reading": {
+                                "type": "string",
+                                "description": "Reading for the term or expression."
+                            },
+                            "pitches": {
+                                "type": "array",
+                                "description": "List of different pitch accent information for the term and reading combination.",
+                                "additionalItems": {
+                                    "type": "object",
+                                    "required": [
+                                        "position"
+                                    ],
+                                    "additionalProperties": false,
+                                    "properties": {
+                                        "position": {
+                                            "type": "integer",
+                                            "description": "Mora position of the pitch accent downstep. A value of 0 indicates that the word does not have a downstep (heiban).",
+                                            "minimum": 0
+                                        },
+                                        "tags": {
+                                            "type": "array",
+                                            "description": "List of tags for this pitch accent.",
+                                            "items": {
+                                                "type": "string",
+                                                "description": "Tag for this pitch accent. This typically corresponds to a certain type of part of speech."
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                ]
             }
         ]
     }

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -105,7 +105,10 @@
                                     "customPopupCss",
                                     "customPopupOuterCss",
                                     "enableWanakana",
-                                    "enableClipboardMonitor"
+                                    "enableClipboardMonitor",
+                                    "showPitchAccentDownstepNotation",
+                                    "showPitchAccentPositionNotation",
+                                    "showPitchAccentGraph"
                                 ],
                                 "properties": {
                                     "enable": {
@@ -225,6 +228,18 @@
                                         "default": true
                                     },
                                     "enableClipboardMonitor": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "showPitchAccentDownstepNotation": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "showPitchAccentPositionNotation": {
+                                        "type": "boolean",
+                                        "default": true
+                                    },
+                                    "showPitchAccentGraph": {
                                         "type": "boolean",
                                         "default": false
                                     }

--- a/ext/bg/js/dictionary.js
+++ b/ext/bg/js/dictionary.js
@@ -137,30 +137,6 @@ function dictTermsGroup(definitions, dictionaries) {
     return dictTermsSort(results);
 }
 
-function dictAreSetsEqual(set1, set2) {
-    if (set1.size !== set2.size) {
-        return false;
-    }
-
-    for (const value of set1) {
-        if (!set2.has(value)) {
-            return false;
-        }
-    }
-
-    return true;
-}
-
-function dictGetSetIntersection(set1, set2) {
-    const result = [];
-    for (const value of set1) {
-        if (set2.has(value)) {
-            result.push(value);
-        }
-    }
-    return result;
-}
-
 function dictTermsMergeBySequence(definitions, mainDictionary) {
     const sequencedDefinitions = new Map();
     const nonSequencedDefinitions = [];
@@ -281,11 +257,11 @@ function dictTermsMergeByGloss(result, definitions, appendTo=null, mergedIndices
         const only = [];
         const expressionSet = definition.expression;
         const readingSet = definition.reading;
-        if (!dictAreSetsEqual(expressionSet, resultExpressionSet)) {
-            only.push(...dictGetSetIntersection(expressionSet, resultExpressionSet));
+        if (!areSetsEqual(expressionSet, resultExpressionSet)) {
+            only.push(...getSetIntersection(expressionSet, resultExpressionSet));
         }
-        if (!dictAreSetsEqual(readingSet, resultReadingSet)) {
-            only.push(...dictGetSetIntersection(readingSet, resultReadingSet));
+        if (!areSetsEqual(readingSet, resultReadingSet)) {
+            only.push(...getSetIntersection(readingSet, resultReadingSet));
         }
         definition.only = only;
     }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -124,7 +124,10 @@ function profileOptionsCreateDefaults() {
             customPopupCss: '',
             customPopupOuterCss: '',
             enableWanakana: true,
-            enableClipboardMonitor: false
+            enableClipboardMonitor: false,
+            showPitchAccentDownstepNotation: true,
+            showPitchAccentPositionNotation: true,
+            showPitchAccentGraph: false
         },
 
         audio: {

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -84,6 +84,9 @@ async function formRead(options) {
     options.general.popupScalingFactor = parseFloat($('#popup-scaling-factor').val());
     options.general.popupScaleRelativeToPageZoom = $('#popup-scale-relative-to-page-zoom').prop('checked');
     options.general.popupScaleRelativeToVisualViewport = $('#popup-scale-relative-to-visual-viewport').prop('checked');
+    options.general.showPitchAccentDownstepNotation = $('#show-pitch-accent-downstep-notation').prop('checked');
+    options.general.showPitchAccentPositionNotation = $('#show-pitch-accent-position-notation').prop('checked');
+    options.general.showPitchAccentGraph = $('#show-pitch-accent-graph').prop('checked');
     options.general.popupTheme = $('#popup-theme').val();
     options.general.popupOuterTheme = $('#popup-outer-theme').val();
     options.general.customPopupCss = $('#custom-popup-css').val();
@@ -161,6 +164,9 @@ async function formWrite(options) {
     $('#popup-scaling-factor').val(options.general.popupScalingFactor);
     $('#popup-scale-relative-to-page-zoom').prop('checked', options.general.popupScaleRelativeToPageZoom);
     $('#popup-scale-relative-to-visual-viewport').prop('checked', options.general.popupScaleRelativeToVisualViewport);
+    $('#show-pitch-accent-downstep-notation').prop('checked', options.general.showPitchAccentDownstepNotation);
+    $('#show-pitch-accent-position-notation').prop('checked', options.general.showPitchAccentPositionNotation);
+    $('#show-pitch-accent-graph').prop('checked', options.general.showPitchAccentGraph);
     $('#popup-theme').val(options.general.popupTheme);
     $('#popup-outer-theme').val(options.general.popupOuterTheme);
     $('#custom-popup-css').val(options.general.customPopupCss);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -163,6 +163,18 @@
                 </div>
 
                 <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="show-pitch-accent-downstep-notation"> Show downstep notation for pitch accents</label>
+                </div>
+
+                <div class="checkbox options-position">
+                    <label><input type="checkbox" id="show-pitch-accent-position-notation"> Show position notation for pitch accents</label>
+                </div>
+
+                <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="show-pitch-accent-graph"> Show graph for pitch accents</label>
+                </div>
+
+                <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="show-debug-info"> Show debug information</label>
                 </div>
 

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -59,12 +59,14 @@ h2 { border-bottom-color: #2f2f2f; }
     color: #666666;
 }
 
-.term-definition-container,
-.kanji-glossary-container {
+.term-definition-list,
+.term-pitch-accent-group-list,
+.kanji-glossary-list {
     color: #888888;
 }
 
 .term-glossary,
+.term-pitch-accent,
 .kanji-glossary {
     color: #d4d4d4;
 }
@@ -74,3 +76,5 @@ h2 { border-bottom-color: #2f2f2f; }
     background-color: #d4d4d4;
     color: #1e1e1e;
 }
+
+.term-pitch-accent-character:before { border-color: #ffffff; }

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -41,6 +41,7 @@ h2 { border-bottom-color: #2f2f2f; }
 .tag[data-category=frequency]    { background-color: #489148; }
 .tag[data-category=partOfSpeech] { background-color: #565656; }
 .tag[data-category=search]       { background-color: #69696e; }
+.tag[data-category=pitch-accent-dictionary] { background-color: #6640be; }
 
 .term-reasons { color: #888888; }
 
@@ -76,6 +77,8 @@ h2 { border-bottom-color: #2f2f2f; }
     background-color: #d4d4d4;
     color: #1e1e1e;
 }
+
+.term-pitch-accent-container { border-bottom-color: #2f2f2f; }
 
 .term-pitch-accent-character:before { border-color: #ffffff; }
 

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -78,3 +78,16 @@ h2 { border-bottom-color: #2f2f2f; }
 }
 
 .term-pitch-accent-character:before { border-color: #ffffff; }
+
+.term-pitch-accent-graph-line,
+.term-pitch-accent-graph-line-tail,
+#term-pitch-accent-graph-dot,
+#term-pitch-accent-graph-dot-downstep,
+#term-pitch-accent-graph-triangle {
+    stroke: #ffffff;
+}
+
+#term-pitch-accent-graph-dot,
+#term-pitch-accent-graph-dot-downstep>circle:last-of-type {
+    fill: #ffffff;
+}

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -62,7 +62,7 @@ h2 { border-bottom-color: #2f2f2f; }
 
 .term-definition-list,
 .term-pitch-accent-group-list,
-.term-pitch-accent-expression-list,
+.term-pitch-accent-disambiguation-list,
 .kanji-glossary-list {
     color: #888888;
 }

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -62,6 +62,7 @@ h2 { border-bottom-color: #2f2f2f; }
 
 .term-definition-list,
 .term-pitch-accent-group-list,
+.term-pitch-accent-expression-list,
 .kanji-glossary-list {
     color: #888888;
 }

--- a/ext/mixed/css/display-dark.css
+++ b/ext/mixed/css/display-dark.css
@@ -19,6 +19,8 @@
 
 body { background-color: #1e1e1e; color: #d4d4d4; }
 
+h2 { border-bottom-color: #2f2f2f; }
+
 .navigation-header {
     background-color: #1e1e1e;
     border-bottom-color: #2f2f2f;

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -62,7 +62,7 @@ h2 { border-bottom-color: #eeeeee; }
 
 .term-definition-list,
 .term-pitch-accent-group-list,
-.term-pitch-accent-expression-list,
+.term-pitch-accent-disambiguation-list,
 .kanji-glossary-list {
     color: #777777;
 }

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -19,6 +19,8 @@
 
 body { background-color: #ffffff; color: #333333; }
 
+h2 { border-bottom-color: #eeeeee; }
+
 .navigation-header {
     background-color: #ffffff;
     border-bottom-color: #eeeeee;

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -62,6 +62,7 @@ h2 { border-bottom-color: #eeeeee; }
 
 .term-definition-list,
 .term-pitch-accent-group-list,
+.term-pitch-accent-expression-list,
 .kanji-glossary-list {
     color: #777777;
 }

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -41,6 +41,7 @@ h2 { border-bottom-color: #eeeeee; }
 .tag[data-category=frequency]    { background-color: #5cb85c; }
 .tag[data-category=partOfSpeech] { background-color: #565656; }
 .tag[data-category=search]       { background-color: #8a8a91; }
+.tag[data-category=pitch-accent-dictionary] { background-color: #6640be; }
 
 .term-reasons { color: #777777; }
 
@@ -76,6 +77,8 @@ h2 { border-bottom-color: #eeeeee; }
     background-color: #333333;
     color: #ffffff;
 }
+
+.term-pitch-accent-container { border-bottom-color: #eeeeee; }
 
 .term-pitch-accent-character:before { border-color: #000000; }
 

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -59,12 +59,14 @@ h2 { border-bottom-color: #eeeeee; }
     color: #999999;
 }
 
-.term-definition-container,
-.kanji-glossary-container {
+.term-definition-list,
+.term-pitch-accent-group-list,
+.kanji-glossary-list {
     color: #777777;
 }
 
 .term-glossary,
+.term-pitch-accent,
 .kanji-glossary {
     color: #000000;
 }
@@ -74,3 +76,5 @@ h2 { border-bottom-color: #eeeeee; }
     background-color: #333333;
     color: #ffffff;
 }
+
+.term-pitch-accent-character:before { border-color: #000000; }

--- a/ext/mixed/css/display-default.css
+++ b/ext/mixed/css/display-default.css
@@ -78,3 +78,16 @@ h2 { border-bottom-color: #eeeeee; }
 }
 
 .term-pitch-accent-character:before { border-color: #000000; }
+
+.term-pitch-accent-graph-line,
+.term-pitch-accent-graph-line-tail,
+#term-pitch-accent-graph-dot,
+#term-pitch-accent-graph-dot-downstep,
+#term-pitch-accent-graph-triangle {
+    stroke: #000000;
+}
+
+#term-pitch-accent-graph-dot,
+#term-pitch-accent-graph-dot-downstep>circle:last-of-type {
+    fill: #000000;
+}

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -437,6 +437,107 @@ button.action-button {
 
 
 /*
+ * Pitch accent styles
+ */
+
+.term-pitch-accent-group-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+}
+
+.term-pitch-accent-group-list:not([data-count="0"]):not([data-count="1"]) {
+    padding-left: 1.4em;
+    list-style-type: decimal;
+}
+
+.term-pitch-accent-list {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    display: inline;
+}
+
+.term-pitch-accent-list:not([data-count="0"]):not([data-count="1"]) {
+    padding-left: 1.4em;
+    list-style-type: circle;
+    display: block;
+}
+
+.term-pitch-accent {
+    display: inline;
+    line-height: 1.5em;
+}
+
+.term-pitch-accent-list:not([data-count="0"]):not([data-count="1"])>.term-pitch-accent {
+    display: list-item;
+}
+
+.term-pitch-accent-group-tag-list {
+    margin-right: 0.375em;
+}
+.entry[data-unique-expression-count="1"] .term-pitch-accent-expression-list {
+    display: none;
+}
+.term-pitch-accent-expression:not(:last-of-type):after {
+    content: "\3001";
+}
+.term-pitch-accent-expression:last-of-type:after {
+    content: "\FF1A";
+}
+
+.term-pitch-accent-tag-list:not([data-count="0"]) {
+    margin-right: 0.375em;
+}
+
+.term-special-tags>.pitches {
+    display: inline;
+}
+
+.term-pitch-accent-character {
+    display: inline-block;
+    position: relative;
+}
+.term-pitch-accent-character[data-pitch='high']:before {
+    content: "";
+    display: block;
+    user-select: none;
+    pointer-events: none;
+    position: absolute;
+    top: 0.1em;
+    left: 0;
+    right: 0;
+    height: 0;
+    border-top-width: 0.1em;
+    border-top-style: solid;
+}
+.term-pitch-accent-character[data-pitch='high'][data-pitch-next='low']:before {
+    right: -0.1em;
+    height: 0.4em;
+    border-right-width: 0.1em;
+    border-right-style: solid;
+}
+.term-pitch-accent-character[data-pitch='high'][data-pitch-next='low'] {
+    padding-right: 0.1em;
+    margin-right: 0.1em;
+}
+
+.term-pitch-accent-position:before {
+    content: " [";
+}
+.term-pitch-accent-position:after {
+    content: "]";
+}
+
+.term-pitch-accent-details {
+    display: inline-block;
+    height: 0;
+    padding: 0 0.25em;
+    vertical-align: middle;
+}
+
+
+/*
  * Kanji
  */
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -65,6 +65,14 @@ ol, ul {
     height: 2.28571428em; /* 14px => 32px */
 }
 
+h2 {
+    font-size: 1.25em;
+    font-weight: normal;
+    margin: 0.25em 0 0;
+    border-bottom-width: 0.05714285714285714em; /* 14px * 1.25em => 1px */
+    border-bottom-style: solid;
+}
+
 /*
  * Navigation
  */
@@ -420,6 +428,11 @@ button.action-button {
 
 .term-special-tags>.frequencies {
     display: inline;
+}
+
+.term-entry-body[data-section-count="0"] .term-entry-body-section-header,
+.term-entry-body[data-section-count="1"] .term-entry-body-section-header {
+    display: none;
 }
 
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -310,6 +310,7 @@ button.action-button {
     width: 0;
     height: 0;
     visibility: hidden;
+    z-index: 1;
 }
 
 .term-expression-list[data-multi=true] .term-expression:hover .term-expression-details {

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -488,14 +488,25 @@ button.action-button {
 .term-pitch-accent-group-tag-list {
     margin-right: 0.375em;
 }
-.entry[data-unique-expression-count="1"] .term-pitch-accent-expression-list {
+
+.term-pitch-accent-expression-list {
+    padding-right: 0.25em;
+}
+
+.term-pitch-accent-expression-list[data-count="0"] {
     display: none;
 }
-.term-pitch-accent-expression:not(:last-of-type):after {
-    content: "\3001";
+
+.term-pitch-accent-expression-list:before {
+    content: "(";
 }
-.term-pitch-accent-expression:last-of-type:after {
-    content: "\FF1A";
+
+.term-pitch-accent-expression-list:after {
+    content: " only)";
+}
+
+.term-pitch-accent-expression+.term-pitch-accent-expression:before {
+    content: ", ";
 }
 
 .term-pitch-accent-tag-list:not([data-count="0"]) {

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -538,6 +538,44 @@ button.action-button {
 
 
 /*
+ * Pitch accent graph styles
+ */
+
+.term-pitch-accent-graph {
+    display: block;
+    height: 1.5em;
+    transform: translateY(-0.875em);
+}
+.term-pitch-accent-graph-line,
+.term-pitch-accent-graph-line-tail {
+    fill: none;
+    stroke: #000000;
+    stroke-width: 5;
+}
+.term-pitch-accent-graph-line-tail {
+    stroke-dasharray: 5 5;
+}
+#term-pitch-accent-graph-dot {
+    fill: #000000;
+    stroke: #000000;
+    stroke-width: 5;
+}
+#term-pitch-accent-graph-dot-downstep {
+    fill: none;
+    stroke: #000000;
+    stroke-width: 5;
+}
+#term-pitch-accent-graph-dot-downstep>circle:last-of-type {
+    fill: #000000;
+}
+#term-pitch-accent-graph-triangle {
+    fill: none;
+    stroke: #000000;
+    stroke-width: 5;
+}
+
+
+/*
  * Kanji
  */
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -493,10 +493,6 @@ button.action-button {
     padding-right: 0.25em;
 }
 
-.term-pitch-accent-disambiguation-list[data-count="0"] {
-    display: none;
-}
-
 .term-pitch-accent-disambiguation-list:before {
     content: "(";
 }
@@ -507,6 +503,12 @@ button.action-button {
 
 .term-pitch-accent-disambiguation+.term-pitch-accent-disambiguation:before {
     content: ", ";
+}
+
+.term-pitch-accent-disambiguation-list[data-count="0"],
+:root[data-show-pitch-accent-downstep-notation=true] .term-pitch-accent-disambiguation-list[data-expression-count="0"],
+:root[data-show-pitch-accent-downstep-notation=true] .term-pitch-accent-disambiguation[data-type=reading] {
+    display: none;
 }
 
 .term-pitch-accent-tag-list:not([data-count="0"]) {

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -441,6 +441,17 @@ button.action-button {
  * Pitch accent styles
  */
 
+.entry[data-pitch-accent-count='0'] .term-pitch-accent-container {
+    display: none;
+}
+
+.term-pitch-accent-container {
+    border-bottom-width: 0.05714285714285714em; /* 14px * 1.25em => 1px */
+    border-bottom-style: solid;
+    padding-bottom: 0.25em;
+    margin-bottom: 0.25em;
+}
+
 .term-pitch-accent-group-list {
     margin: 0;
     padding: 0;

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -489,23 +489,23 @@ button.action-button {
     margin-right: 0.375em;
 }
 
-.term-pitch-accent-expression-list {
+.term-pitch-accent-disambiguation-list {
     padding-right: 0.25em;
 }
 
-.term-pitch-accent-expression-list[data-count="0"] {
+.term-pitch-accent-disambiguation-list[data-count="0"] {
     display: none;
 }
 
-.term-pitch-accent-expression-list:before {
+.term-pitch-accent-disambiguation-list:before {
     content: "(";
 }
 
-.term-pitch-accent-expression-list:after {
+.term-pitch-accent-disambiguation-list:after {
     content: " only)";
 }
 
-.term-pitch-accent-expression+.term-pitch-accent-expression:before {
+.term-pitch-accent-disambiguation+.term-pitch-accent-disambiguation:before {
     content: ", ";
 }
 

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -537,6 +537,19 @@ button.action-button {
 }
 
 
+:root[data-show-pitch-accent-downstep-notation=false] .term-pitch-accent-characters {
+    display: none;
+}
+
+:root[data-show-pitch-accent-position-notation=false] .term-pitch-accent-position {
+    display: none;
+}
+
+:root[data-show-pitch-accent-graph=false] .term-pitch-accent-details {
+    display: none;
+}
+
+
 /*
  * Pitch accent graph styles
  */

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -17,7 +17,9 @@
         </div>
         <div class="term-special-tags"><div class="frequencies tag-list"></div></div>
     </div>
-    <div class="term-definition-container"><ol class="term-definition-list"></ol></div>
+    <div class="term-entry-body">
+        <div class="term-entry-body-section term-pitch-accent-container"><h2 class="term-entry-body-section-header term-pitch-accent-header">Pitch Accents</h2><ol class="term-entry-body-section-content term-pitch-accent-group-list"></ol></div>
+    </div>
     <pre class="debug-info"></pre>
 </div></template>
 <template id="term-expression-template"><div class="term-expression"><span class="term-expression-text source-text"></span><div class="term-expression-details">

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -45,8 +45,8 @@
     </defs>
 </svg></template>
 <template id="term-pitch-accent-group-template"><li class="term-pitch-accent-group"><span class="term-pitch-accent-group-tag-list tag-list"></span><ul class="term-pitch-accent-list"></ul></li></template>
-<template id="term-pitch-accent-expression-template"><span class="term-pitch-accent-expression"></span></template>
-<template id="term-pitch-accent-template"><li class="term-pitch-accent"><span class="term-pitch-accent-tag-list tag-list"></span><span class="term-pitch-accent-expression-list"></span><span class="term-pitch-accent-characters"></span><span class="term-pitch-accent-position"></span><span class="term-pitch-accent-details"><svg class="term-pitch-accent-graph" xmlns="http://www.w3.org/2000/svg"><path class="term-pitch-accent-graph-line" /><path class="term-pitch-accent-graph-line-tail" /></svg></span></li></template>
+<template id="term-pitch-accent-disambiguation-template"><span class="term-pitch-accent-disambiguation"></span></template>
+<template id="term-pitch-accent-template"><li class="term-pitch-accent"><span class="term-pitch-accent-tag-list tag-list"></span><span class="term-pitch-accent-disambiguation-list"></span><span class="term-pitch-accent-characters"></span><span class="term-pitch-accent-position"></span><span class="term-pitch-accent-details"><svg class="term-pitch-accent-graph" xmlns="http://www.w3.org/2000/svg"><path class="term-pitch-accent-graph-line" /><path class="term-pitch-accent-graph-line-tail" /></svg></span></li></template>
 <template id="term-pitch-accent-character-template"><span class="term-pitch-accent-character"><span class="term-pitch-accent-character-inner"></span></span></template>
 
 <template id="kanji-entry-template"><div class="entry" data-type="kanji">

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -37,9 +37,16 @@
 <template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary-separator"> </span><span class="term-glossary"></span></li></template>
 <template id="term-reason-template"><span class="term-reason"></span><span class="term-reason-separator"> </span></template>
 
+<template id="term-pitch-accent-static-template"><svg xmlns="http://www.w3.org/2000/svg" style="display: none;">
+    <defs>
+        <g id="term-pitch-accent-graph-dot"><circle cx="0" cy="0" r="15" /></g>
+        <g id="term-pitch-accent-graph-dot-downstep"><circle cx="0" cy="0" r="15" /><circle cx="0" cy="0" r="5" /></g>
+        <g id="term-pitch-accent-graph-triangle"><path d="M0 13 L15 -13 L-15 -13 Z" /></g>
+    </defs>
+</svg></template>
 <template id="term-pitch-accent-group-template"><li class="term-pitch-accent-group"><span class="term-pitch-accent-group-tag-list tag-list"></span><ul class="term-pitch-accent-list"></ul></li></template>
 <template id="term-pitch-accent-expression-template"><span class="term-pitch-accent-expression"></span></template>
-<template id="term-pitch-accent-template"><li class="term-pitch-accent"><span class="term-pitch-accent-tag-list tag-list"></span><span class="term-pitch-accent-expression-list"></span><span class="term-pitch-accent-characters"></span><span class="term-pitch-accent-position"></span></li></template>
+<template id="term-pitch-accent-template"><li class="term-pitch-accent"><span class="term-pitch-accent-tag-list tag-list"></span><span class="term-pitch-accent-expression-list"></span><span class="term-pitch-accent-characters"></span><span class="term-pitch-accent-position"></span><span class="term-pitch-accent-details"><svg class="term-pitch-accent-graph" xmlns="http://www.w3.org/2000/svg"><path class="term-pitch-accent-graph-line" /><path class="term-pitch-accent-graph-line-tail" /></svg></span></li></template>
 <template id="term-pitch-accent-character-template"><span class="term-pitch-accent-character"><span class="term-pitch-accent-character-inner"></span></span></template>
 
 <template id="kanji-entry-template"><div class="entry" data-type="kanji">

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -18,8 +18,8 @@
         <div class="term-special-tags"><div class="frequencies tag-list"></div></div>
     </div>
     <div class="term-entry-body">
-        <div class="term-entry-body-section term-pitch-accent-container"><h2 class="term-entry-body-section-header term-pitch-accent-header">Pitch Accents</h2><ol class="term-entry-body-section-content term-pitch-accent-group-list"></ol></div>
-        <div class="term-entry-body-section term-definition-container"><h2 class="term-entry-body-section-header term-definition-header">Definitions</h2><ol class="term-entry-body-section-content term-definition-list"></ol></div>
+        <div class="term-entry-body-section term-pitch-accent-container"><ol class="term-entry-body-section-content term-pitch-accent-group-list"></ol></div>
+        <div class="term-entry-body-section term-definition-container"><ol class="term-entry-body-section-content term-definition-list"></ol></div>
     </div>
     <pre class="debug-info"></pre>
 </div></template>

--- a/ext/mixed/display-templates.html
+++ b/ext/mixed/display-templates.html
@@ -19,6 +19,7 @@
     </div>
     <div class="term-entry-body">
         <div class="term-entry-body-section term-pitch-accent-container"><h2 class="term-entry-body-section-header term-pitch-accent-header">Pitch Accents</h2><ol class="term-entry-body-section-content term-pitch-accent-group-list"></ol></div>
+        <div class="term-entry-body-section term-definition-container"><h2 class="term-entry-body-section-header term-definition-header">Definitions</h2><ol class="term-entry-body-section-content term-definition-list"></ol></div>
     </div>
     <pre class="debug-info"></pre>
 </div></template>
@@ -35,6 +36,11 @@
 <template id="term-definition-only-template"><span class="term-definition-only"></span></template>
 <template id="term-glossary-item-template"><li class="term-glossary-item"><span class="term-glossary-separator"> </span><span class="term-glossary"></span></li></template>
 <template id="term-reason-template"><span class="term-reason"></span><span class="term-reason-separator"> </span></template>
+
+<template id="term-pitch-accent-group-template"><li class="term-pitch-accent-group"><span class="term-pitch-accent-group-tag-list tag-list"></span><ul class="term-pitch-accent-list"></ul></li></template>
+<template id="term-pitch-accent-expression-template"><span class="term-pitch-accent-expression"></span></template>
+<template id="term-pitch-accent-template"><li class="term-pitch-accent"><span class="term-pitch-accent-tag-list tag-list"></span><span class="term-pitch-accent-expression-list"></span><span class="term-pitch-accent-characters"></span><span class="term-pitch-accent-position"></span></li></template>
+<template id="term-pitch-accent-character-template"><span class="term-pitch-accent-character"><span class="term-pitch-accent-character-inner"></span></span></template>
 
 <template id="kanji-entry-template"><div class="entry" data-type="kanji">
     <div class="entry-header1">

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -132,6 +132,30 @@ function parseUrl(url) {
     return {baseUrl, queryParams};
 }
 
+function areSetsEqual(set1, set2) {
+    if (set1.size !== set2.size) {
+        return false;
+    }
+
+    for (const value of set1) {
+        if (!set2.has(value)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+function getSetIntersection(set1, set2) {
+    const result = [];
+    for (const value of set1) {
+        if (set2.has(value)) {
+            result.push(value);
+        }
+    }
+    return result;
+}
+
 
 /*
  * Async utilities

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -294,7 +294,7 @@ class DisplayGenerator {
         node.dataset.pitchesMulti = 'true';
         node.dataset.pitchesCount = `${dictionaryPitches.length}`;
 
-        const tag = this.createTag({notes: '', name: dictionary, category: 'dictionary'});
+        const tag = this.createTag({notes: '', name: dictionary, category: 'pitch-accent-dictionary'});
         node.querySelector('.term-pitch-accent-group-tag-list').appendChild(tag);
 
         const n = node.querySelector('.term-pitch-accent-list');

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -301,22 +301,28 @@ class DisplayGenerator {
         }
     }
 
-    static _appendMultiple(container, createItem, detailsArray, fallback=[]) {
+    static _appendMultiple(container, createItem, detailsIterable, fallback=[]) {
         if (container === null) { return 0; }
 
-        const isArray = Array.isArray(detailsArray);
-        if (!isArray) { detailsArray = fallback; }
+        const multi = (
+            detailsIterable !== null &&
+            typeof detailsIterable === 'object' &&
+            typeof detailsIterable[Symbol.iterator] !== 'undefined'
+        );
+        if (!multi) { detailsIterable = fallback; }
 
-        container.dataset.multi = `${isArray}`;
-        container.dataset.count = `${detailsArray.length}`;
-
-        for (const details of detailsArray) {
+        let count = 0;
+        for (const details of detailsIterable) {
             const item = createItem(details);
             if (item === null) { continue; }
             container.appendChild(item);
+            ++count;
         }
 
-        return detailsArray.length;
+        container.dataset.multi = `${multi}`;
+        container.dataset.count = `${count}`;
+
+        return count;
     }
 
     static _appendFurigana(container, segments, addText) {

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -43,11 +43,17 @@ class DisplayGenerator {
 
         const expressionMulti = Array.isArray(details.expressions);
         const definitionMulti = Array.isArray(details.definitions);
+        const expressionCount = expressionMulti ? details.expressions.length : 1;
+        const definitionCount = definitionMulti ? details.definitions.length : 1;
 
         node.dataset.expressionMulti = `${expressionMulti}`;
         node.dataset.definitionMulti = `${definitionMulti}`;
-        node.dataset.expressionCount = `${expressionMulti ? details.expressions.length : 1}`;
-        node.dataset.definitionCount = `${definitionMulti ? details.definitions.length : 1}`;
+        node.dataset.expressionCount = `${expressionCount}`;
+        node.dataset.definitionCount = `${definitionCount}`;
+
+        bodyContainer.dataset.sectionCount = `${
+            (definitionCount > 0 ? 1 : 0)
+        }`;
 
         const termTags = details.termTags;
         let expressions = details.expressions;

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -304,7 +304,7 @@ class DisplayGenerator {
     }
 
     createPitch(details) {
-        const {expressions, reading, position, tags} = details;
+        const {exclusiveExpressions, reading, position, tags} = details;
         const morae = jp.getKanaMorae(reading);
 
         const node = this._templateHandler.instantiate('term-pitch-accent');
@@ -319,7 +319,7 @@ class DisplayGenerator {
         DisplayGenerator._appendMultiple(n, this.createTag.bind(this), tags);
 
         n = node.querySelector('.term-pitch-accent-expression-list');
-        DisplayGenerator._appendMultiple(n, this.createPitchExpression.bind(this), expressions);
+        DisplayGenerator._appendMultiple(n, this.createPitchExpression.bind(this), exclusiveExpressions);
 
         n = node.querySelector('.term-pitch-accent-characters');
         for (let i = 0, ii = morae.length; i < ii; ++i) {
@@ -481,6 +481,7 @@ class DisplayGenerator {
     static _getPitchInfos(definition) {
         const results = new Map();
 
+        const allExpressions = new Set();
         const expressions = definition.expressions;
         const sources = Array.isArray(expressions) ? expressions : [definition];
         for (const {pitches: expressionPitches, expression} of sources) {
@@ -498,7 +499,19 @@ class DisplayGenerator {
                         dictionaryResults.push(pitchInfo);
                     }
                     pitchInfo.expressions.add(expression);
+                    allExpressions.add(expression);
                 }
+            }
+        }
+
+        for (const dictionaryResults of results.values()) {
+            for (const result of dictionaryResults) {
+                const exclusiveExpressions = [];
+                const resultExpressions = result.expressions;
+                if (!areSetsEqual(resultExpressions, allExpressions)) {
+                    exclusiveExpressions.push(...getSetIntersection(resultExpressions, allExpressions));
+                }
+                result.exclusiveExpressions = exclusiveExpressions;
             }
         }
 

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -25,6 +25,7 @@
 class DisplayGenerator {
     constructor() {
         this._templateHandler = null;
+        this._termPitchAccentStaticTemplateIsSetup = false;
     }
 
     async prepare() {
@@ -337,6 +338,10 @@ class DisplayGenerator {
             n.appendChild(n1);
         }
 
+        if (morae.length > 0) {
+            this.populatePitchGraph(node.querySelector('.term-pitch-accent-graph'), position, morae);
+        }
+
         return node;
     }
 
@@ -344,6 +349,46 @@ class DisplayGenerator {
         const node = this._templateHandler.instantiate('term-pitch-accent-expression');
         node.textContent = expression;
         return node;
+    }
+
+    populatePitchGraph(svg, position, morae) {
+        const svgns = svg.getAttribute('xmlns');
+        const ii = morae.length;
+        svg.setAttribute('viewBox', `0 0 ${50 * (ii + 1)} 100`);
+
+        const pathPoints = [];
+        for (let i = 0; i < ii; ++i) {
+            const highPitch = DisplayGenerator._jpIsMoraPitchHigh(i, position);
+            const highPitchNext = DisplayGenerator._jpIsMoraPitchHigh(i + 1, position);
+            const graphic = (highPitch && !highPitchNext ? '#term-pitch-accent-graph-dot-downstep' : '#term-pitch-accent-graph-dot');
+            const x = `${i * 50 + 25}`;
+            const y = highPitch ? '25' : '75';
+            const use = document.createElementNS(svgns, 'use');
+            use.setAttribute('href', graphic);
+            use.setAttribute('x', x);
+            use.setAttribute('y', y);
+            svg.appendChild(use);
+            pathPoints.push(`${x} ${y}`);
+        }
+
+        let path = svg.querySelector('.term-pitch-accent-graph-line');
+        path.setAttribute('d', `M${pathPoints.join(' L')}`);
+
+        pathPoints.splice(0, ii - 1);
+        {
+            const highPitch = DisplayGenerator._jpIsMoraPitchHigh(ii, position);
+            const x = `${ii * 50 + 25}`;
+            const y = highPitch ? '25' : '75';
+            const use = document.createElementNS(svgns, 'use');
+            use.setAttribute('href', '#term-pitch-accent-graph-triangle');
+            use.setAttribute('x', x);
+            use.setAttribute('y', y);
+            svg.appendChild(use);
+            pathPoints.push(`${x} ${y}`);
+        }
+
+        path = svg.querySelector('.term-pitch-accent-graph-line-tail');
+        path.setAttribute('d', `M${pathPoints.join(' L')}`);
     }
 
     createFrequencyTag(details) {

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -305,7 +305,7 @@ class DisplayGenerator {
 
     createPitch(details) {
         const {expressions, reading, position, tags} = details;
-        const morae = DisplayGenerator._jpGetKanaMorae(reading);
+        const morae = jp.getKanaMorae(reading);
 
         const node = this._templateHandler.instantiate('term-pitch-accent');
 
@@ -324,8 +324,8 @@ class DisplayGenerator {
         n = node.querySelector('.term-pitch-accent-characters');
         for (let i = 0, ii = morae.length; i < ii; ++i) {
             const mora = morae[i];
-            const highPitch = DisplayGenerator._jpIsMoraPitchHigh(i, position);
-            const highPitchNext = DisplayGenerator._jpIsMoraPitchHigh(i + 1, position);
+            const highPitch = jp.isMoraPitchHigh(i, position);
+            const highPitchNext = jp.isMoraPitchHigh(i + 1, position);
 
             const n1 = this._templateHandler.instantiate('term-pitch-accent-character');
             const n2 = n1.querySelector('.term-pitch-accent-character-inner');
@@ -358,8 +358,8 @@ class DisplayGenerator {
 
         const pathPoints = [];
         for (let i = 0; i < ii; ++i) {
-            const highPitch = DisplayGenerator._jpIsMoraPitchHigh(i, position);
-            const highPitchNext = DisplayGenerator._jpIsMoraPitchHigh(i + 1, position);
+            const highPitch = jp.isMoraPitchHigh(i, position);
+            const highPitchNext = jp.isMoraPitchHigh(i + 1, position);
             const graphic = (highPitch && !highPitchNext ? '#term-pitch-accent-graph-dot-downstep' : '#term-pitch-accent-graph-dot');
             const x = `${i * 50 + 25}`;
             const y = highPitch ? '25' : '75';
@@ -376,7 +376,7 @@ class DisplayGenerator {
 
         pathPoints.splice(0, ii - 1);
         {
-            const highPitch = DisplayGenerator._jpIsMoraPitchHigh(ii, position);
+            const highPitch = jp.isMoraPitchHigh(ii, position);
             const x = `${ii * 50 + 25}`;
             const y = highPitch ? '25' : '75';
             const use = document.createElementNS(svgns, 'use');
@@ -532,30 +532,4 @@ class DisplayGenerator {
 
         return true;
     }
-
-    static _jpGetKanaMorae(text) {
-        // This function splits Japanese kana reading into its individual mora
-        // components. It is assumed that the text is well-formed.
-        const smallKanaSet = DisplayGenerator._smallKanaSet;
-        const morae = [];
-        let i;
-        for (const c of text) {
-            if (smallKanaSet.has(c) && (i = morae.length) > 0) {
-                morae[i - 1] += c;
-            } else {
-                morae.push(c);
-            }
-        }
-        return morae;
-    }
-
-    static _jpCreateSmallKanaSet() {
-        return new Set(Array.from('ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ'));
-    }
-
-    static _jpIsMoraPitchHigh(moraIndex, pitchAccentPosition) {
-        return pitchAccentPosition === 0 ? (moraIndex > 0) : (moraIndex < pitchAccentPosition);
-    }
 }
-
-DisplayGenerator._smallKanaSet = DisplayGenerator._jpCreateSmallKanaSet();

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -45,11 +45,13 @@ class DisplayGenerator {
         const definitionMulti = Array.isArray(details.definitions);
         const expressionCount = expressionMulti ? details.expressions.length : 1;
         const definitionCount = definitionMulti ? details.definitions.length : 1;
+        const uniqueExpressionCount = Array.isArray(details.expression) ? new Set(details.expression).size : 1;
 
         node.dataset.expressionMulti = `${expressionMulti}`;
         node.dataset.definitionMulti = `${definitionMulti}`;
         node.dataset.expressionCount = `${expressionCount}`;
         node.dataset.definitionCount = `${definitionCount}`;
+        node.dataset.uniqueExpressionCount = `${uniqueExpressionCount}`;
 
         bodyContainer.dataset.sectionCount = `${
             (definitionCount > 0 ? 1 : 0)

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -318,7 +318,7 @@ class DisplayGenerator {
         n = node.querySelector('.term-pitch-accent-tag-list');
         DisplayGenerator._appendMultiple(n, this.createTag.bind(this), tags);
 
-        n = node.querySelector('.term-pitch-accent-expression-list');
+        n = node.querySelector('.term-pitch-accent-disambiguation-list');
         DisplayGenerator._appendMultiple(n, this.createPitchExpression.bind(this), exclusiveExpressions);
 
         n = node.querySelector('.term-pitch-accent-characters');
@@ -346,7 +346,7 @@ class DisplayGenerator {
     }
 
     createPitchExpression(expression) {
-        const node = this._templateHandler.instantiate('term-pitch-accent-expression');
+        const node = this._templateHandler.instantiate('term-pitch-accent-disambiguation');
         node.textContent = expression;
         return node;
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -385,6 +385,9 @@ class Display {
         data.audioEnabled = `${options.audio.enabled}`;
         data.compactGlossaries = `${options.general.compactGlossaries}`;
         data.enableSearchTags = `${options.scanning.enableSearchTags}`;
+        data.showPitchAccentDownstepNotation = `${options.general.showPitchAccentDownstepNotation}`;
+        data.showPitchAccentPositionNotation = `${options.general.showPitchAccentPositionNotation}`;
+        data.showPitchAccentGraph = `${options.general.showPitchAccentGraph}`;
         data.debug = `${options.general.debugInfo}`;
     }
 

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -64,6 +64,8 @@ const jp = (() => {
         [0xffe0, 0xffee]  // Currency markers
     ];
 
+    const SMALL_KANA_SET = new Set(Array.from('ぁぃぅぇぉゃゅょゎァィゥェォャュョヮ'));
+
 
     // Character code testing functions
 
@@ -112,6 +114,26 @@ const jp = (() => {
     }
 
 
+    // Mora functions
+
+    function isMoraPitchHigh(moraIndex, pitchAccentPosition) {
+        return pitchAccentPosition === 0 ? (moraIndex > 0) : (moraIndex < pitchAccentPosition);
+    }
+
+    function getKanaMorae(text) {
+        const morae = [];
+        let i;
+        for (const c of text) {
+            if (SMALL_KANA_SET.has(c) && (i = morae.length) > 0) {
+                morae[i - 1] += c;
+            } else {
+                morae.push(c);
+            }
+        }
+        return morae;
+    }
+
+
     // Exports
 
     return {
@@ -119,6 +141,8 @@ const jp = (() => {
         isCodePointKana,
         isCodePointJapanese,
         isStringEntirelyKana,
-        isStringPartiallyJapanese
+        isStringPartiallyJapanese,
+        isMoraPitchHigh,
+        getKanaMorae
     };
 })();

--- a/test/data/dictionaries/valid-dictionary1/tag_bank_3.json
+++ b/test/data/dictionaries/valid-dictionary1/tag_bank_3.json
@@ -1,0 +1,4 @@
+[
+    ["ptag1", "pcategory1", 0, "ptag1 notes", 0],
+    ["ptag2", "pcategory2", 0, "ptag2 notes", 0]
+]

--- a/test/data/dictionaries/valid-dictionary1/term_meta_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_meta_bank_1.json
@@ -1,5 +1,39 @@
 [
     ["打", "freq", 1],
     ["打つ", "freq", 2],
-    ["打ち込む", "freq", 3]
+    ["打ち込む", "freq", 3],
+    [
+        "打ち込む",
+        "pitch",
+        {
+            "reading": "うちこむ",
+            "pitches": [
+                {"position": 0},
+                {"position": 3}
+            ]
+        }
+    ],
+    [
+        "打ち込む",
+        "pitch",
+        {
+            "reading": "ぶちこむ",
+            "pitches": [
+                {"position": 0},
+                {"position": 3}
+            ]
+        }
+    ],
+    [
+        "お手前",
+        "pitch",
+        {
+            "reading": "おてまえ",
+            "pitches": [
+                {"position": 2, "tags": ["ptag1"]},
+                {"position": 2, "tags": ["ptag2"]},
+                {"position": 0, "tags": ["ptag2"]}
+            ]
+        }
+    ]
 ]

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -231,8 +231,8 @@ async function testDatabase1() {
             true
         );
         vm.assert.deepStrictEqual(counts, {
-            counts: [{kanji: 2, kanjiMeta: 2, terms: 32, termMeta: 3, tagMeta: 12}],
-            total: {kanji: 2, kanjiMeta: 2, terms: 32, termMeta: 3, tagMeta: 12}
+            counts: [{kanji: 2, kanjiMeta: 2, terms: 32, termMeta: 6, tagMeta: 14}],
+            total: {kanji: 2, kanjiMeta: 2, terms: 32, termMeta: 6, tagMeta: 14}
         });
 
         // Test find* functions
@@ -648,9 +648,10 @@ async function testFindTermMetaBulk1(database, titles) {
                 }
             ],
             expectedResults: {
-                total: 1,
+                total: 3,
                 modes: [
-                    ['freq', 1]
+                    ['freq', 1],
+                    ['pitch', 2]
                 ]
             }
         },

--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -392,6 +392,59 @@ function testDistributeFuriganaInflected() {
     }
 }
 
+function testIsMoraPitchHigh() {
+    const data = [
+        [[0, 0], false],
+        [[1, 0], true],
+        [[2, 0], true],
+        [[3, 0], true],
+
+        [[0, 1], true],
+        [[1, 1], false],
+        [[2, 1], false],
+        [[3, 1], false],
+
+        [[0, 2], true],
+        [[1, 2], true],
+        [[2, 2], false],
+        [[3, 2], false],
+
+        [[0, 3], true],
+        [[1, 3], true],
+        [[2, 3], true],
+        [[3, 3], false],
+
+        [[0, 4], true],
+        [[1, 4], true],
+        [[2, 4], true],
+        [[3, 4], true]
+    ];
+
+    for (const [[moraIndex, pitchAccentPosition], expected] of data) {
+        const actual = jp.isMoraPitchHigh(moraIndex, pitchAccentPosition);
+        assert.strictEqual(actual, expected);
+    }
+}
+
+function testGetKanaMorae() {
+    const data = [
+        ['かこ', ['か', 'こ']],
+        ['かっこ', ['か', 'っ', 'こ']],
+        ['カコ', ['カ', 'コ']],
+        ['カッコ', ['カ', 'ッ', 'コ']],
+        ['コート', ['コ', 'ー', 'ト']],
+        ['ちゃんと', ['ちゃ', 'ん', 'と']],
+        ['とうきょう', ['と', 'う', 'きょ', 'う']],
+        ['ぎゅう', ['ぎゅ', 'う']],
+        ['ディスコ', ['ディ', 'ス', 'コ']]
+    ];
+
+    for (const [text, expected] of data) {
+        const actual = jp.getKanaMorae(text);
+        vm.assert.deepStrictEqual(actual, expected);
+    }
+}
+
 
 function main() {
     testIsCodePointKanji();
@@ -408,6 +461,8 @@ function main() {
     testConvertAlphabeticToKana();
     testDistributeFurigana();
     testDistributeFuriganaInflected();
+    testIsMoraPitchHigh();
+    testGetKanaMorae();
 }
 
 


### PR DESCRIPTION
Adds support for #61.

The dictionary generation script can be found here:
https://github.com/toasted-nutbread/yomichan-pitch-accent-dictionary

A build of the dictionary can be found here:
https://github.com/toasted-nutbread/yomichan-pitch-accent-dictionary/releases/tag/1.0.0

There are three different modes for displaying pitch accent data, each of which can be enabled/disabled individually.
* **Show downstep notation for pitch accents**
  Shows a bar over characters with a higher pitch and, if present, a small down bar where the pitch drop is.
* **Show position notation for pitch accents**
  Shows the numeric indication for the accent position. E.g. [1]
* **Show graph for pitch accents**
  Shows a graph of points indicating the accent positions of the mora. Currently disabled by default.

Here are some good terms for testing:
| Term | Reason |
| ----- |:--------- |
| 端 | Single kanji term with three readings with varying accent positions. |
| に | Single term with many sequenced terms in merged mode. |
| ２つ | Term which has multiple pitch accent positions with tags. |
| 博士 | Term with two kanji which has multiple readings with the same accent position. |
| し | Term with single pitch accent definition and no sequenced terms. |
| しっ | Term with no pitch accent definition. |

Example image showing all 3 modes:
![image](https://user-images.githubusercontent.com/11037431/75633831-8f170180-5bd6-11ea-8396-d859e1a28e7c.png)
