### PR TITLE
Badge improvements

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -67,8 +67,6 @@ class Backend {
             url: window.location.href
         };
 
-        this.isPrepared = false;
-
         this.clipboardPasteTarget = document.querySelector('#clipboard-paste-target');
 
         this.popupWindow = null;
@@ -76,6 +74,8 @@ class Backend {
         this.apiForwarder = new BackendApiForwarder();
 
         this.messageToken = yomichan.generateId(16);
+
+        this._isPrepared = false;
 
         this._messageHandlers = new Map([
             ['yomichanCoreReady', {handler: this._onApiYomichanCoreReady.bind(this), async: false}],
@@ -144,8 +144,6 @@ class Backend {
         }
         chrome.runtime.onMessage.addListener(this.onMessage.bind(this));
 
-        this.isPrepared = true;
-
         const options = this.getOptions(this.optionsContext);
         if (options.general.showGuide) {
             chrome.tabs.create({url: chrome.runtime.getURL('/bg/guide.html')});
@@ -156,6 +154,12 @@ class Backend {
         this._sendMessageAllTabs('backendPrepared');
         const callback = () => this.checkLastError(chrome.runtime.lastError);
         chrome.runtime.sendMessage({action: 'backendPrepared'}, callback);
+
+        this._isPrepared = true;
+    }
+
+    isPrepared() {
+        return this._isPrepared;
     }
 
     _sendMessageAllTabs(action, params={}) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -886,7 +886,7 @@ class Backend {
         let status = null;
 
         if (!this._isPrepared) {
-            if (this._prepareError !== null) {
+            if (this._prepareError) {
                 text = '!!';
                 color = '#f04e4e';
                 status = 'Error';

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -28,7 +28,6 @@
  * Mecab
  * Translator
  * conditionsTestValue
- * dictConfigured
  * dictTermsSort
  * handlebarsRenderDynamic
  * jp

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -868,21 +868,16 @@ class Backend {
 
     _getBrowserIconTitle() {
         return (
-            chrome.browserAction !== null &&
-            typeof chrome.browserAction === 'object' &&
+            isObject(chrome.browserAction) &&
             typeof chrome.browserAction.getTitle === 'function' ?
-            new Promise((resolve) => chrome.browserAction.getTitle({}, resolve)) :
-            Promise.resolve('')
+                new Promise((resolve) => chrome.browserAction.getTitle({}, resolve)) :
+                Promise.resolve('')
         );
     }
 
     _updateBadge() {
         let title = this._defaultBrowserActionTitle;
-        if (
-            title === null ||
-            chrome.browserAction === null ||
-            typeof chrome.browserAction !== 'object'
-        ) {
+        if (title === null || !isObject(chrome.browserAction)) {
             // Not ready or invalid
             return;
         }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -60,7 +60,7 @@ function utilBackgroundFunctionIsolate(func) {
 
 function utilBackend() {
     const backend = chrome.extension.getBackgroundPage().yomichanBackend;
-    if (!backend.isPrepared) {
+    if (!backend.isPrepared()) {
         throw new Error('Backend not ready yet');
     }
     return backend;


### PR DESCRIPTION
Some improvements to the status reporting functionality on the browser badge. This satisfies the following task from #270:

> Indicate when the backend / database is upgrading. When the database version is upgrading, the extension won't run. This operation can take multiple seconds, so it can be noticeable. This was the case in the version upgrade in #287, despite the difference being very small.

When the backend is `prepare()`ing, the status will show as "..." if it takes longer than 1 second. Additionally, if any error occurs during `prepare()`, this will be logged and the status will change to a red "!!". Additionally, the hover tooltip text is changed to reflect this status.

Prepare errors don't/shouldn't currently happen in typical use cases, but it can in development workflows. For example, when switching to a branch which upgraded the database version and then switching branches to an older version, the `database.prepare()` will fail.