### PR TITLE
Audio system refactoring

### DIFF
--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -85,14 +85,14 @@ class AnkiNoteBuilder {
         });
     }
 
-    async injectAudio(definition, fields, sources, optionsContext) {
+    async injectAudio(definition, fields, sources, details) {
         if (!this._containsMarker(fields, 'audio')) { return; }
 
         try {
             const expressions = definition.expressions;
             const audioSourceDefinition = Array.isArray(expressions) ? expressions[0] : definition;
 
-            const {uri} = await this._audioSystem.getDefinitionAudio(audioSourceDefinition, sources, {tts: false, optionsContext});
+            const {uri} = await this._audioSystem.getDefinitionAudio(audioSourceDefinition, sources, details);
             const filename = this._createInjectedAudioFileName(audioSourceDefinition);
             if (filename !== null) {
                 definition.audio = {url: uri, filename};

--- a/ext/bg/js/audio-uri-builder.js
+++ b/ext/bg/js/audio-uri-builder.js
@@ -49,11 +49,11 @@ class AudioUriBuilder {
         return url;
     }
 
-    async getUri(definition, source, options) {
+    async getUri(definition, source, details) {
         const handler = this._getUrlHandlers.get(source);
         if (typeof handler === 'function') {
             try {
-                return await handler(definition, options);
+                return await handler(definition, details);
             } catch (e) {
                 // NOP
             }
@@ -132,26 +132,24 @@ class AudioUriBuilder {
         throw new Error('Failed to find audio URL');
     }
 
-    async _getUriTextToSpeech(definition, options) {
-        const voiceURI = options.audio.textToSpeechVoice;
-        if (!voiceURI) {
+    async _getUriTextToSpeech(definition, {textToSpeechVoice}) {
+        if (!textToSpeechVoice) {
             throw new Error('No voice');
         }
-
-        return `tts:?text=${encodeURIComponent(definition.expression)}&voice=${encodeURIComponent(voiceURI)}`;
+        return `tts:?text=${encodeURIComponent(definition.expression)}&voice=${encodeURIComponent(textToSpeechVoice)}`;
     }
 
-    async _getUriTextToSpeechReading(definition, options) {
-        const voiceURI = options.audio.textToSpeechVoice;
-        if (!voiceURI) {
+    async _getUriTextToSpeechReading(definition, {textToSpeechVoice}) {
+        if (!textToSpeechVoice) {
             throw new Error('No voice');
         }
-
-        return `tts:?text=${encodeURIComponent(definition.reading || definition.expression)}&voice=${encodeURIComponent(voiceURI)}`;
+        return `tts:?text=${encodeURIComponent(definition.reading || definition.expression)}&voice=${encodeURIComponent(textToSpeechVoice)}`;
     }
 
-    async _getUriCustom(definition, options) {
-        const customSourceUrl = options.audio.customSourceUrl;
+    async _getUriCustom(definition, {customSourceUrl}) {
+        if (typeof customSourceUrl !== 'string') {
+            throw new Error('No custom URL defined');
+        }
         return customSourceUrl.replace(/\{([^}]*)\}/g, (m0, m1) => (hasOwn(definition, m1) ? `${definition[m1]}` : m0));
     }
 }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -53,7 +53,8 @@ class Backend {
         this.defaultAnkiFieldTemplates = null;
         this.audioUriBuilder = new AudioUriBuilder();
         this.audioSystem = new AudioSystem({
-            audioUriBuilder: this.audioUriBuilder
+            audioUriBuilder: this.audioUriBuilder,
+            useCache: false
         });
         this.ankiNoteBuilder = new AnkiNoteBuilder({
             anki: this.anki,

--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -28,7 +28,10 @@ let audioSourceUI = null;
 let audioSystem = null;
 
 async function audioSettingsInitialize() {
-    audioSystem = new AudioSystem({audioUriBuilder: null});
+    audioSystem = new AudioSystem({
+        audioUriBuilder: null,
+        useCache: true
+    });
 
     const optionsContext = getOptionsContext();
     const options = await getOptionsMutable(optionsContext);

--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -110,7 +110,7 @@ function textToSpeechTest() {
         const text = document.querySelector('#text-to-speech-voice-test').dataset.speechText || '';
         const voiceUri = document.querySelector('#text-to-speech-voice').value;
 
-        const audio = audioSystem.createTextToSpeechAudio({text, voiceUri});
+        const audio = audioSystem.createTextToSpeechAudio(text, voiceUri);
         audio.volume = 1.0;
         audio.play();
     } catch (e) {

--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -18,7 +18,6 @@
 /* global
  * AudioSourceUI
  * AudioSystem
- * apiAudioGetUri
  * getOptionsContext
  * getOptionsMutable
  * settingsSaveOptions

--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -28,12 +28,7 @@ let audioSourceUI = null;
 let audioSystem = null;
 
 async function audioSettingsInitialize() {
-    audioSystem = new AudioSystem({
-        getAudioUri: async (definition, source) => {
-            const optionsContext = getOptionsContext();
-            return await apiAudioGetUri(definition, source, optionsContext);
-        }
-    });
+    audioSystem = new AudioSystem({audioUriBuilder: null});
 
     const optionsContext = getOptionsContext();
     const options = await getOptionsMutable(optionsContext);

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -64,8 +64,8 @@ function apiTemplateRender(template, data) {
     return _apiInvoke('templateRender', {data, template});
 }
 
-function apiAudioGetUri(definition, source, optionsContext) {
-    return _apiInvoke('audioGetUri', {definition, source, optionsContext});
+function apiAudioGetUri(definition, source, details) {
+    return _apiInvoke('audioGetUri', {definition, source, details});
 }
 
 function apiCommandExec(command, params) {

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -40,7 +40,7 @@ class TextToSpeechAudio {
         }
     }
 
-    play() {
+    async play() {
         try {
             if (this._utterance === null) {
                 this._utterance = new SpeechSynthesisUtterance(this.text || '');

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -102,7 +102,7 @@ class AudioSystem {
         throw new Error('Could not create audio');
     }
 
-    createTextToSpeechAudio({text, voiceUri}) {
+    createTextToSpeechAudio(text, voiceUri) {
         const voice = this._getTextToSpeechVoiceFromVoiceUri(voiceUri);
         if (voice === null) {
             throw new Error('Invalid text-to-speech voice');
@@ -117,7 +117,8 @@ class AudioSystem {
     async _createAudio(uri) {
         const ttsParameters = this._getTextToSpeechParameters(uri);
         if (ttsParameters !== null) {
-            return this.createTextToSpeechAudio(ttsParameters);
+            const {text, voiceUri} = ttsParameters;
+            return this.createTextToSpeechAudio(text, voiceUri);
         }
 
         return await this._createAudioFromUrl(uri);

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -85,7 +85,9 @@ class AudioSystem {
             const cacheValue = this._cache.get(key);
             if (typeof cacheValue !== 'undefined') {
                 const {audio, uri, source} = cacheValue;
-                return {audio, uri, source};
+                if (sources.includes(source)) {
+                    return {audio, uri, source};
+                }
             }
         }
 

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -85,13 +85,15 @@ class AudioSystem {
             const cacheValue = this._cache.get(key);
             if (typeof cacheValue !== 'undefined') {
                 const {audio, uri, source} = cacheValue;
-                if (sources.includes(source)) {
-                    return {audio, uri, source};
+                const index = sources.indexOf(source);
+                if (index >= 0) {
+                    return {audio, uri, index};
                 }
             }
         }
 
-        for (const source of sources) {
+        for (let i = 0, ii = sources.length; i < ii; ++i) {
+            const source = sources[i];
             const uri = await this._getAudioUri(definition, source, details);
             if (uri === null) { continue; }
 
@@ -101,7 +103,7 @@ class AudioSystem {
                     this._cacheCheck();
                     this._cache.set(key, {audio, uri, source});
                 }
-                return {audio, uri, source};
+                return {audio, uri, index: i};
             } catch (e) {
                 // NOP
             }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -823,7 +823,14 @@ class Display {
             this.audioPlaying = audio;
             audio.currentTime = 0;
             audio.volume = this.options.audio.volume / 100.0;
-            audio.play();
+            const playPromise = audio.play();
+            if (typeof playPromise !== 'undefined') {
+                try {
+                    await playPromise;
+                } catch (e2) {
+                    // NOP
+                }
+            }
         } catch (e) {
             this.onError(e);
         } finally {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -810,7 +810,7 @@ class Display {
                 info = 'Could not find audio';
             }
 
-            const button = this.audioButtonFindImage(entryIndex);
+            const button = this.audioButtonFindImage(entryIndex, expressionIndex);
             if (button !== null) {
                 let titleDefault = button.dataset.titleDefault;
                 if (!titleDefault) {
@@ -909,9 +909,16 @@ class Display {
         viewerButton.dataset.noteId = noteId;
     }
 
-    audioButtonFindImage(index) {
+    audioButtonFindImage(index, expressionIndex) {
         const entry = this.getEntry(index);
-        return entry !== null ? entry.querySelector('.action-play-audio>img') : null;
+        if (entry === null) { return null; }
+
+        const container = (
+            expressionIndex >= 0 ?
+            entry.querySelector(`.term-expression:nth-of-type(${expressionIndex + 1})`) :
+            entry
+        );
+        return container !== null ? container.querySelector('.action-play-audio>img') : null;
     }
 
     async getDefinitionsAddable(definitions, modes) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -45,7 +45,13 @@ class Display {
         this.index = 0;
         this.audioPlaying = null;
         this.audioFallback = null;
-        this.audioSystem = new AudioSystem({getAudioUri: this._getAudioUri.bind(this)});
+        this.audioSystem = new AudioSystem({
+            audioUriBuilder: {
+                async getUri(definition, source, details) {
+                    return await apiAudioGetUri(definition, source, details);
+                }
+            }
+        });
         this.styleNode = null;
 
         this.eventListeners = new EventListenerCollection();
@@ -789,10 +795,10 @@ class Display {
                 this.audioPlaying = null;
             }
 
-            const sources = this.options.audio.sources;
             let audio, source, info;
             try {
-                ({audio, source} = await this.audioSystem.getDefinitionAudio(expression, sources));
+                const {sources, textToSpeechVoice, customSourceUrl} = this.options.audio;
+                ({audio, source} = await this.audioSystem.getDefinitionAudio(expression, sources, {textToSpeechVoice, customSourceUrl}));
                 info = `From source ${1 + sources.indexOf(source)}: ${source}`;
             } catch (e) {
                 if (this.audioFallback === null) {
@@ -946,10 +952,5 @@ class Display {
                 title: documentTitle
             }
         };
-    }
-
-    async _getAudioUri(definition, source) {
-        const optionsContext = this.getOptionsContext();
-        return await apiAudioGetUri(definition, source, optionsContext);
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -791,10 +791,7 @@ class Display {
 
             const expression = expressionIndex === -1 ? definition : definition.expressions[expressionIndex];
 
-            if (this.audioPlaying !== null) {
-                this.audioPlaying.pause();
-                this.audioPlaying = null;
-            }
+            this._stopPlayingAudio();
 
             let audio, info;
             try {
@@ -820,6 +817,8 @@ class Display {
                 button.title = `${titleDefault}\n${info}`;
             }
 
+            this._stopPlayingAudio();
+
             this.audioPlaying = audio;
             audio.currentTime = 0;
             audio.volume = this.options.audio.volume / 100.0;
@@ -835,6 +834,13 @@ class Display {
             this.onError(e);
         } finally {
             this.setSpinnerVisible(false);
+        }
+    }
+
+    _stopPlayingAudio() {
+        if (this.audioPlaying !== null) {
+            this.audioPlaying.pause();
+            this.audioPlaying = null;
         }
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -50,7 +50,8 @@ class Display {
                 async getUri(definition, source, details) {
                     return await apiAudioGetUri(definition, source, details);
                 }
-            }
+            },
+            useCache: true
         });
         this.styleNode = null;
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -47,7 +47,7 @@ class Display {
         this.audioFallback = null;
         this.audioSystem = new AudioSystem({
             audioUriBuilder: {
-                async getUri(definition, source, details) {
+                getUri: async (definition, source, details) => {
                     return await apiAudioGetUri(definition, source, details);
                 }
             },

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -796,11 +796,12 @@ class Display {
                 this.audioPlaying = null;
             }
 
-            let audio, source, info;
+            let audio, info;
             try {
                 const {sources, textToSpeechVoice, customSourceUrl} = this.options.audio;
-                ({audio, source} = await this.audioSystem.getDefinitionAudio(expression, sources, {textToSpeechVoice, customSourceUrl}));
-                info = `From source ${1 + sources.indexOf(source)}: ${source}`;
+                let index;
+                ({audio, index} = await this.audioSystem.getDefinitionAudio(expression, sources, {textToSpeechVoice, customSourceUrl}));
+                info = `From source ${1 + index}: ${sources[index]}`;
             } catch (e) {
                 if (this.audioFallback === null) {
                     this.audioFallback = new Audio('/mixed/mp3/button.mp3');


### PR DESCRIPTION
Various refactorings/fixes to the audio-related classes.

* Refactored the arguments that are passed to `AudiUriBuilder.getUri`, `AnkiNoteBuilder.injectAudio`, and `AudioSystem.constructor`. The intent is to make it so that only the relevant details are passed, rather than the entire `options` object or an `optionsContext`. This was mentioned in the first bullet point of https://github.com/FooSoft/yomichan/pull/427#issue-397307625.
* Disabled audio caching on the backend when creating cards. Caching should not be necessary and could potentially cause unnecessary memory to remain allocated.
* Updated the audio cache to only return a value if the source is in the `sources` parameter.
* Fixed a bug where the cache didn't work correctly (was using the wrong key).
* Fixed a bug on the audio playback buttons in merged mode where the title text wouldn't be updated properly to display what the audio source is.
* General organization of what data is passed in and where it is coming from, intended to remove redundancies.