### PR TITLE
Error logging refactoring

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -80,7 +80,6 @@
                 "yomichan": "readonly",
                 "errorToJson": "readonly",
                 "jsonToError": "readonly",
-                "logError": "readonly",
                 "isObject": "readonly",
                 "hasOwn": "readonly",
                 "toIterable": "readonly",

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -112,7 +112,8 @@ class Backend {
             ['getDictionaryInfo', {handler: this._onApiGetDictionaryInfo.bind(this), async: true}],
             ['getDictionaryCounts', {handler: this._onApiGetDictionaryCounts.bind(this), async: true}],
             ['purgeDatabase', {handler: this._onApiPurgeDatabase.bind(this), async: true}],
-            ['getMedia', {handler: this._onApiGetMedia.bind(this), async: true}]
+            ['getMedia', {handler: this._onApiGetMedia.bind(this), async: true}],
+            ['log', {handler: this._onApiLog.bind(this), async: false}]
         ]);
 
         this._commandHandlers = new Map([
@@ -765,6 +766,10 @@ class Backend {
 
     async _onApiGetMedia({targets}) {
         return await this.database.getMedia(targets);
+    }
+
+    _onApiLog({error, level, type}) {
+        yomichan.log(jsonToError(error), level, type);
     }
 
     // Command handlers

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -164,7 +164,7 @@ class Backend {
             this._isPrepared = true;
         } catch (e) {
             this._prepareError = true;
-            logError(e);
+            yomichan.logError(e);
             throw e;
         } finally {
             if (this._badgePrepareDelayTimer !== null) {
@@ -260,7 +260,7 @@ class Backend {
             this.options = JsonSchema.getValidValueOrDefault(this.optionsSchema, utilIsolate(options));
         } catch (e) {
             // This shouldn't happen, but catch errors just in case of bugs
-            logError(e);
+            yomichan.logError(e);
         }
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -770,8 +770,8 @@ class Backend {
         return await this.database.getMedia(targets);
     }
 
-    _onApiLog({error, level, type, context}) {
-        yomichan.log(jsonToError(error), level, type, context);
+    _onApiLog({error, level, context}) {
+        yomichan.log(jsonToError(error), level, context);
 
         const levelValue = this._getErrorLevelValue(level);
         if (levelValue <= this._getErrorLevelValue(this._logErrorLevel)) { return; }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -770,8 +770,8 @@ class Backend {
         return await this.database.getMedia(targets);
     }
 
-    _onApiLog({error, level, type}) {
-        yomichan.log(jsonToError(error), level, type);
+    _onApiLog({error, level, type, context}) {
+        yomichan.log(jsonToError(error), level, type, context);
 
         const levelValue = this._getErrorLevelValue(level);
         if (levelValue <= this._getErrorLevelValue(this._logErrorLevel)) { return; }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -114,7 +114,8 @@ class Backend {
             ['getDictionaryCounts', {handler: this._onApiGetDictionaryCounts.bind(this), async: true}],
             ['purgeDatabase', {handler: this._onApiPurgeDatabase.bind(this), async: true}],
             ['getMedia', {handler: this._onApiGetMedia.bind(this), async: true}],
-            ['log', {handler: this._onApiLog.bind(this), async: false}]
+            ['log', {handler: this._onApiLog.bind(this), async: false}],
+            ['logIndicatorClear', {handler: this._onApiLogIndicatorClear.bind(this), async: false}]
         ]);
 
         this._commandHandlers = new Map([
@@ -776,6 +777,12 @@ class Backend {
         if (levelValue <= this._getErrorLevelValue(this._logErrorLevel)) { return; }
 
         this._logErrorLevel = level;
+        this._updateBadge();
+    }
+
+    _onApiLogIndicatorClear() {
+        if (this._logErrorLevel === null) { return; }
+        this._logErrorLevel = null;
         this._updateBadge();
     }
 

--- a/ext/bg/js/context-main.js
+++ b/ext/bg/js/context-main.js
@@ -17,6 +17,7 @@
 
 /* global
  * apiCommandExec
+ * apiForwardLogsToBackend
  * apiGetEnvironmentInfo
  * apiLogIndicatorClear
  * apiOptionsGet
@@ -53,6 +54,7 @@ function setupButtonEvents(selector, command, url) {
 }
 
 async function mainInner() {
+    apiForwardLogsToBackend();
     await yomichan.prepare();
 
     await apiLogIndicatorClear();

--- a/ext/bg/js/context-main.js
+++ b/ext/bg/js/context-main.js
@@ -18,6 +18,7 @@
 /* global
  * apiCommandExec
  * apiGetEnvironmentInfo
+ * apiLogIndicatorClear
  * apiOptionsGet
  */
 
@@ -53,6 +54,8 @@ function setupButtonEvents(selector, command, url) {
 
 async function mainInner() {
     await yomichan.prepare();
+
+    await apiLogIndicatorClear();
 
     showExtensionInfo();
 

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -104,7 +104,7 @@ class Database {
             });
             return true;
         } catch (e) {
-            logError(e);
+            yomichan.logError(e);
             return false;
         }
     }

--- a/ext/bg/js/mecab.js
+++ b/ext/bg/js/mecab.js
@@ -24,7 +24,7 @@ class Mecab {
     }
 
     onError(error) {
-        logError(error, false);
+        yomichan.logError(error);
     }
 
     async checkVersion() {

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -17,6 +17,7 @@
 
 /* global
  * DisplaySearch
+ * apiForwardLogsToBackend
  * apiOptionsGet
  */
 
@@ -53,6 +54,7 @@ function injectSearchFrontend() {
 }
 
 (async () => {
+    apiForwardLogsToBackend();
     await yomichan.prepare();
 
     const displaySearch = new DisplaySearch();

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -45,7 +45,7 @@ class QueryParser extends TextScanner {
     }
 
     onError(error) {
-        logError(error, false);
+        yomichan.logError(error);
     }
 
     onClick(e) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -122,7 +122,7 @@ class DisplaySearch extends Display {
     }
 
     onError(error) {
-        logError(error, true);
+        yomichan.logError(error);
     }
 
     onSearchClear() {

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -133,7 +133,7 @@ async function _settingsImportSetOptionsFull(optionsFull) {
 }
 
 function _showSettingsImportError(error) {
-    logError(error);
+    yomichan.logError(error);
     document.querySelector('#settings-import-error-modal-message').textContent = `${error}`;
     $('#settings-import-error-modal').modal('show');
 }

--- a/ext/bg/js/settings/dictionaries.js
+++ b/ext/bg/js/settings/dictionaries.js
@@ -554,7 +554,7 @@ function dictionaryErrorsShow(errors) {
     if (errors !== null && errors.length > 0) {
         const uniqueErrors = new Map();
         for (let e of errors) {
-            logError(e);
+            yomichan.logError(e);
             e = dictionaryErrorToString(e);
             let count = uniqueErrors.get(e);
             if (typeof count === 'undefined') {

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -21,6 +21,7 @@
  * ankiInitialize
  * ankiTemplatesInitialize
  * ankiTemplatesUpdateValue
+ * apiForwardLogsToBackend
  * apiOptionsSave
  * appearanceInitialize
  * audioSettingsInitialize
@@ -284,6 +285,7 @@ function showExtensionInformation() {
 
 
 async function onReady() {
+    apiForwardLogsToBackend();
     await yomichan.prepare();
 
     showExtensionInformation();

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -17,8 +17,10 @@
 
 /* global
  * SettingsPopupPreview
+ * apiForwardLogsToBackend
  */
 
 (() => {
+    apiForwardLogsToBackend();
     new SettingsPopupPreview();
 })();

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -22,6 +22,7 @@
  * PopupProxy
  * PopupProxyHost
  * apiBroadcastTab
+ * apiForwardLogsToBackend
  * apiOptionsGet
  */
 
@@ -62,6 +63,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
 }
 
 (async () => {
+    apiForwardLogsToBackend();
     await yomichan.prepare();
 
     const data = window.frontendInitializationData || {};

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -17,6 +17,7 @@
 
 /* global
  * DisplayFloat
+ * apiForwardLogsToBackend
  * apiOptionsGet
  */
 
@@ -68,5 +69,6 @@ async function popupNestedInitialize(id, depth, parentFrameId, url) {
 }
 
 (async () => {
+    apiForwardLogsToBackend();
     new DisplayFloat();
 })();

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -84,7 +84,7 @@ class DisplayFloat extends Display {
         if (this._orphaned) {
             this.setContent('orphaned');
         } else {
-            logError(error, true);
+            yomichan.logError(error);
         }
     }
 

--- a/ext/fg/js/frontend-api-sender.js
+++ b/ext/fg/js/frontend-api-sender.js
@@ -81,12 +81,12 @@ class FrontendApiSender {
     onAck(id) {
         const info = this.callbacks.get(id);
         if (typeof info === 'undefined') {
-            console.warn(`ID ${id} not found for ack`);
+            yomichan.logWarning(new Error(`ID ${id} not found for ack`));
             return;
         }
 
         if (info.ack) {
-            console.warn(`Request ${id} already ack'd`);
+            yomichan.logWarning(new Error(`Request ${id} already ack'd`));
             return;
         }
 
@@ -98,12 +98,12 @@ class FrontendApiSender {
     onResult(id, data) {
         const info = this.callbacks.get(id);
         if (typeof info === 'undefined') {
-            console.warn(`ID ${id} not found`);
+            yomichan.logWarning(new Error(`ID ${id} not found`));
             return;
         }
 
         if (!info.ack) {
-            console.warn(`Request ${id} not ack'd`);
+            yomichan.logWarning(new Error(`Request ${id} not ack'd`));
             return;
         }
 

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -148,7 +148,7 @@ class PopupProxy {
             }
             this._frameOffsetUpdatedAt = now;
         } catch (e) {
-            logError(e);
+            yomichan.logError(e);
         } finally {
             this._frameOffsetPromise = null;
         }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -182,7 +182,7 @@ function _apiCheckLastError() {
 
 yomichan.on('log', async ({error, level, type, context}) => {
     try {
-        await apiLog(jsonToError(error), level, type, context);
+        await apiLog(errorToJson(error), level, type, context);
     } catch (e) {
         // NOP
     }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -144,6 +144,10 @@ function apiGetMedia(targets) {
     return _apiInvoke('getMedia', {targets});
 }
 
+function apiLog(error, level, type) {
+    return _apiInvoke('log', {error, level, type});
+}
+
 function _apiInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -144,8 +144,8 @@ function apiGetMedia(targets) {
     return _apiInvoke('getMedia', {targets});
 }
 
-function apiLog(error, level, type, context) {
-    return _apiInvoke('log', {error, level, type, context});
+function apiLog(error, level, context) {
+    return _apiInvoke('log', {error, level, context});
 }
 
 function apiLogIndicatorClear() {
@@ -180,9 +180,9 @@ function _apiCheckLastError() {
     // NOP
 }
 
-yomichan.on('log', async ({error, level, type, context}) => {
+yomichan.on('log', async ({error, level, context}) => {
     try {
-        await apiLog(errorToJson(error), level, type, context);
+        await apiLog(errorToJson(error), level, context);
     } catch (e) {
         // NOP
     }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -180,10 +180,16 @@ function _apiCheckLastError() {
     // NOP
 }
 
-yomichan.on('log', async ({error, level, context}) => {
-    try {
-        await apiLog(errorToJson(error), level, context);
-    } catch (e) {
-        // NOP
-    }
-});
+let _apiForwardLogsToBackendEnabled = false;
+function apiForwardLogsToBackend() {
+    if (_apiForwardLogsToBackendEnabled) { return; }
+    _apiForwardLogsToBackendEnabled = true;
+
+    yomichan.on('log', async ({error, level, context}) => {
+        try {
+            await apiLog(errorToJson(error), level, context);
+        } catch (e) {
+            // NOP
+        }
+    });
+}

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -148,6 +148,10 @@ function apiLog(error, level, type) {
     return _apiInvoke('log', {error, level, type});
 }
 
+function apiLogIndicatorClear() {
+    return _apiInvoke('logIndicatorClear');
+}
+
 function _apiInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -175,3 +175,11 @@ function _apiInvoke(action, params={}) {
 function _apiCheckLastError() {
     // NOP
 }
+
+yomichan.on('log', async ({error, level, type}) => {
+    try {
+        await apiLog(jsonToError(error), level, type);
+    } catch (e) {
+        // NOP
+    }
+});

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -144,8 +144,8 @@ function apiGetMedia(targets) {
     return _apiInvoke('getMedia', {targets});
 }
 
-function apiLog(error, level, type) {
-    return _apiInvoke('log', {error, level, type});
+function apiLog(error, level, type, context) {
+    return _apiInvoke('log', {error, level, type, context});
 }
 
 function apiLogIndicatorClear() {
@@ -180,9 +180,9 @@ function _apiCheckLastError() {
     // NOP
 }
 
-yomichan.on('log', async ({error, level, type}) => {
+yomichan.on('log', async ({error, level, type, context}) => {
     try {
-        await apiLog(jsonToError(error), level, type);
+        await apiLog(jsonToError(error), level, type, context);
     } catch (e) {
         // NOP
     }

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -362,7 +362,11 @@ const yomichan = (() => {
             this.log(error, 'error');
         }
 
-        log(error, level, type=null) {
+        log(error, level, type=null, context=null) {
+            if (!isObject(context)) {
+                context = this._getErrorContext();
+            }
+
             let errorString;
             try {
                 errorString = error.toString();
@@ -395,7 +399,7 @@ const yomichan = (() => {
 
             const manifest = chrome.runtime.getManifest();
             let message = `${manifest.name} v${manifest.version} ${this._getProblemMessage(type)}`;
-            message += `\nOriginating URL: ${window.location.href}\n`;
+            message += `\nOriginating URL: ${context.url}\n`;
             message += errorString;
             if (typeof errorData !== 'undefined') {
                 message += `\nData: ${JSON.stringify(errorData, null, 4)}`;
@@ -410,10 +414,16 @@ const yomichan = (() => {
                 default: console.log(message); break;
             }
 
-            this.trigger('log', {error, level, type});
+            this.trigger('log', {error, level, type, context});
         }
 
         // Private
+
+        _getErrorContext() {
+            return {
+                url: window.location.href
+            };
+        }
 
         _getProblemMessage(type) {
             switch (type) {

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -284,8 +284,6 @@ const yomichan = (() => {
             ]);
 
             chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
-
-            window.addEventListener('unhandledrejection', this._onUnhandledRejection.bind(this));
         }
 
         // Public
@@ -425,11 +423,8 @@ const yomichan = (() => {
             };
         }
 
-        _getProblemMessage(type) {
-            switch (type) {
-                case 'unhandled-rejection': return 'has encountered an unhandled promise rejection.';
-                default: return 'has encountered a problem.';
-            }
+        _getProblemMessage() {
+            return 'has encountered a problem.';
         }
 
         _onMessage({action, params}, sender, callback) {
@@ -451,11 +446,6 @@ const yomichan = (() => {
 
         _onMessageZoomChanged({oldZoomFactor, newZoomFactor}) {
             this.trigger('zoomChanged', {oldZoomFactor, newZoomFactor});
-        }
-
-        _onUnhandledRejection(event) {
-            this.log(event.reason, 'warn', 'unhandled-rejection');
-            event.preventDefault();
         }
     }
 

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -271,6 +271,8 @@ const yomichan = (() => {
             ]);
 
             chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
+
+            window.addEventListener('unhandledrejection', this._onUnhandledRejection.bind(this));
         }
 
         // Public
@@ -349,7 +351,7 @@ const yomichan = (() => {
 
         // Private
 
-        _log(error, level) {
+        _log(error, level, problem=null) {
             let errorString;
             try {
                 errorString = error.toString();
@@ -381,8 +383,9 @@ const yomichan = (() => {
             }
 
             const manifest = chrome.runtime.getManifest();
-            let message = `${manifest.name} v${manifest.version} has encountered a problem.\n`;
-            message += `Originating URL: ${window.location.href}\n`;
+            let message = `${manifest.name} v${manifest.version}`;
+            message += problem ? problem : ' has encountered a problem.';
+            message += `\nOriginating URL: ${window.location.href}\n`;
             message += errorString;
             if (typeof errorData !== 'undefined') {
                 message += `\nData: ${JSON.stringify(errorData, null, 4)}`;
@@ -417,6 +420,11 @@ const yomichan = (() => {
 
         _onMessageZoomChanged({oldZoomFactor, newZoomFactor}) {
             this.trigger('zoomChanged', {oldZoomFactor, newZoomFactor});
+        }
+
+        _onUnhandledRejection(event) {
+            this._log(event.reason, 'warn', ' has encountered an unhandled promise rejection.');
+            event.preventDefault();
         }
     }
 

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -68,28 +68,6 @@ function jsonToError(jsonError) {
     return error;
 }
 
-function logError(error, alert) {
-    const manifest = chrome.runtime.getManifest();
-    let errorMessage = `${manifest.name} v${manifest.version} has encountered an error.\n`;
-    errorMessage += `Originating URL: ${window.location.href}\n`;
-
-    const errorString = `${error.toString ? error.toString() : error}`;
-    const stack = `${error.stack}`.trimRight();
-    if (!stack.startsWith(errorString)) { errorMessage += `${errorString}\n`; }
-    errorMessage += stack;
-
-    const data = error.data;
-    if (typeof data !== 'undefined') { errorMessage += `\nData: ${JSON.stringify(data, null, 4)}`; }
-
-    errorMessage += '\n\nIssues can be reported at https://github.com/FooSoft/yomichan/issues';
-
-    console.error(errorMessage);
-
-    if (alert) {
-        window.alert(`${errorString}\n\nCheck the developer console for more details.`);
-    }
-}
-
 
 /*
  * Common helpers

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -362,7 +362,7 @@ const yomichan = (() => {
 
         log(error, level, context=null) {
             if (!isObject(context)) {
-                context = this._getErrorContext();
+                context = this._getLogContext();
             }
 
             let errorString;
@@ -417,7 +417,7 @@ const yomichan = (() => {
 
         // Private
 
-        _getErrorContext() {
+        _getLogContext() {
             return {
                 url: window.location.href
             };

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -342,16 +342,14 @@ const yomichan = (() => {
         }
 
         logWarning(error) {
-            this._log(error, 'warn');
+            this.log(error, 'warn');
         }
 
         logError(error) {
-            this._log(error, 'error');
+            this.log(error, 'error');
         }
 
-        // Private
-
-        _log(error, level, problem=null) {
+        log(error, level, type=null) {
             let errorString;
             try {
                 errorString = error.toString();
@@ -383,8 +381,7 @@ const yomichan = (() => {
             }
 
             const manifest = chrome.runtime.getManifest();
-            let message = `${manifest.name} v${manifest.version}`;
-            message += problem ? problem : ' has encountered a problem.';
+            let message = `${manifest.name} v${manifest.version} ${this._getProblemMessage(type)}`;
             message += `\nOriginating URL: ${window.location.href}\n`;
             message += errorString;
             if (typeof errorData !== 'undefined') {
@@ -398,6 +395,15 @@ const yomichan = (() => {
                 case 'warn': console.warn(message); break;
                 case 'error': console.error(message); break;
                 default: console.log(message); break;
+            }
+        }
+
+        // Private
+
+        _getProblemMessage(type) {
+            switch (type) {
+                case 'unhandled-rejection': return 'has encountered an unhandled promise rejection.';
+                default: return 'has encountered a problem.';
             }
         }
 
@@ -423,7 +429,7 @@ const yomichan = (() => {
         }
 
         _onUnhandledRejection(event) {
-            this._log(event.reason, 'warn', ' has encountered an unhandled promise rejection.');
+            this.log(event.reason, 'warn', 'unhandled-rejection');
             event.preventDefault();
         }
     }

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -409,6 +409,8 @@ const yomichan = (() => {
                 case 'error': console.error(message); break;
                 default: console.log(message); break;
             }
+
+            this.trigger('log', {error, level, type});
         }
 
         // Private

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -52,15 +52,28 @@ if (EXTENSION_IS_BROWSER_EDGE) {
  */
 
 function errorToJson(error) {
+    try {
+        if (isObject(error)) {
+            return {
+                name: error.name,
+                message: error.message,
+                stack: error.stack,
+                data: error.data
+            };
+        }
+    } catch (e) {
+        // NOP
+    }
     return {
-        name: error.name,
-        message: error.message,
-        stack: error.stack,
-        data: error.data
+        value: error,
+        hasValue: true
     };
 }
 
 function jsonToError(jsonError) {
+    if (jsonError.hasValue) {
+        return jsonError.value;
+    }
     const error = new Error(jsonError.message);
     error.name = jsonError.name;
     error.stack = jsonError.stack;

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -360,7 +360,7 @@ const yomichan = (() => {
             this.log(error, 'error');
         }
 
-        log(error, level, type=null, context=null) {
+        log(error, level, context=null) {
             if (!isObject(context)) {
                 context = this._getErrorContext();
             }
@@ -396,7 +396,7 @@ const yomichan = (() => {
             }
 
             const manifest = chrome.runtime.getManifest();
-            let message = `${manifest.name} v${manifest.version} ${this._getProblemMessage(type)}`;
+            let message = `${manifest.name} v${manifest.version} has encountered a problem.`;
             message += `\nOriginating URL: ${context.url}\n`;
             message += errorString;
             if (typeof errorData !== 'undefined') {
@@ -412,7 +412,7 @@ const yomichan = (() => {
                 default: console.log(message); break;
             }
 
-            this.trigger('log', {error, level, type, context});
+            this.trigger('log', {error, level, context});
         }
 
         // Private
@@ -421,10 +421,6 @@ const yomichan = (() => {
             return {
                 url: window.location.href
             };
-        }
-
-        _getProblemMessage() {
-            return 'has encountered a problem.';
         }
 
         _onMessage({action, params}, sender, callback) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -201,7 +201,7 @@ class TextScanner {
     }
 
     onError(error) {
-        logError(error, false);
+        yomichan.logError(error);
     }
 
     async scanTimerWait() {

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -145,7 +145,10 @@ const vm = new VM({
     XMLHttpRequest,
     indexedDB: global.indexedDB,
     IDBKeyRange: global.IDBKeyRange,
-    JSZip: yomichanTest.JSZip
+    JSZip: yomichanTest.JSZip,
+    addEventListener() {
+        // NOP
+    }
 });
 vm.context.window = vm.context;
 


### PR DESCRIPTION
* Moves `logError` onto `yomichan` object, similar to how `console.error` and related functions are on the `console` object.
* Adds `logWarning`.
* Improves the log function to handle all types of error values, in case something unexpected is received. This can happen when throwing or rejecting promises with non-errors.
* Removes the alert functionality since it is intrusive and rarely used.
* Handles the [`unhandledrejection`](https://developer.mozilla.org/en-US/docs/Web/API/Window/unhandledrejection_event) event.