### PR TITLE
Fix getSelection not working in QueryParser

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -209,7 +209,7 @@ class DisplaySearch extends Display {
 
     onCopy() {
         // ignore copy from search page
-        this.clipboardMonitor.setPreviousText(document.getSelection().toString().trim());
+        this.clipboardMonitor.setPreviousText(window.getSelection().toString().trim());
     }
 
     onExternalSearchUpdate({text}) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -134,7 +134,7 @@ class TextScanner {
         this.preventNextClick = false;
 
         const primaryTouch = e.changedTouches[0];
-        if (DOM.isPointInSelection(primaryTouch.clientX, primaryTouch.clientY, this.node.getSelection())) {
+        if (DOM.isPointInSelection(primaryTouch.clientX, primaryTouch.clientY, window.getSelection())) {
             return;
         }
 


### PR DESCRIPTION
`getSelection` only works on window, not on DOM nodes.