### PR TITLE
adjust containsPoint offset with nested popups

### DIFF
--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -116,8 +116,8 @@ class PopupProxyHost {
 
     async _onApiContainsPoint({id, x, y}) {
         const popup = this._getPopup(id);
-        const rootPagePoint = PopupProxyHost._convertPopupPointToRootPagePoint(popup, x, y);
-        return await popup.containsPoint(...rootPagePoint);
+        [x, y] = PopupProxyHost._convertPopupPointToRootPagePoint(popup, x, y);
+        return await popup.containsPoint(x, y);
     }
 
     async _onApiShowContent({id, elementRect, writingMode, type, details}) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -116,7 +116,8 @@ class PopupProxyHost {
 
     async _onApiContainsPoint({id, x, y}) {
         const popup = this._getPopup(id);
-        return await popup.containsPoint(x, y);
+        const rootPagePoint = PopupProxyHost._convertPopupPointToRootPagePoint(popup, x, y);
+        return await popup.containsPoint(...rootPagePoint);
     }
 
     async _onApiShowContent({id, elementRect, writingMode, type, details}) {
@@ -152,14 +153,17 @@ class PopupProxyHost {
     }
 
     static _convertJsonRectToDOMRect(popup, jsonRect) {
-        let x = jsonRect.x;
-        let y = jsonRect.y;
+        const [x, y] = PopupProxyHost._convertPopupPointToRootPagePoint(popup, jsonRect.x, jsonRect.y);
+        return new DOMRect(x, y, jsonRect.width, jsonRect.height);
+    }
+
+    static _convertPopupPointToRootPagePoint(popup, x, y) {
         if (popup.parent !== null) {
             const popupRect = popup.parent.getContainerRect();
             x += popupRect.x;
             y += popupRect.y;
         }
-        return new DOMRect(x, y, jsonRect.width, jsonRect.height);
+        return [x, y];
     }
 
     static _popupCanShow(popup) {


### PR DESCRIPTION
The point can originate from within a popup where the coordinates start from the top left corner of the popup iframe. containsPoint check is done on the root page, and thus the offset has to be adjusted to match the point inside the iframe rect.

Fixes https://github.com/FooSoft/yomichan/issues/394