### PR TITLE
Backend api handler changes

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -94,7 +94,7 @@ class Backend {
             ['commandExec', {handler: this._onApiCommandExec.bind(this), async: false}],
             ['audioGetUri', {handler: this._onApiAudioGetUri.bind(this), async: true}],
             ['screenshotGet', {handler: this._onApiScreenshotGet.bind(this), async: true}],
-            ['forward', {handler: this._onApiForward.bind(this), async: true}],
+            ['forward', {handler: this._onApiForward.bind(this), async: false}],
             ['frameInformationGet', {handler: this._onApiFrameInformationGet.bind(this), async: true}],
             ['injectStylesheet', {handler: this._onApiInjectStylesheet.bind(this), async: true}],
             ['getEnvironmentInfo', {handler: this._onApiGetEnvironmentInfo.bind(this), async: true}],
@@ -569,13 +569,13 @@ class Backend {
 
     _onApiForward({action, params}, sender) {
         if (!(sender && sender.tab)) {
-            return Promise.resolve();
+            return false;
         }
 
         const tabId = sender.tab.id;
-        return new Promise((resolve) => {
-            chrome.tabs.sendMessage(tabId, {action, params}, (response) => resolve(response));
-        });
+        const callback = () => this.checkLastError(chrome.runtime.lastError);
+        chrome.tabs.sendMessage(tabId, {action, params}, callback);
+        return true;
     }
 
     _onApiFrameInformationGet(params, sender) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -94,7 +94,7 @@ class Backend {
             ['commandExec', {handler: this._onApiCommandExec.bind(this), async: false}],
             ['audioGetUri', {handler: this._onApiAudioGetUri.bind(this), async: true}],
             ['screenshotGet', {handler: this._onApiScreenshotGet.bind(this), async: true}],
-            ['forward', {handler: this._onApiForward.bind(this), async: false}],
+            ['broadcast', {handler: this._onApiBroadcast.bind(this), async: false}],
             ['frameInformationGet', {handler: this._onApiFrameInformationGet.bind(this), async: true}],
             ['injectStylesheet', {handler: this._onApiInjectStylesheet.bind(this), async: true}],
             ['getEnvironmentInfo', {handler: this._onApiGetEnvironmentInfo.bind(this), async: true}],
@@ -567,7 +567,7 @@ class Backend {
         });
     }
 
-    _onApiForward({action, params}, sender) {
+    _onApiBroadcast({action, params}, sender) {
         if (!(sender && sender.tab)) {
             return false;
         }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -78,9 +78,9 @@ class Backend {
 
         this._messageHandlers = new Map([
             ['yomichanCoreReady', {handler: this._onApiYomichanCoreReady.bind(this), async: true}],
-            ['optionsSchemaGet', {handler: this._onApiOptionsSchemaGet.bind(this), async: true}],
-            ['optionsGet', {handler: this._onApiOptionsGet.bind(this), async: true}],
-            ['optionsGetFull', {handler: this._onApiOptionsGetFull.bind(this), async: true}],
+            ['optionsSchemaGet', {handler: this._onApiOptionsSchemaGet.bind(this), async: false}],
+            ['optionsGet', {handler: this._onApiOptionsGet.bind(this), async: false}],
+            ['optionsGetFull', {handler: this._onApiOptionsGetFull.bind(this), async: false}],
             ['optionsSet', {handler: this._onApiOptionsSet.bind(this), async: true}],
             ['optionsSave', {handler: this._onApiOptionsSave.bind(this), async: true}],
             ['kanjiFind', {handler: this._onApiKanjiFind.bind(this), async: true}],
@@ -91,7 +91,7 @@ class Backend {
             ['definitionsAddable', {handler: this._onApiDefinitionsAddable.bind(this), async: true}],
             ['noteView', {handler: this._onApiNoteView.bind(this), async: true}],
             ['templateRender', {handler: this._onApiTemplateRender.bind(this), async: true}],
-            ['commandExec', {handler: this._onApiCommandExec.bind(this), async: true}],
+            ['commandExec', {handler: this._onApiCommandExec.bind(this), async: false}],
             ['audioGetUri', {handler: this._onApiAudioGetUri.bind(this), async: true}],
             ['screenshotGet', {handler: this._onApiScreenshotGet.bind(this), async: true}],
             ['forward', {handler: this._onApiForward.bind(this), async: true}],
@@ -102,8 +102,8 @@ class Backend {
             ['getDisplayTemplatesHtml', {handler: this._onApiGetDisplayTemplatesHtml.bind(this), async: true}],
             ['getQueryParserTemplatesHtml', {handler: this._onApiGetQueryParserTemplatesHtml.bind(this), async: true}],
             ['getZoom', {handler: this._onApiGetZoom.bind(this), async: true}],
-            ['getMessageToken', {handler: this._onApiGetMessageToken.bind(this), async: true}],
-            ['getDefaultAnkiFieldTemplates', {handler: this._onApiGetDefaultAnkiFieldTemplates.bind(this), async: true}]
+            ['getMessageToken', {handler: this._onApiGetMessageToken.bind(this), async: false}],
+            ['getDefaultAnkiFieldTemplates', {handler: this._onApiGetDefaultAnkiFieldTemplates.bind(this), async: false}]
         ]);
 
         this._commandHandlers = new Map([
@@ -332,15 +332,15 @@ class Backend {
         });
     }
 
-    async _onApiOptionsSchemaGet() {
+    _onApiOptionsSchemaGet() {
         return this.getOptionsSchema();
     }
 
-    async _onApiOptionsGet({optionsContext}) {
+    _onApiOptionsGet({optionsContext}) {
         return this.getOptions(optionsContext);
     }
 
-    async _onApiOptionsGetFull() {
+    _onApiOptionsGetFull() {
         return this.getFullOptions();
     }
 
@@ -547,7 +547,7 @@ class Backend {
         return this._renderTemplate(template, data);
     }
 
-    async _onApiCommandExec({command, params}) {
+    _onApiCommandExec({command, params}) {
         return this._runCommand(command, params);
     }
 
@@ -698,11 +698,11 @@ class Backend {
         });
     }
 
-    async _onApiGetMessageToken() {
+    _onApiGetMessageToken() {
         return this.messageToken;
     }
 
-    async _onApiGetDefaultAnkiFieldTemplates() {
+    _onApiGetDefaultAnkiFieldTemplates() {
         return this.defaultAnkiFieldTemplates;
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -94,7 +94,7 @@ class Backend {
             ['commandExec', {handler: this._onApiCommandExec.bind(this), async: false}],
             ['audioGetUri', {handler: this._onApiAudioGetUri.bind(this), async: true}],
             ['screenshotGet', {handler: this._onApiScreenshotGet.bind(this), async: true}],
-            ['broadcast', {handler: this._onApiBroadcast.bind(this), async: false}],
+            ['broadcastTab', {handler: this._onApiBroadcastTab.bind(this), async: false}],
             ['frameInformationGet', {handler: this._onApiFrameInformationGet.bind(this), async: true}],
             ['injectStylesheet', {handler: this._onApiInjectStylesheet.bind(this), async: true}],
             ['getEnvironmentInfo', {handler: this._onApiGetEnvironmentInfo.bind(this), async: true}],
@@ -566,7 +566,7 @@ class Backend {
         });
     }
 
-    _onApiBroadcast({action, params}, sender) {
+    _onApiBroadcastTab({action, params}, sender) {
         if (!(sender && sender.tab)) {
             return false;
         }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -18,7 +18,7 @@
 
 /* global
  * Display
- * apiBroadcast
+ * apiBroadcastTab
  * apiGetMessageToken
  * popupNestedInitialize
  */
@@ -80,7 +80,7 @@ class DisplayFloat extends Display {
 
         this.setContentScale(scale);
 
-        apiBroadcast('popupPrepareCompleted', {targetPopupId: this._popupId});
+        apiBroadcastTab('popupPrepareCompleted', {targetPopupId: this._popupId});
     }
 
     onError(error) {
@@ -181,7 +181,7 @@ class DisplayFloat extends Display {
                 },
                 2000
             );
-            apiBroadcast('requestDocumentInformationBroadcast', {uniqueId});
+            apiBroadcastTab('requestDocumentInformationBroadcast', {uniqueId});
 
             const {title} = await promise;
             return title;

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -18,7 +18,7 @@
 
 /* global
  * Display
- * apiForward
+ * apiBroadcast
  * apiGetMessageToken
  * popupNestedInitialize
  */
@@ -80,7 +80,7 @@ class DisplayFloat extends Display {
 
         this.setContentScale(scale);
 
-        apiForward('popupPrepareCompleted', {targetPopupId: this._popupId});
+        apiBroadcast('popupPrepareCompleted', {targetPopupId: this._popupId});
     }
 
     onError(error) {
@@ -181,7 +181,7 @@ class DisplayFloat extends Display {
                 },
                 2000
             );
-            apiForward('requestDocumentInformationBroadcast', {uniqueId});
+            apiBroadcast('requestDocumentInformationBroadcast', {uniqueId});
 
             const {title} = await promise;
             return title;

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -17,7 +17,7 @@
  */
 
 /* global
- * apiBroadcast
+ * apiBroadcastTab
  */
 
 class FrameOffsetForwarder {
@@ -97,6 +97,6 @@ class FrameOffsetForwarder {
     }
 
     _forwardFrameOffsetOrigin(offset, uniqueId) {
-        apiBroadcast('frameOffset', {offset, uniqueId});
+        apiBroadcastTab('frameOffset', {offset, uniqueId});
     }
 }

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -17,7 +17,7 @@
  */
 
 /* global
- * apiForward
+ * apiBroadcast
  */
 
 class FrameOffsetForwarder {
@@ -97,6 +97,6 @@ class FrameOffsetForwarder {
     }
 
     _forwardFrameOffsetOrigin(offset, uniqueId) {
-        apiForward('frameOffset', {offset, uniqueId});
+        apiBroadcast('frameOffset', {offset, uniqueId});
     }
 }

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -21,7 +21,7 @@
  * Frontend
  * PopupProxy
  * PopupProxyHost
- * apiForward
+ * apiBroadcast
  * apiOptionsGet
  */
 
@@ -44,7 +44,7 @@ async function main() {
                 }
             }
         );
-        apiForward('rootPopupRequestInformationBroadcast');
+        apiBroadcast('rootPopupRequestInformationBroadcast');
         const {popupId, frameId} = await rootPopupInformationPromise;
 
         const frameOffsetForwarder = new FrameOffsetForwarder();

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -21,7 +21,7 @@
  * Frontend
  * PopupProxy
  * PopupProxyHost
- * apiBroadcast
+ * apiBroadcastTab
  * apiOptionsGet
  */
 
@@ -44,7 +44,7 @@ async function main() {
                 }
             }
         );
-        apiBroadcast('rootPopupRequestInformationBroadcast');
+        apiBroadcastTab('rootPopupRequestInformationBroadcast');
         const {popupId, frameId} = await rootPopupInformationPromise;
 
         const frameOffsetForwarder = new FrameOffsetForwarder();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -18,7 +18,7 @@
 
 /* global
  * TextScanner
- * apiBroadcast
+ * apiBroadcastTab
  * apiGetZoom
  * apiKanjiFind
  * apiOptionsGet
@@ -261,12 +261,12 @@ class Frontend extends TextScanner {
 
     _broadcastRootPopupInformation() {
         if (!this.popup.isProxy() && this.popup.depth === 0) {
-            apiBroadcast('rootPopupInformation', {popupId: this.popup.id, frameId: this.popup.frameId});
+            apiBroadcastTab('rootPopupInformation', {popupId: this.popup.id, frameId: this.popup.frameId});
         }
     }
 
     _broadcastDocumentInformation(uniqueId) {
-        apiBroadcast('documentInformationBroadcast', {
+        apiBroadcastTab('documentInformationBroadcast', {
             uniqueId,
             frameId: this.popup.frameId,
             title: document.title

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -18,7 +18,7 @@
 
 /* global
  * TextScanner
- * apiForward
+ * apiBroadcast
  * apiGetZoom
  * apiKanjiFind
  * apiOptionsGet
@@ -261,12 +261,12 @@ class Frontend extends TextScanner {
 
     _broadcastRootPopupInformation() {
         if (!this.popup.isProxy() && this.popup.depth === 0) {
-            apiForward('rootPopupInformation', {popupId: this.popup.id, frameId: this.popup.frameId});
+            apiBroadcast('rootPopupInformation', {popupId: this.popup.id, frameId: this.popup.frameId});
         }
     }
 
     _broadcastDocumentInformation(uniqueId) {
-        apiForward('documentInformationBroadcast', {
+        apiBroadcast('documentInformationBroadcast', {
             uniqueId,
             frameId: this.popup.frameId,
             title: document.title

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -81,8 +81,8 @@ function apiScreenshotGet(options) {
     return _apiInvoke('screenshotGet', {options});
 }
 
-function apiBroadcast(action, params) {
-    return _apiInvoke('broadcast', {action, params});
+function apiBroadcastTab(action, params) {
+    return _apiInvoke('broadcastTab', {action, params});
 }
 
 function apiFrameInformationGet() {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -81,8 +81,8 @@ function apiScreenshotGet(options) {
     return _apiInvoke('screenshotGet', {options});
 }
 
-function apiForward(action, params) {
-    return _apiInvoke('forward', {action, params});
+function apiBroadcast(action, params) {
+    return _apiInvoke('broadcast', {action, params});
 }
 
 function apiFrameInformationGet() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -23,9 +23,9 @@
  * DisplayGenerator
  * WindowScroll
  * apiAudioGetUri
+ * apiBroadcast
  * apiDefinitionAdd
  * apiDefinitionsAddable
- * apiForward
  * apiKanjiFind
  * apiNoteView
  * apiOptionsGet
@@ -855,7 +855,7 @@ class Display {
     }
 
     setPopupVisibleOverride(visible) {
-        return apiForward('popupSetVisibleOverride', {visible});
+        return apiBroadcast('popupSetVisibleOverride', {visible});
     }
 
     setSpinnerVisible(visible) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -23,7 +23,7 @@
  * DisplayGenerator
  * WindowScroll
  * apiAudioGetUri
- * apiBroadcast
+ * apiBroadcastTab
  * apiDefinitionAdd
  * apiDefinitionsAddable
  * apiKanjiFind
@@ -855,7 +855,7 @@ class Display {
     }
 
     setPopupVisibleOverride(visible) {
-        return apiBroadcast('popupSetVisibleOverride', {visible});
+        return apiBroadcastTab('popupSetVisibleOverride', {visible});
     }
 
     setSpinnerVisible(visible) {


### PR DESCRIPTION
This PR fixes a few issues causing the following error message to be shown:

```
Unchecked runtime.lastError: The message port closed before a response was received.
```

This was primarily caused by `apiForward`, which was was awaiting the response of its `sendMessage` call, rather than ignoring it. This behaviour was initially described in #185. There was a similar issue in the `yomichanCoreReady` handler.

This PR makes the following changes:
* API message handlers are now defined as an object of the form `{handler: function, async: boolean}`. The `handler` is the same function as before, and the `async` value indicates whether the function returns a promise or not. When `async` is `false`, the handler can be optimized to return early.
* A few handlers which didn't require `async` have been converter to synchronous handlers. This includes the handlers for the following:
  * `optionsSchemaGet`
  * `optionsGet`
  * `optionsGetFull`
  * `commandExec`
  * `getMessageToken`
  * `getDefaultAnkiFieldTemplates`
  * `yomichanCoreReady`
  * `forward`*
* The `apiForward` handler no longer waits for its internal `sendMessage` calls.
* `apiForward` has been renamed to `apiBroadcast` to better reflect its use.
* The `apiYomichanCoreReady` handler no longer waits for its internal `sendMessage` calls.
