### PR TITLE
apply all options on profile change

### DIFF
--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -30,12 +30,7 @@ async function searchFrontendSetup() {
     const options = await apiOptionsGet(optionsContext);
     if (!options.scanning.enableOnSearchPage) { return; }
 
-    const ignoreNodes = ['.scan-disable', '.scan-disable *'];
-    if (!options.scanning.enableOnPopupExpressions) {
-        ignoreNodes.push('.source-text', '.source-text *');
-    }
-
-    window.frontendInitializationData = {depth: 1, ignoreNodes, proxy: false};
+    window.frontendInitializationData = {depth: 1, proxy: false};
 
     const scriptSrcs = [
         '/mixed/js/text-scanner.js',

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -28,11 +28,10 @@
 
 class QueryParser extends TextScanner {
     constructor(search) {
-        super(document.querySelector('#query-parser-content'), [], [], []);
+        super(document.querySelector('#query-parser-content'), [], []);
         this.search = search;
 
         this.parseResults = [];
-        this.selectedParser = null;
 
         this.queryParser = document.querySelector('#query-parser-content');
         this.queryParserSelect = document.querySelector('#query-parser-select-container');
@@ -79,9 +78,7 @@ class QueryParser extends TextScanner {
 
     onParserChange(e) {
         const selectedParser = e.target.value;
-        this.selectedParser = selectedParser;
         apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
-        this.renderParseResult();
     }
 
     getMouseEventListeners() {
@@ -112,19 +109,16 @@ class QueryParser extends TextScanner {
 
     refreshSelectedParser() {
         if (this.parseResults.length > 0) {
-            if (this.selectedParser === null) {
-                this.selectedParser = this.search.options.parsing.selectedParser;
-            }
-            if (this.selectedParser === null || !this.getParseResult()) {
+            if (!this.getParseResult()) {
                 const selectedParser = this.parseResults[0].id;
-                this.selectedParser = selectedParser;
                 apiOptionsSet({parsing: {selectedParser}}, this.search.getOptionsContext());
             }
         }
     }
 
     getParseResult() {
-        return this.parseResults.find((r) => r.id === this.selectedParser);
+        const {selectedParser} = this.options.parsing;
+        return this.parseResults.find((r) => r.id === selectedParser);
     }
 
     async setText(text) {
@@ -176,7 +170,8 @@ class QueryParser extends TextScanner {
     renderParserSelect() {
         this.queryParserSelect.textContent = '';
         if (this.parseResults.length > 1) {
-            const select = this.queryParserGenerator.createParserSelect(this.parseResults, this.selectedParser);
+            const {selectedParser} = this.options.parsing;
+            const select = this.queryParserGenerator.createParserSelect(this.parseResults, selectedParser);
             select.addEventListener('change', this.onParserChange.bind(this));
             this.queryParserSelect.appendChild(select);
         }

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -110,18 +110,6 @@ class QueryParser extends TextScanner {
         this.queryParser.dataset.termSpacing = `${options.parsing.termSpacing}`;
     }
 
-    getOptionsContext() {
-        throw new Error('Override me');
-    }
-
-    setContent(_type, _details) {
-        throw new Error('Override me');
-    }
-
-    setSpinnerVisible(_visible) {
-        throw new Error('Override me');
-    }
-
     refreshSelectedParser() {
         if (this.parseResults.length > 0) {
             if (!this.getParseResult()) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -247,15 +247,12 @@ class DisplaySearch extends Display {
     }
 
     onWanakanaEnableChange(e) {
-        const {queryParams: {query=''}} = parseUrl(window.location.href);
         const enableWanakana = e.target.checked;
         if (enableWanakana) {
             window.wanakana.bind(this.query);
         } else {
             window.wanakana.unbind(this.query);
         }
-        this.setQuery(query);
-        this.onSearchQueryUpdated(this.query.value, false);
         apiOptionsSet({general: {enableWanakana}}, this.getOptionsContext());
     }
 
@@ -278,17 +275,18 @@ class DisplaySearch extends Display {
         }
     }
 
-    async updateOptions(options) {
-        await super.updateOptions(options);
+    async updateOptions() {
+        await super.updateOptions();
         this.queryParser.setOptions(this.options);
+        const query = this.query.value;
+        if (query) {
+            this.setQuery(query);
+            this.onSearchQueryUpdated(query, false);
+        }
     }
 
     isWanakanaEnabled() {
         return this.wanakanaEnable !== null && this.wanakanaEnable.checked;
-    }
-
-    getOptionsContext() {
-        return this.optionsContext;
     }
 
     setQuery(query) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -29,12 +29,18 @@ class DisplaySearch extends Display {
     constructor() {
         super(document.querySelector('#spinner'), document.querySelector('#content'));
 
+        this._isPrepared = false;
+
         this.optionsContext = {
             depth: 0,
             url: window.location.href
         };
 
-        this.queryParser = new QueryParser(this);
+        this.queryParser = new QueryParser({
+            getOptionsContext: this.getOptionsContext.bind(this),
+            setContent: this.setContent.bind(this),
+            setSpinnerVisible: this.setSpinnerVisible.bind(this)
+        });
 
         this.search = document.querySelector('#search');
         this.query = document.querySelector('#query');
@@ -112,6 +118,8 @@ class DisplaySearch extends Display {
             this.clipboardMonitor.on('change', this.onExternalSearchUpdate.bind(this));
 
             this.updateSearchButton();
+
+            this._isPrepared = true;
         } catch (e) {
             this.onError(e);
         }
@@ -278,6 +286,7 @@ class DisplaySearch extends Display {
     async updateOptions() {
         await super.updateOptions();
         this.queryParser.setOptions(this.options);
+        if (!this._isPrepared) { return; }
         const query = this.query.value;
         if (query) {
             this.setQuery(query);

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -28,6 +28,8 @@ class DisplayFloat extends Display {
         super(document.querySelector('#spinner'), document.querySelector('#definitions'));
         this.autoPlayAudioTimer = null;
 
+        this._popupId = null;
+
         this.optionsContext = {
             depth: 0,
             url: window.location.href
@@ -53,7 +55,7 @@ class DisplayFloat extends Display {
             ['setContent', ({type, details}) => this.setContent(type, details)],
             ['clearAutoPlayTimer', () => this.clearAutoPlayTimer()],
             ['setCustomCss', ({css}) => this.setCustomCss(css)],
-            ['prepare', ({options, popupInfo, url, childrenSupported, scale, uniqueId}) => this.prepare(options, popupInfo, url, childrenSupported, scale, uniqueId)],
+            ['prepare', ({popupInfo, url, childrenSupported, scale}) => this.prepare(popupInfo, url, childrenSupported, scale)],
             ['setContentScale', ({scale}) => this.setContentScale(scale)]
         ]);
 
@@ -61,15 +63,16 @@ class DisplayFloat extends Display {
         window.addEventListener('message', this.onMessage.bind(this), false);
     }
 
-    async prepare(options, popupInfo, url, childrenSupported, scale, uniqueId) {
+    async prepare(popupInfo, url, childrenSupported, scale) {
         if (this._prepareInvoked) { return; }
         this._prepareInvoked = true;
 
-        await super.prepare(options);
-
         const {id, depth, parentFrameId} = popupInfo;
+        this._popupId = id;
         this.optionsContext.depth = depth;
         this.optionsContext.url = url;
+
+        await super.prepare();
 
         if (childrenSupported) {
             popupNestedInitialize(id, depth, parentFrameId, url);
@@ -77,7 +80,7 @@ class DisplayFloat extends Display {
 
         this.setContentScale(scale);
 
-        apiForward('popupPrepareCompleted', {uniqueId});
+        apiForward('popupPrepareCompleted', {targetPopupId: this._popupId});
     }
 
     onError(error) {
@@ -142,10 +145,6 @@ class DisplayFloat extends Display {
         if (typeof handler !== 'function') { return; }
 
         handler(params);
-    }
-
-    getOptionsContext() {
-        return this.optionsContext;
     }
 
     autoPlayAudio() {

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -26,7 +26,7 @@ async function main() {
     await yomichan.prepare();
 
     const data = window.frontendInitializationData || {};
-    const {id, depth=0, parentFrameId, ignoreNodes, url, proxy=false} = data;
+    const {id, depth=0, parentFrameId, url, proxy=false} = data;
 
     let popup;
     if (proxy) {
@@ -38,7 +38,7 @@ async function main() {
         popup = popupHost.getOrCreatePopup(null, null, depth);
     }
 
-    const frontend = new Frontend(popup, ignoreNodes);
+    const frontend = new Frontend(popup);
     await frontend.prepare();
 }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -95,7 +95,7 @@ class Frontend extends TextScanner {
 
     onRuntimeMessage({action, params}, sender, callback) {
         const {targetPopupId} = params || {};
-        if (targetPopupId !== 'all' && targetPopupId !== this.popup.id) { return; }
+        if (typeof targetPopupId !== 'undefined' && targetPopupId !== this.popup.id) { return; }
 
         const handler = this._runtimeMessageHandlers.get(action);
         if (typeof handler !== 'function') { return false; }

--- a/ext/fg/js/popup-nested.js
+++ b/ext/fg/js/popup-nested.js
@@ -36,12 +36,7 @@ async function popupNestedInitialize(id, depth, parentFrameId, url) {
         return;
     }
 
-    const ignoreNodes = ['.scan-disable', '.scan-disable *'];
-    if (!options.scanning.enableOnPopupExpressions) {
-        ignoreNodes.push('.source-text', '.source-text *');
-    }
-
-    window.frontendInitializationData = {id, depth, parentFrameId, ignoreNodes, url, proxy: true};
+    window.frontendInitializationData = {id, depth, parentFrameId, url, proxy: true};
 
     const scriptSrcs = [
         '/mixed/js/text-scanner.js',

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -25,7 +25,6 @@
 class PopupProxyHost {
     constructor() {
         this._popups = new Map();
-        this._nextId = 0;
         this._apiReceiver = null;
         this._frameIdPromise = null;
     }
@@ -76,7 +75,7 @@ class PopupProxyHost {
 
         // New unique id
         if (id === null) {
-            id = this._nextId++;
+            id = yomichan.generateId(16);
         }
 
         // Create new popup

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -33,6 +33,10 @@ class PopupProxy {
 
     // Public properties
 
+    get id() {
+        return this._id;
+    }
+
     get parent() {
         return null;
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -40,6 +40,7 @@ class Display {
         this.spinner = spinner;
         this.container = container;
         this.definitions = [];
+        this.optionsContext = null;
         this.options = null;
         this.context = null;
         this.index = 0;
@@ -165,12 +166,11 @@ class Display {
         this.setInteractive(true);
     }
 
-    async prepare(options=null) {
+    async prepare() {
         await yomichan.prepare();
-        const displayGeneratorPromise = this.displayGenerator.prepare();
-        const updateOptionsPromise = this.updateOptions(options);
-        await Promise.all([displayGeneratorPromise, updateOptionsPromise]);
-        yomichan.on('optionsUpdated', () => this.updateOptions(null));
+        await this.displayGenerator.prepare();
+        await this.updateOptions();
+        yomichan.on('optionsUpdated', () => this.updateOptions());
     }
 
     onError(_error) {
@@ -369,11 +369,11 @@ class Display {
     }
 
     getOptionsContext() {
-        throw new Error('Override me');
+        return this.optionsContext;
     }
 
-    async updateOptions(options) {
-        this.options = options ? options : await apiOptionsGet(this.getOptionsContext());
+    async updateOptions() {
+        this.options = await apiOptionsGet(this.getOptionsContext());
         this.updateDocumentOptions(this.options);
         this.updateTheme(this.options.general.popupTheme);
         this.setCustomCss(this.options.general.customPopupCss);
@@ -851,7 +851,7 @@ class Display {
     }
 
     setPopupVisibleOverride(visible) {
-        return apiForward('popupSetVisibleOverride', {visible});
+        return apiForward('popupSetVisibleOverride', {visible, targetPopupId: 'all'});
     }
 
     setSpinnerVisible(visible) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -851,7 +851,7 @@ class Display {
     }
 
     setPopupVisibleOverride(visible) {
-        return apiForward('popupSetVisibleOverride', {visible, targetPopupId: 'all'});
+        return apiForward('popupSetVisibleOverride', {visible});
     }
 
     setSpinnerVisible(visible) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -23,13 +23,15 @@
  */
 
 class TextScanner {
-    constructor(node, ignoreNodes, ignoreElements, ignorePoints) {
+    constructor(node, ignoreElements, ignorePoints) {
         this.node = node;
-        this.ignoreNodes = (Array.isArray(ignoreNodes) && ignoreNodes.length > 0 ? ignoreNodes.join(',') : null);
         this.ignoreElements = ignoreElements;
         this.ignorePoints = ignorePoints;
 
+        this.ignoreNodes = null;
+
         this.scanTimerPromise = null;
+        this.causeCurrent = null;
         this.textSourceCurrent = null;
         this.pendingLookup = false;
         this.options = null;
@@ -298,6 +300,7 @@ class TextScanner {
                 this.pendingLookup = true;
                 const result = await this.onSearchSource(textSource, cause);
                 if (result !== null) {
+                    this.causeCurrent = cause;
                     this.textSourceCurrent = textSource;
                     if (this.options.scanning.selectText) {
                         textSource.select();


### PR DESCRIPTION
Extracted from https://github.com/FooSoft/yomichan/pull/389. I think these can be useful while deciding what's the best way to quickly change profiles and how to display it.

Was there a reason why `Frontend` was initialized with options from `Popup`? I removed it to make the code simpler, but it can make the popup appear a bit slower on the first scan.