### PR TITLE
Replace charCodeAt and fromCharCode with codePointAt and fromCodePoint

### DIFF
--- a/ext/bg/js/handlebars.js
+++ b/ext/bg/js/handlebars.js
@@ -16,7 +16,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/*global jpIsCharCodeKanji, jpDistributeFurigana, Handlebars*/
+/*global jpIsCodePointKanji, jpDistributeFurigana, Handlebars*/
 
 function handlebarsEscape(text) {
     return Handlebars.Utils.escapeExpression(text);
@@ -62,7 +62,7 @@ function handlebarsFuriganaPlain(options) {
 function handlebarsKanjiLinks(options) {
     let result = '';
     for (const c of options.fn(this)) {
-        if (jpIsCharCodeKanji(c.charCodeAt(0))) {
+        if (jpIsCodePointKanji(c.codePointAt(0))) {
             result += `<a href="#" class="kanji-link">${c}</a>`;
         } else {
             result += c;

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -20,7 +20,7 @@
 dictTermsMergeBySequence, dictTagBuildSource, dictTermsMergeByGloss, dictTermsSort, dictTagsSort
 dictEnabledSet, dictTermsGroup, dictTermsCompressTags, dictTermsUndupe, dictTagSanitize
 jpDistributeFurigana, jpConvertHalfWidthKanaToFullWidth, jpConvertNumericTofullWidth
-jpConvertAlphabeticToKana, jpHiraganaToKatakana, jpKatakanaToHiragana, jpIsCharCodeJapanese
+jpConvertAlphabeticToKana, jpHiraganaToKatakana, jpKatakanaToHiragana, jpIsCodePointJapanese
 Database, Deinflector*/
 
 class Translator {
@@ -621,13 +621,14 @@ class Translator {
 
     static getSearchableText(text, options) {
         if (!options.scanning.alphanumeric) {
-            const ii = text.length;
-            for (let i = 0; i < ii; ++i) {
-                if (!jpIsCharCodeJapanese(text.charCodeAt(i))) {
-                    text = text.substring(0, i);
+            let newText = '';
+            for (const c of text) {
+                if (!jpIsCodePointJapanese(c.codePointAt(0))) {
                     break;
                 }
+                newText += c;
             }
+            text = newText;
         }
 
         return text;

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -298,7 +298,7 @@ class DisplayGenerator {
     }
 
     static _isCharacterKanji(c) {
-        const code = c.charCodeAt(0);
+        const code = c.codePointAt(0);
         return (
             code >= 0x4e00 && code < 0x9fb0 ||
             code >= 0x3400 && code < 0x4dc0


### PR DESCRIPTION
Resolves #331.

There are still some places in the codebase where UTF-16 character code iteration is still used. Some of these should be fine, while others may potentially have issues with the rare kanji.

For example:
https://github.com/FooSoft/yomichan/blob/7541517d8084b50e054393f3b4fa6d4630ad012e/ext/bg/js/search-query-parser.js#L158-L166

document.js could also have some issues, but I won't touch those for now due to #286.