### PR TITLE
Clipboard monitor refactor

### DIFF
--- a/ext/bg/js/api.js
+++ b/ext/bg/js/api.js
@@ -25,10 +25,6 @@ function apiAudioGetUrl(definition, source, optionsContext) {
     return _apiInvoke('audioGetUrl', {definition, source, optionsContext});
 }
 
-function apiClipboardGet() {
-    return _apiInvoke('clipboardGet');
-}
-
 function _apiInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -117,7 +117,7 @@ class Backend {
             chrome.tabs.create({url: chrome.runtime.getURL('/bg/guide.html')});
         }
 
-        this.clipboardMonitor.onClipboardText = this._onClipboardText.bind(this);
+        this.clipboardMonitor.on('change', this._onClipboardText.bind(this));
 
         this._sendMessageAllTabs('backendPrepared');
         chrome.runtime.sendMessage({action: 'backendPrepared'});
@@ -154,7 +154,7 @@ class Backend {
         }
     }
 
-    _onClipboardText(text) {
+    _onClipboardText({text}) {
         this._onCommandSearch({mode: 'popup', query: text});
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -30,7 +30,7 @@ class Backend {
         this.translator = new Translator();
         this.anki = new AnkiNull();
         this.mecab = new Mecab();
-        this.clipboardMonitor = new ClipboardMonitor();
+        this.clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
         this.options = null;
         this.optionsSchema = null;
         this.defaultAnkiFieldTemplates = null;

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -18,16 +18,13 @@
 
 /*global apiClipboardGet, jpIsStringPartiallyJapanese*/
 
-class ClipboardMonitor {
+class ClipboardMonitor extends EventDispatcher {
     constructor() {
+        super();
         this.timerId = null;
         this.timerToken = null;
         this.interval = 250;
         this.previousText = null;
-    }
-
-    onClipboardText(_text) {
-        throw new Error('Override me');
     }
 
     start() {
@@ -55,7 +52,7 @@ class ClipboardMonitor {
             ) {
                 this.previousText = text;
                 if (jpIsStringPartiallyJapanese(text)) {
-                    this.onClipboardText(text);
+                    this.trigger('change', {text});
                 }
             }
 

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -16,22 +16,23 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global apiClipboardGet, jpIsStringPartiallyJapanese*/
+/*global jpIsStringPartiallyJapanese*/
 
 class ClipboardMonitor extends EventDispatcher {
-    constructor() {
+    constructor({getClipboard}) {
         super();
         this.timerId = null;
         this.timerToken = null;
         this.interval = 250;
         this.previousText = null;
+        this.getClipboard = getClipboard;
     }
 
     start() {
         this.stop();
 
         // The token below is used as a unique identifier to ensure that a new clipboard monitor
-        // hasn't been started during the await call. The check below the await apiClipboardGet()
+        // hasn't been started during the await call. The check below the await this.getClipboard()
         // call will exit early if the reference has changed.
         const token = {};
         const intervalCallback = async () => {
@@ -39,7 +40,7 @@ class ClipboardMonitor extends EventDispatcher {
 
             let text = null;
             try {
-                text = await apiClipboardGet();
+                text = await this.getClipboard();
             } catch (e) {
                 // NOP
             }

--- a/ext/bg/js/clipboard-monitor.js
+++ b/ext/bg/js/clipboard-monitor.js
@@ -21,59 +21,59 @@
 class ClipboardMonitor extends EventDispatcher {
     constructor({getClipboard}) {
         super();
-        this.timerId = null;
-        this.timerToken = null;
-        this.interval = 250;
-        this.previousText = null;
-        this.getClipboard = getClipboard;
+        this._timerId = null;
+        this._timerToken = null;
+        this._interval = 250;
+        this._previousText = null;
+        this._getClipboard = getClipboard;
     }
 
     start() {
         this.stop();
 
         // The token below is used as a unique identifier to ensure that a new clipboard monitor
-        // hasn't been started during the await call. The check below the await this.getClipboard()
+        // hasn't been started during the await call. The check below the await this._getClipboard()
         // call will exit early if the reference has changed.
         const token = {};
         const intervalCallback = async () => {
-            this.timerId = null;
+            this._timerId = null;
 
             let text = null;
             try {
-                text = await this.getClipboard();
+                text = await this._getClipboard();
             } catch (e) {
                 // NOP
             }
-            if (this.timerToken !== token) { return; }
+            if (this._timerToken !== token) { return; }
 
             if (
                 typeof text === 'string' &&
                 (text = text.trim()).length > 0 &&
-                text !== this.previousText
+                text !== this._previousText
             ) {
-                this.previousText = text;
+                this._previousText = text;
                 if (jpIsStringPartiallyJapanese(text)) {
                     this.trigger('change', {text});
                 }
             }
 
-            this.timerId = setTimeout(intervalCallback, this.interval);
+            this._timerId = setTimeout(intervalCallback, this._interval);
         };
 
-        this.timerToken = token;
+        this._timerToken = token;
 
         intervalCallback();
     }
 
     stop() {
-        this.timerToken = null;
-        if (this.timerId !== null) {
-            clearTimeout(this.timerId);
-            this.timerId = null;
+        this._timerToken = null;
+        if (this._timerId !== null) {
+            clearTimeout(this._timerId);
+            this._timerId = null;
         }
     }
 
     setPreviousText(text) {
-        this.previousText = text;
+        this._previousText = text;
     }
 }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -102,8 +102,7 @@ class DisplaySearch extends Display {
             this.wanakanaEnable.addEventListener('change', this.onWanakanaEnableChange.bind(this));
             window.addEventListener('popstate', this.onPopState.bind(this));
             window.addEventListener('copy', this.onCopy.bind(this));
-
-            this.clipboardMonitor.onClipboardText = this.onExternalSearchUpdate.bind(this);
+            this.clipboardMonitor.on('change', this.onExternalSearchUpdate.bind(this));
 
             this.updateSearchButton();
         } catch (e) {
@@ -198,7 +197,7 @@ class DisplaySearch extends Display {
         this.clipboardMonitor.setPreviousText(document.getSelection().toString().trim());
     }
 
-    onExternalSearchUpdate(text) {
+    onExternalSearchUpdate({text}) {
         this.setQuery(text);
         const url = new URL(window.location.href);
         url.searchParams.set('query', text);

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global apiOptionsSet, apiTermsFind, Display, QueryParser, ClipboardMonitor*/
+/*global apiOptionsSet, apiTermsFind, apiClipboardGet, Display, QueryParser, ClipboardMonitor*/
 
 class DisplaySearch extends Display {
     constructor() {
@@ -38,7 +38,7 @@ class DisplaySearch extends Display {
         this.introVisible = true;
         this.introAnimationTimer = null;
 
-        this.clipboardMonitor = new ClipboardMonitor();
+        this.clipboardMonitor = new ClipboardMonitor({getClipboard: apiClipboardGet});
 
         this._onKeyDownIgnoreKeys = new Map([
             ['ANY_MOD', new Set([


### PR DESCRIPTION
Based on some discussion from #391. A bit contrary to what I described in https://github.com/FooSoft/yomichan/pull/391#issuecomment-596096746, I converted `onClipboardText` to an event, but the comment could still apply to other scenarios where the function isn't as event-like, e.g. `ConditionsUI.Container.save`, though arguably this could be done using an event also:

https://github.com/FooSoft/yomichan/blob/24d9001b1449a318113f5ecc5441113cabe7248f/ext/bg/js/settings/profiles.js#L94-L104