### PR TITLE
reconnect FrontendApiSender after disconnecting

### DIFF
--- a/ext/fg/js/frontend-api-sender.js
+++ b/ext/fg/js/frontend-api-sender.js
@@ -31,6 +31,8 @@ class FrontendApiSender {
 
     invoke(action, params, target) {
         if (this.disconnected) {
+            // attempt to reconnect the next time
+            this.disconnected = false;
             return Promise.reject(new Error('Disconnected'));
         }
 
@@ -70,6 +72,7 @@ class FrontendApiSender {
 
     onDisconnect() {
         this.disconnected = true;
+        this.port = null;
 
         for (const id of this.callbacks.keys()) {
             this.onError(id, 'Disconnected');


### PR DESCRIPTION
Helps with https://github.com/FooSoft/yomichan/issues/392. I was able to reproduce the issue again, but with this patch Yomichan is able to continue operation after failing one API request and printing an error to the console. It would also be possible to retry the same request after a timeout, but I don't think this issue is so big that the complexity is warranted.