### PR TITLE
Show iframe popups on root page

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -108,7 +108,8 @@
                                     "enableClipboardMonitor",
                                     "showPitchAccentDownstepNotation",
                                     "showPitchAccentPositionNotation",
-                                    "showPitchAccentGraph"
+                                    "showPitchAccentGraph",
+                                    "showIframePopupsInRootFrame"
                                 ],
                                 "properties": {
                                     "enable": {
@@ -240,6 +241,10 @@
                                         "default": true
                                     },
                                     "showPitchAccentGraph": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "showIframePopupsInRootFrame": {
                                         "type": "boolean",
                                         "default": false
                                     }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -127,7 +127,8 @@ function profileOptionsCreateDefaults() {
             enableClipboardMonitor: false,
             showPitchAccentDownstepNotation: true,
             showPitchAccentPositionNotation: true,
-            showPitchAccentGraph: false
+            showPitchAccentGraph: false,
+            showIframePopupsInRootFrame: false
         },
 
         audio: {

--- a/ext/bg/js/search-frontend.js
+++ b/ext/bg/js/search-frontend.js
@@ -35,6 +35,7 @@ async function searchFrontendSetup() {
     const scriptSrcs = [
         '/mixed/js/text-scanner.js',
         '/fg/js/frontend-api-receiver.js',
+        '/fg/js/frame-offset-forwarder.js',
         '/fg/js/popup.js',
         '/fg/js/popup-proxy-host.js',
         '/fg/js/frontend.js',

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -87,6 +87,7 @@ async function formRead(options) {
     options.general.showPitchAccentDownstepNotation = $('#show-pitch-accent-downstep-notation').prop('checked');
     options.general.showPitchAccentPositionNotation = $('#show-pitch-accent-position-notation').prop('checked');
     options.general.showPitchAccentGraph = $('#show-pitch-accent-graph').prop('checked');
+    options.general.showIframePopupsInRootFrame = $('#show-iframe-popups-in-root-frame').prop('checked');
     options.general.popupTheme = $('#popup-theme').val();
     options.general.popupOuterTheme = $('#popup-outer-theme').val();
     options.general.customPopupCss = $('#custom-popup-css').val();
@@ -167,6 +168,7 @@ async function formWrite(options) {
     $('#show-pitch-accent-downstep-notation').prop('checked', options.general.showPitchAccentDownstepNotation);
     $('#show-pitch-accent-position-notation').prop('checked', options.general.showPitchAccentPositionNotation);
     $('#show-pitch-accent-graph').prop('checked', options.general.showPitchAccentGraph);
+    $('#show-iframe-popups-in-root-frame').prop('checked', options.general.showIframePopupsInRootFrame);
     $('#popup-theme').val(options.general.popupTheme);
     $('#popup-outer-theme').val(options.general.popupOuterTheme);
     $('#custom-popup-css').val(options.general.customPopupCss);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -175,6 +175,10 @@
                 </div>
 
                 <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="show-iframe-popups-in-root-frame"> Show iframe popups in root frame</label>
+                </div>
+
+                <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="show-debug-info"> Show debug information</label>
                 </div>
 

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -22,15 +22,23 @@
 
 class FrameOffsetForwarder {
     constructor() {
-        this._forwardFrameOffset = window !== window.parent ?
+        this._started = false;
+
+        this._forwardFrameOffset = (
+            window !== window.parent ?
             this._forwardFrameOffsetParent.bind(this) :
-            this._forwardFrameOffsetOrigin.bind(this);
+            this._forwardFrameOffsetOrigin.bind(this)
+        );
 
         this._windowMessageHandlers = new Map([
-            ['getFrameOffset', ({offset, uniqueId}, e) => { return this._onGetFrameOffset(offset, uniqueId, e); }]
+            ['getFrameOffset', ({offset, uniqueId}, e) => this._onGetFrameOffset(offset, uniqueId, e)]
         ]);
+    }
 
+    start() {
+        if (this._started) { return; }
         window.addEventListener('message', this.onMessage.bind(this), false);
+        this._started = true;
     }
 
     async applyOffset(x, y) {
@@ -44,7 +52,6 @@ class FrameOffsetForwarder {
                 chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
                 callback();
                 frameOffsetResolve(params);
-                return false;
             }
         };
         chrome.runtime.onMessage.addListener(runtimeMessageCallback);

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -41,7 +41,7 @@ class FrameOffsetForwarder {
         this._started = true;
     }
 
-    async applyOffset(x, y) {
+    async getOffset() {
         const uniqueId = yomichan.generateId(16);
 
         const frameOffsetPromise = yomichan.getTemporaryListenerResult(
@@ -58,7 +58,7 @@ class FrameOffsetForwarder {
             action: 'getFrameOffset',
             params: {
                 uniqueId,
-                offset: [x, y]
+                offset: [0, 0]
             }
         }, '*');
 

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -44,17 +44,14 @@ class FrameOffsetForwarder {
     async applyOffset(x, y) {
         const uniqueId = yomichan.generateId(16);
 
-        let frameOffsetResolve = null;
-        const frameOffsetPromise = new Promise((resolve) => (frameOffsetResolve = resolve));
-
-        const runtimeMessageCallback = ({action, params}, sender, callback) => {
-            if (action === 'frameOffset' && isObject(params) && params.uniqueId === uniqueId) {
-                chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
-                callback();
-                frameOffsetResolve(params);
+        const frameOffsetPromise = yomichan.getTemporaryListenerResult(
+            chrome.runtime.onMessage,
+            ({action, params}, {resolve}) => {
+                if (action === 'frameOffset' && isObject(params) && params.uniqueId === uniqueId) {
+                    resolve(params);
+                }
             }
-        };
-        chrome.runtime.onMessage.addListener(runtimeMessageCallback);
+        );
 
         window.parent.postMessage({
             action: 'getFrameOffset',

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -80,7 +80,10 @@ class FrameOffsetForwarder {
             sourceFrame = frame;
             break;
         }
-        if (sourceFrame === null) { return; }
+        if (sourceFrame === null) {
+            this._forwardFrameOffsetOrigin(null, uniqueId);
+            return;
+        }
 
         const [forwardedX, forwardedY] = offset;
         const {x, y} = sourceFrame.getBoundingClientRect();

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -50,7 +50,8 @@ class FrameOffsetForwarder {
                 if (action === 'frameOffset' && isObject(params) && params.uniqueId === uniqueId) {
                     resolve(params);
                 }
-            }
+            },
+            5000
         );
 
         window.parent.postMessage({

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2020  Alex Yatskov <alex@foosoft.net>
+ * Author: Alex Yatskov <alex@foosoft.net>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* global
+ * apiForward
+ */
+
+class FrameOffsetForwarder {
+    constructor() {
+        this._forwardFrameOffset = window !== window.parent ?
+            this._forwardFrameOffsetParent.bind(this) :
+            this._forwardFrameOffsetOrigin.bind(this);
+
+        this._windowMessageHandlers = new Map([
+            ['getFrameOffset', ({offset, uniqueId}, e) => { return this._onGetFrameOffset(offset, uniqueId, e); }]
+        ]);
+
+        window.addEventListener('message', this.onMessage.bind(this), false);
+    }
+
+    async applyOffset(x, y) {
+        const uniqueId = yomichan.generateId(16);
+
+        let frameOffsetResolve = null;
+        const frameOffsetPromise = new Promise((resolve) => (frameOffsetResolve = resolve));
+
+        const runtimeMessageCallback = ({action, params}, sender, callback) => {
+            if (action === 'frameOffset' && isObject(params) && params.uniqueId === uniqueId) {
+                chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
+                callback();
+                frameOffsetResolve(params);
+                return false;
+            }
+        };
+        chrome.runtime.onMessage.addListener(runtimeMessageCallback);
+
+        window.parent.postMessage({
+            action: 'getFrameOffset',
+            params: {
+                uniqueId,
+                offset: [x, y]
+            }
+        }, '*');
+
+        const {offset} = await frameOffsetPromise;
+        return offset;
+    }
+
+    onMessage(e) {
+        const {action, params} = e.data;
+        const handler = this._windowMessageHandlers.get(action);
+        if (typeof handler !== 'function') { return; }
+        handler(params, e);
+    }
+
+    _onGetFrameOffset(offset, uniqueId, e) {
+        let sourceFrame = null;
+        for (const frame of document.querySelectorAll('frame, iframe:not(.yomichan-float)')) {
+            if (frame.contentWindow !== e.source) { continue; }
+            sourceFrame = frame;
+            break;
+        }
+        if (sourceFrame === null) { return; }
+
+        const [forwardedX, forwardedY] = offset;
+        const {x, y} = sourceFrame.getBoundingClientRect();
+        offset = [forwardedX + x, forwardedY + y];
+
+        this._forwardFrameOffset(offset, uniqueId);
+    }
+
+    _forwardFrameOffsetParent(offset, uniqueId) {
+        window.parent.postMessage({action: 'getFrameOffset', params: {offset, uniqueId}}, '*');
+    }
+
+    _forwardFrameOffsetOrigin(offset, uniqueId) {
+        apiForward('frameOffset', {offset, uniqueId});
+    }
+}

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -32,19 +32,15 @@ async function main() {
 
     let popup;
     if (!proxy && (window !== window.parent)) {
-        let rootPopupInformationResolve;
-        const rootPopupInformationPromise = new Promise((resolve) => (rootPopupInformationResolve = resolve));
-
-        const runtimeMessageCallback = ({action, params}, sender, callback) => {
-            if (action === 'rootPopupInformation') {
-                chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
-                callback();
-                rootPopupInformationResolve(params);
+        const rootPopupInformationPromise = yomichan.getTemporaryListenerResult(
+            chrome.runtime.onMessage,
+            ({action, params}, {resolve}) => {
+                if (action === 'rootPopupInformation') {
+                    resolve(params);
+                }
             }
-        };
-        chrome.runtime.onMessage.addListener(runtimeMessageCallback);
+        );
         apiForward('rootPopupRequestInformationBroadcast');
-
         const {popupId, frameId} = await rootPopupInformationPromise;
 
         const frameOffsetForwarder = new FrameOffsetForwarder();

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -45,9 +45,9 @@ async function main() {
 
         const frameOffsetForwarder = new FrameOffsetForwarder();
         frameOffsetForwarder.start();
-        const applyFrameOffset = frameOffsetForwarder.applyOffset.bind(frameOffsetForwarder);
+        const getFrameOffset = frameOffsetForwarder.getOffset.bind(frameOffsetForwarder);
 
-        popup = new PopupProxy(popupId, 0, null, frameId, url, applyFrameOffset);
+        popup = new PopupProxy(popupId, 0, null, frameId, url, getFrameOffset);
         await popup.prepare();
     } else if (proxy) {
         popup = new PopupProxy(null, depth + 1, id, parentFrameId, url);

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -22,6 +22,7 @@
  * PopupProxy
  * PopupProxyHost
  * apiForward
+ * apiOptionsGet
  */
 
 async function main() {
@@ -30,8 +31,11 @@ async function main() {
     const data = window.frontendInitializationData || {};
     const {id, depth=0, parentFrameId, url, proxy=false} = data;
 
+    const optionsContext = {depth, url};
+    const options = await apiOptionsGet(optionsContext);
+
     let popup;
-    if (!proxy && (window !== window.parent)) {
+    if (!proxy && (window !== window.parent) && options.general.showIframePopupsInRootFrame) {
         const rootPopupInformationPromise = yomichan.getTemporaryListenerResult(
             chrome.runtime.onMessage,
             ({action, params}, {resolve}) => {

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -40,23 +40,26 @@ async function main() {
                 chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
                 callback();
                 rootPopupInformationResolve(params);
-                return false;
             }
         };
         chrome.runtime.onMessage.addListener(runtimeMessageCallback);
-        apiForward('rootPopupInformationGet');
+        apiForward('rootPopupRequestInformationBroadcast');
 
         const {popupId, frameId} = await rootPopupInformationPromise;
 
-        window._frameOffsetForwarder = new FrameOffsetForwarder();
-        const applyFrameOffset = window._frameOffsetForwarder.applyOffset.bind(window._frameOffsetForwarder);
+        const frameOffsetForwarder = new FrameOffsetForwarder();
+        frameOffsetForwarder.start();
+        const applyFrameOffset = frameOffsetForwarder.applyOffset.bind(frameOffsetForwarder);
+
         popup = new PopupProxy(popupId, 0, null, frameId, url, applyFrameOffset);
         await popup.prepare();
     } else if (proxy) {
         popup = new PopupProxy(null, depth + 1, id, parentFrameId, url);
         await popup.prepare();
     } else {
-        window._frameOffsetForwarder = new FrameOffsetForwarder();
+        const frameOffsetForwarder = new FrameOffsetForwarder();
+        frameOffsetForwarder.start();
+
         const popupHost = new PopupProxyHost();
         await popupHost.prepare();
 

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -48,8 +48,10 @@ async function main() {
         const {popupId, frameId} = await rootPopupInformationPromise;
 
         popup = new PopupProxy(popupId, 0, null, frameId, url);
+        await popup.prepare();
     } else if (proxy) {
         popup = new PopupProxy(null, depth + 1, id, parentFrameId, url);
+        await popup.prepare();
     } else {
         const popupHost = new PopupProxyHost();
         await popupHost.prepare();

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -17,6 +17,7 @@
  */
 
 /* global
+ * FrameOffsetForwarder
  * Frontend
  * PopupProxy
  * PopupProxyHost
@@ -47,12 +48,15 @@ async function main() {
 
         const {popupId, frameId} = await rootPopupInformationPromise;
 
-        popup = new PopupProxy(popupId, 0, null, frameId, url);
+        window._frameOffsetForwarder = new FrameOffsetForwarder();
+        const applyFrameOffset = window._frameOffsetForwarder.applyOffset.bind(window._frameOffsetForwarder);
+        popup = new PopupProxy(popupId, 0, null, frameId, url, applyFrameOffset);
         await popup.prepare();
     } else if (proxy) {
         popup = new PopupProxy(null, depth + 1, id, parentFrameId, url);
         await popup.prepare();
     } else {
+        window._frameOffsetForwarder = new FrameOffsetForwarder();
         const popupHost = new PopupProxyHost();
         await popupHost.prepare();
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -52,7 +52,8 @@ class Frontend extends TextScanner {
         ]);
 
         this._runtimeMessageHandlers = new Map([
-            ['popupSetVisibleOverride', ({visible}) => { this.popup.setVisibleOverride(visible); }]
+            ['popupSetVisibleOverride', ({visible}) => { this.popup.setVisibleOverride(visible); }],
+            ['rootPopupInformationGet', () => { this.popup.broadcastRootPopupInformation(); }]
         ]);
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -18,6 +18,7 @@
 
 /* global
  * TextScanner
+ * apiForward
  * apiGetZoom
  * apiKanjiFind
  * apiOptionsGet
@@ -53,7 +54,7 @@ class Frontend extends TextScanner {
 
         this._runtimeMessageHandlers = new Map([
             ['popupSetVisibleOverride', ({visible}) => { this.popup.setVisibleOverride(visible); }],
-            ['rootPopupRequestInformationBroadcast', () => { this.popup.broadcastRootPopupInformation(); }]
+            ['rootPopupRequestInformationBroadcast', () => { this._broadcastRootPopupInformation(); }]
         ]);
     }
 
@@ -77,7 +78,7 @@ class Frontend extends TextScanner {
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
 
             this._updateContentScale();
-            this.popup.broadcastRootPopupInformation();
+            this._broadcastRootPopupInformation();
         } catch (e) {
             this.onError(e);
         }
@@ -255,6 +256,12 @@ class Frontend extends TextScanner {
         this._contentScale = contentScale;
         this.popup.setContentScale(this._contentScale);
         this._updatePopupPosition();
+    }
+
+    _broadcastRootPopupInformation() {
+        if (!this.popup.isProxy() && this.popup.depth === 0) {
+            apiForward('rootPopupInformation', {popupId: this.popup.id, frameId: this.popup.frameId});
+        }
     }
 
     async _updatePopupPosition() {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -77,6 +77,7 @@ class Frontend extends TextScanner {
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
 
             this._updateContentScale();
+            this.popup.broadcastRootPopupInformation();
         } catch (e) {
             this.onError(e);
         }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -53,7 +53,7 @@ class Frontend extends TextScanner {
 
         this._runtimeMessageHandlers = new Map([
             ['popupSetVisibleOverride', ({visible}) => { this.popup.setVisibleOverride(visible); }],
-            ['rootPopupInformationGet', () => { this.popup.broadcastRootPopupInformation(); }]
+            ['rootPopupRequestInformationBroadcast', () => { this.popup.broadcastRootPopupInformation(); }]
         ]);
     }
 

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -26,17 +26,17 @@ class PopupProxyHost {
     constructor() {
         this._popups = new Map();
         this._apiReceiver = null;
-        this._frameIdPromise = null;
+        this._frameId = null;
     }
 
     // Public functions
 
     async prepare() {
-        this._frameIdPromise = apiFrameInformationGet();
-        const {frameId} = await this._frameIdPromise;
+        const {frameId} = await apiFrameInformationGet();
         if (typeof frameId !== 'number') { return; }
+        this._frameId = frameId;
 
-        this._apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${frameId}`, new Map([
+        this._apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
             ['getOrCreatePopup', this._onApiGetOrCreatePopup.bind(this)],
             ['setOptions', this._onApiSetOptions.bind(this)],
             ['hide', this._onApiHide.bind(this)],
@@ -87,7 +87,7 @@ class PopupProxyHost {
         } else if (depth === null) {
             depth = 0;
         }
-        const popup = new Popup(id, depth, this._frameIdPromise);
+        const popup = new Popup(id, depth, this._frameId);
         if (parent !== null) {
             popup.setParent(parent);
         }

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -19,7 +19,6 @@
 /* global
  * FrontendApiReceiver
  * Popup
- * apiForward
  * apiFrameInformationGet
  */
 
@@ -49,12 +48,6 @@ class PopupProxyHost {
             ['clearAutoPlayTimer', this._onApiClearAutoPlayTimer.bind(this)],
             ['setContentScale', this._onApiSetContentScale.bind(this)]
         ]));
-
-        this._windowMessageHandlers = new Map([
-            ['getIframeOffset', ({offset, uniqueId}, e) => { return this._onGetIframeOffset(offset, uniqueId, e); }]
-        ]);
-
-        window.addEventListener('message', this.onMessage.bind(this), false);
     }
 
     getOrCreatePopup(id=null, parentId=null, depth=null) {
@@ -157,30 +150,6 @@ class PopupProxyHost {
     async _onApiSetContentScale({id, scale}) {
         const popup = this._getPopup(id);
         return popup.setContentScale(scale);
-    }
-
-    // Window message handlers
-
-    onMessage(e) {
-        const {action, params} = e.data;
-        const handler = this._windowMessageHandlers.get(action);
-        if (typeof handler !== 'function') { return; }
-        handler(params, e);
-    }
-
-    _onGetIframeOffset(offset, uniqueId, e) {
-        let sourceIframe = null;
-        for (const iframe of document.querySelectorAll('iframe:not(.yomichan-float)')) {
-            if (iframe.contentWindow !== e.source) { continue; }
-            sourceIframe = iframe;
-            break;
-        }
-        if (sourceIframe === null) { return; }
-
-        const [forwardedX, forwardedY] = offset;
-        const {x, y} = sourceIframe.getBoundingClientRect();
-        offset = [forwardedX + x, forwardedY + y];
-        apiForward('iframeOffset', {offset, uniqueId});
     }
 
     // Private functions

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -138,7 +138,8 @@ class PopupProxy {
         this._frameOffsetPromise = this._getFrameOffset();
         if (firstRun) {
             try {
-                this._frameOffset = await this._frameOffsetPromise;
+                const offset = await this._frameOffsetPromise;
+                this._frameOffset = offset !== null ? offset : [0, 0];
                 this._frameOffsetUpdatedAt = Date.now();
             } catch (e) {
                 console.error(e);
@@ -146,7 +147,7 @@ class PopupProxy {
             this._frameOffsetPromise = null;
         } else {
             this._frameOffsetPromise.then((offset) => {
-                this._frameOffset = offset;
+                this._frameOffset = offset !== null ? offset : [0, 0];
                 this._frameOffsetUpdatedAt = Date.now();
                 this._frameOffsetPromise = null;
             }, (e) => {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -61,6 +61,10 @@ class PopupProxy {
         return true;
     }
 
+    broadcastRootPopupInformation() {
+        // NOP
+    }
+
     async setOptions(options) {
         const id = await this._getPopupId();
         return await this._invokeHostApi('setOptions', {id, options});
@@ -97,11 +101,11 @@ class PopupProxy {
 
     async showContent(elementRect, writingMode, type=null, details=null) {
         const id = await this._getPopupId();
-        let {x, y, width, height} = PopupProxy._convertDOMRectToJson(elementRect);
+        let {x, y, width, height} = elementRect;
         if (this._depth === 0) {
             [x, y] = await PopupProxy._convertIframePointToRootPagePoint(x, y);
-            elementRect = {x, y, width, height};
         }
+        elementRect = {x, y, width, height};
         return await this._invokeHostApi('showContent', {id, elementRect, writingMode, type, details});
     }
 
@@ -196,14 +200,5 @@ class PopupProxy {
         const {offset} = await frameOffsetPromise;
 
         return offset;
-    }
-
-    static _convertDOMRectToJson(domRect) {
-        return {
-            x: domRect.x,
-            y: domRect.y,
-            width: domRect.width,
-            height: domRect.height
-        };
     }
 }

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -121,7 +121,7 @@ class PopupProxy {
 
     async _updateFrameOffset() {
         const firstRun = this._frameOffsetUpdatedAt === null;
-        const expired = firstRun || this._frameOffsetUpdatedAt < Date.now() - 1000;
+        const expired = firstRun || this._frameOffsetUpdatedAt < Date.now() - PopupProxy._frameOffsetExpireTimeout;
         if (this._frameOffsetPromise === null && !expired) { return; }
 
         if (this._frameOffsetPromise !== null) {
@@ -158,3 +158,5 @@ class PopupProxy {
         return [x + offsetX, y + offsetY];
     }
 }
+
+PopupProxy._frameOffsetExpireTimeout = 1000;

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -132,24 +132,26 @@ class PopupProxy {
         }
 
         this._frameOffsetPromise = this._getFrameOffset();
+
+        const handleOffset = (offset) => {
+            this._frameOffset = offset !== null ? offset : [0, 0];
+            this._frameOffsetUpdatedAt = Date.now();
+            this._frameOffsetPromise = null;
+        };
+
+        const handleError = (e) => {
+            console.error(e);
+            this._frameOffsetPromise = null;
+        };
+
         if (firstRun) {
             try {
-                const offset = await this._frameOffsetPromise;
-                this._frameOffset = offset !== null ? offset : [0, 0];
-                this._frameOffsetUpdatedAt = Date.now();
+                handleOffset(await this._frameOffsetPromise);
             } catch (e) {
-                console.error(e);
+                handleError(e);
             }
-            this._frameOffsetPromise = null;
         } else {
-            this._frameOffsetPromise.then((offset) => {
-                this._frameOffset = offset !== null ? offset : [0, 0];
-                this._frameOffsetUpdatedAt = Date.now();
-                this._frameOffsetPromise = null;
-            }, (e) => {
-                console.error(e);
-                this._frameOffsetPromise = null;
-            });
+            this._frameOffsetPromise.then(handleOffset, handleError);
         }
     }
 

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -129,19 +129,29 @@ class PopupProxy {
         if (this._frameOffsetPromise === null && !expired) { return; }
 
         if (this._frameOffsetPromise !== null) {
-            await this._frameOffsetPromise;
+            if (firstRun) {
+                await this._frameOffsetPromise;
+            }
             return;
         }
 
+        this._frameOffsetPromise = this._getFrameOffset();
         if (firstRun) {
-            this._frameOffsetPromise = this._getFrameOffset();
-            this._frameOffset = await this._frameOffsetPromise;
+            try {
+                this._frameOffset = await this._frameOffsetPromise;
+                this._frameOffsetUpdatedAt = Date.now();
+            } catch (e) {
+                console.error(e);
+            }
             this._frameOffsetPromise = null;
-            this._frameOffsetUpdatedAt = Date.now();
         } else {
-            this._getFrameOffset().then((offset) => {
+            this._frameOffsetPromise.then((offset) => {
                 this._frameOffset = offset;
                 this._frameOffsetUpdatedAt = Date.now();
+                this._frameOffsetPromise = null;
+            }, (e) => {
+                console.error(e);
+                this._frameOffsetPromise = null;
             });
         }
     }

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -21,7 +21,7 @@
  */
 
 class PopupProxy {
-    constructor(id, depth, parentId, parentFrameId, url, applyFrameOffset=async (x, y) => [x, y]) {
+    constructor(id, depth, parentId, parentFrameId, url, applyFrameOffset=null) {
         this._parentId = parentId;
         this._parentFrameId = parentFrameId;
         this._id = id;
@@ -81,7 +81,7 @@ class PopupProxy {
     }
 
     async containsPoint(x, y) {
-        if (this._depth === 0) {
+        if (this._applyFrameOffset !== null) {
             [x, y] = await this._applyFrameOffset(x, y);
         }
         return await this._invokeHostApi('containsPoint', {id: this._id, x, y});
@@ -89,7 +89,7 @@ class PopupProxy {
 
     async showContent(elementRect, writingMode, type=null, details=null) {
         let {x, y, width, height} = elementRect;
-        if (this._depth === 0) {
+        if (this._applyFrameOffset !== null) {
             [x, y] = await this._applyFrameOffset(x, y);
         }
         elementRect = {x, y, width, height};

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -64,10 +64,6 @@ class PopupProxy {
         return true;
     }
 
-    broadcastRootPopupInformation() {
-        // NOP
-    }
-
     async setOptions(options) {
         return await this._invokeHostApi('setOptions', {id: this._id, options});
     }

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -29,6 +29,12 @@ class PopupProxy {
         this._depth = depth;
         this._url = url;
         this._apiSender = new FrontendApiSender();
+
+        this._windowMessageHandlers = new Map([
+            ['getIframeOffset', ({offset, uniqueId}, e) => { return this._onGetIframeOffset(offset, uniqueId, e); }]
+        ]);
+
+        window.addEventListener('message', this.onMessage.bind(this), false);
     }
 
     // Public properties
@@ -83,12 +89,19 @@ class PopupProxy {
         if (this._id === null) {
             return false;
         }
+        if (this._depth === 0) {
+            [x, y] = await PopupProxy._convertIframePointToRootPagePoint(x, y);
+        }
         return await this._invokeHostApi('containsPoint', {id: this._id, x, y});
     }
 
     async showContent(elementRect, writingMode, type=null, details=null) {
         const id = await this._getPopupId();
-        elementRect = PopupProxy._convertDOMRectToJson(elementRect);
+        let {x, y, width, height} = PopupProxy._convertDOMRectToJson(elementRect);
+        if (this._depth === 0) {
+            [x, y] = await PopupProxy._convertIframePointToRootPagePoint(x, y);
+            elementRect = {x, y, width, height};
+        }
         return await this._invokeHostApi('showContent', {id, elementRect, writingMode, type, details});
     }
 
@@ -108,6 +121,31 @@ class PopupProxy {
         const id = await this._getPopupId();
         this._invokeHostApi('setContentScale', {id, scale});
     }
+
+    // Window message handlers
+
+    onMessage(e) {
+        const {action, params} = e.data;
+        const handler = this._windowMessageHandlers.get(action);
+        if (typeof handler !== 'function') { return; }
+        handler(params, e);
+    }
+
+    _onGetIframeOffset(offset, uniqueId, e) {
+        let sourceIframe = null;
+        for (const iframe of document.querySelectorAll('iframe:not(.yomichan-float)')) {
+            if (iframe.contentWindow !== e.source) { continue; }
+            sourceIframe = iframe;
+            break;
+        }
+        if (sourceIframe === null) { return; }
+
+        const [forwardedX, forwardedY] = offset;
+        const {x, y} = sourceIframe.getBoundingClientRect();
+        offset = [forwardedX + x, forwardedY + y];
+        window.parent.postMessage({action: 'getIframeOffset', params: {offset, uniqueId}}, '*');
+    }
+
 
     // Private
 
@@ -129,6 +167,35 @@ class PopupProxy {
             return Promise.reject(new Error('Invalid frame'));
         }
         return this._apiSender.invoke(action, params, `popup-proxy-host#${this._parentFrameId}`);
+    }
+
+    static async _convertIframePointToRootPagePoint(x, y) {
+        const uniqueId = yomichan.generateId(16);
+
+        let frameOffsetResolve = null;
+        const frameOffsetPromise = new Promise((resolve) => (frameOffsetResolve = resolve));
+
+        const runtimeMessageCallback = ({action, params}, sender, callback) => {
+            if (action === 'iframeOffset' && isObject(params) && params.uniqueId === uniqueId) {
+                chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
+                callback();
+                frameOffsetResolve(params);
+                return false;
+            }
+        };
+        chrome.runtime.onMessage.addListener(runtimeMessageCallback);
+
+        window.parent.postMessage({
+            action: 'getIframeOffset',
+            params: {
+                uniqueId,
+                offset: [x, y]
+            }
+        }, '*');
+
+        const {offset} = await frameOffsetPromise;
+
+        return offset;
     }
 
     static _convertDOMRectToJson(domRect) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -17,6 +17,7 @@
  */
 
 /* global
+ * apiForward
  * apiGetMessageToken
  * apiInjectStylesheet
  */
@@ -77,6 +78,20 @@ class Popup {
 
     isProxy() {
         return false;
+    }
+
+    async broadcastRootPopupInformation() {
+        if (this._depth === 0) {
+            try {
+                const {frameId} = await this._frameIdPromise;
+                if (typeof frameId === 'number') {
+                    this._frameId = frameId;
+                }
+            } catch (e) {
+                // NOP
+            }
+            apiForward('rootPopupInformation', {popupId: this._id, frameId: this._frameId});
+        }
     }
 
     async setOptions(options) {
@@ -200,6 +215,10 @@ class Popup {
             }
         } catch (e) {
             // NOP
+        }
+
+        if (this._depth === 0) {
+            apiForward('rootPopupInformation', {popupId: this._id, frameId: this._frameId});
         }
 
         if (this._messageToken === null) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -199,8 +199,6 @@ class Popup {
     }
 
     async _createInjectPromise() {
-        this.broadcastRootPopupInformation();
-
         if (this._messageToken === null) {
             this._messageToken = await apiGetMessageToken();
         }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -23,11 +23,10 @@
  */
 
 class Popup {
-    constructor(id, depth, frameIdPromise) {
+    constructor(id, depth, frameId) {
         this._id = id;
         this._depth = depth;
-        this._frameIdPromise = frameIdPromise;
-        this._frameId = null;
+        this._frameId = frameId;
         this._parent = null;
         this._child = null;
         this._childrenSupported = true;
@@ -80,16 +79,8 @@ class Popup {
         return false;
     }
 
-    async broadcastRootPopupInformation() {
+    broadcastRootPopupInformation() {
         if (this._depth === 0) {
-            try {
-                const {frameId} = await this._frameIdPromise;
-                if (typeof frameId === 'number') {
-                    this._frameId = frameId;
-                }
-            } catch (e) {
-                // NOP
-            }
             apiForward('rootPopupInformation', {popupId: this._id, frameId: this._frameId});
         }
     }
@@ -208,18 +199,7 @@ class Popup {
     }
 
     async _createInjectPromise() {
-        try {
-            const {frameId} = await this._frameIdPromise;
-            if (typeof frameId === 'number') {
-                this._frameId = frameId;
-            }
-        } catch (e) {
-            // NOP
-        }
-
-        if (this._depth === 0) {
-            apiForward('rootPopupInformation', {popupId: this._id, frameId: this._frameId});
-        }
+        this.broadcastRootPopupInformation();
 
         if (this._messageToken === null) {
             this._messageToken = await apiGetMessageToken();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -17,7 +17,6 @@
  */
 
 /* global
- * apiForward
  * apiGetMessageToken
  * apiInjectStylesheet
  */
@@ -69,6 +68,10 @@ class Popup {
         return this._depth;
     }
 
+    get frameId() {
+        return this._frameId;
+    }
+
     get url() {
         return window.location.href;
     }
@@ -77,12 +80,6 @@ class Popup {
 
     isProxy() {
         return false;
-    }
-
-    broadcastRootPopupInformation() {
-        if (this._depth === 0) {
-            apiForward('rootPopupInformation', {popupId: this._id, frameId: this._frameId});
-        }
     }
 
     async setOptions(options) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -368,7 +368,6 @@ class Popup {
                 chrome.runtime.onMessage.removeListener(runtimeMessageCallback);
                 callback();
                 resolve();
-                return false;
             }
         };
         chrome.runtime.onMessage.addListener(runtimeMessageCallback);

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -23,9 +23,11 @@
             "mixed/js/api.js",
             "mixed/js/text-scanner.js",
             "fg/js/document.js",
+            "fg/js/frontend-api-sender.js",
             "fg/js/frontend-api-receiver.js",
             "fg/js/popup.js",
             "fg/js/source.js",
+            "fg/js/popup-proxy.js",
             "fg/js/popup-proxy-host.js",
             "fg/js/frontend.js",
             "fg/js/frontend-initialize.js"

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -27,6 +27,7 @@
             "fg/js/frontend-api-receiver.js",
             "fg/js/popup.js",
             "fg/js/source.js",
+            "fg/js/frame-offset-forwarder.js",
             "fg/js/popup-proxy.js",
             "fg/js/popup-proxy-host.js",
             "fg/js/frontend.js",

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -278,11 +278,16 @@ const yomichan = (() => {
         constructor() {
             super();
 
-            this._isBackendPreparedResolve = null;
-            this._isBackendPreparedPromise = new Promise((resolve) => (this._isBackendPreparedResolve = resolve));
+            this._isBackendPreparedPromise = this.getTemporaryListenerResult(
+                chrome.runtime.onMessage,
+                ({action}, {resolve}) => {
+                    if (action === 'backendPrepared') {
+                        resolve();
+                    }
+                }
+            );
 
             this._messageHandlers = new Map([
-                ['backendPrepared', this._onBackendPrepared.bind(this)],
                 ['getUrl', this._onMessageGetUrl.bind(this)],
                 ['optionsUpdated', this._onMessageOptionsUpdated.bind(this)],
                 ['zoomChanged', this._onMessageZoomChanged.bind(this)]
@@ -360,10 +365,6 @@ const yomichan = (() => {
             const result = handler(params, sender);
             callback(result);
             return false;
-        }
-
-        _onBackendPrepared() {
-            this._isBackendPreparedResolve();
         }
 
         _onMessageGetUrl() {

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -319,7 +319,7 @@ const yomichan = (() => {
 
         getTemporaryListenerResult(eventHandler, userCallback, timeout=null) {
             if (!(
-                typeof eventHandler.addListener === 'function' ||
+                typeof eventHandler.addListener === 'function' &&
                 typeof eventHandler.removeListener === 'function'
             )) {
                 throw new Error('Event handler type not supported');

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -318,10 +318,10 @@ const yomichan = (() => {
         }
 
         getTemporaryListenerResult(eventHandler, userCallback, timeout=null) {
-            if (
-                typeof eventHandler.addListener === 'undefined' ||
-                typeof eventHandler.removeListener === 'undefined'
-            ) {
+            if (!(
+                typeof eventHandler.addListener === 'function' ||
+                typeof eventHandler.removeListener === 'function'
+            )) {
                 throw new Error('Event handler type not supported');
             }
 

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -331,14 +331,15 @@ const yomichan = (() => {
                     if (timeout !== null) {
                         timeoutId = window.setTimeout(() => {
                             timeoutId = null;
-                            reject(new Error(`Listener timed out in ${timeout} ms`));
                             eventHandler.removeListener(runtimeMessageCallback);
+                            reject(new Error(`Listener timed out in ${timeout} ms`));
                         }, timeout);
                     }
 
                     const cleanupResolve = (value) => {
                         if (timeoutId !== null) {
                             window.clearTimeout(timeoutId);
+                            timeoutId = null;
                         }
                         eventHandler.removeListener(runtimeMessageCallback);
                         sendResponse();

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -27,7 +27,8 @@ require('fake-indexeddb/auto');
 const chrome = {
     runtime: {
         onMessage: {
-            addListener() { /* NOP */ }
+            addListener() { /* NOP */ },
+            removeListener() { /* NOP */ }
         },
         getURL(path2) {
             return url.pathToFileURL(path.join(__dirname, '..', 'ext', path2.replace(/^\//, '')));


### PR DESCRIPTION
Replaces https://github.com/FooSoft/yomichan/pull/364.
Fixes https://github.com/FooSoft/yomichan/issues/29.

https://github.com/FooSoft/yomichan/commit/765c1feec9b954c0d0cf79fa2146b0954466c987 does basically the same thing as https://github.com/toasted-nutbread/yomichan/tree/iframe-popups. The difference is that it's compatible with the ID generation in https://github.com/FooSoft/yomichan/pull/411 and doesn't expect the ID to be `'root'`. It should also handle the timing issue.

https://github.com/FooSoft/yomichan/commit/5c216a9416475116ecba191fa6f0e648de94bc83 replaces `frameIdPromise` with `frameId` (https://github.com/FooSoft/yomichan/issues/356).

https://github.com/FooSoft/yomichan/pull/417/commits/ea1da87041fad7eb04f2b70d0bacb26eeb4428bf is the magic, it basically passes an offset starting from 0 to the parent frame checking the offset of the origin frame until it reaches the root frame, and after that it's bounced back using `apiForward` with the accumulated offset and an ID token.

~The iframe lookup logic is duplicated in two places and could be refactored to a new class.~ (done in https://github.com/FooSoft/yomichan/pull/417/commits/b5c3d07ac906dc6905175c6821c193fe6921a899) I also noticed that the offset check adds some latency, but is probably needed for each check because the frames can move between scans. It would be too complex to monitor each iframe for resizes, but a compromise could be to cache the position for some time before checking again.