### PR TITLE
Iframe popup edge cases

### DIFF
--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -79,9 +79,28 @@ class FrameOffsetForwarder {
             sourceFrame = frame;
             break;
         }
+
         if (sourceFrame === null) {
-            this._forwardFrameOffsetOrigin(null, uniqueId);
-            return;
+            const getShadowRootElements = (documentOrElement) => {
+                const elements = Array.from(documentOrElement.querySelectorAll('*'))
+                    .filter((el) => !!el.shadowRoot);
+                const childElements = elements
+                    .map((el) => el.shadowRoot)
+                    .map(getShadowRootElements);
+                elements.push(childElements.flat());
+
+                return elements.flat();
+            };
+
+            sourceFrame = getShadowRootElements(document)
+                .map((el) => Array.from(el.shadowRoot.querySelectorAll('frame, iframe:not(.yomichan-float)')))
+                .flat()
+                .find((el) => el.contentWindow === e.source);
+
+            if (!sourceFrame) {
+                this._forwardFrameOffsetOrigin(null, uniqueId);
+                return;
+            }
         }
 
         const [forwardedX, forwardedY] = offset;

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -23,6 +23,7 @@ class FrameOffsetForwarder {
     constructor() {
         this._started = false;
         this._frameCache = new Set();
+        this._unreachableContentWindowCache = new Set();
 
         this._forwardFrameOffset = (
             window !== window.parent ?
@@ -74,9 +75,13 @@ class FrameOffsetForwarder {
     }
 
     _onGetFrameOffset(offset, uniqueId, e) {
-        const sourceFrame = this._findFrameWithContentWindow(e.source);
+        let sourceFrame = null;
+        if (!this._unreachableContentWindowCache.has(e.source)) {
+            sourceFrame = this._findFrameWithContentWindow(e.source);
+        }
         if (sourceFrame === null) {
             // closed shadow root etc.
+            this._unreachableContentWindowCache.add(e.source);
             this._forwardFrameOffsetOrigin(null, uniqueId);
             return;
         }

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -88,7 +88,7 @@ async function main() {
         }
 
         let popup;
-        if (isIframe && options.general.showIframePopupsInRootFrame) {
+        if (isIframe && options.general.showIframePopupsInRootFrame && !document.fullscreen) {
             popup = popups.iframe || await createIframePopupProxy(url, frameOffsetForwarder);
             popups.iframe = popup;
         } else if (proxy) {
@@ -117,6 +117,7 @@ async function main() {
     };
 
     yomichan.on('optionsUpdated', applyOptions);
+    window.addEventListener('fullscreenchange', applyOptions, false);
 
     await applyOptions();
 }

--- a/ext/fg/js/frontend-initialize.js
+++ b/ext/fg/js/frontend-initialize.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DOM
  * FrameOffsetForwarder
  * Frontend
  * PopupProxy
@@ -95,7 +96,7 @@ async function main() {
         }
 
         let popup;
-        if (isIframe && options.general.showIframePopupsInRootFrame && !document.fullscreen && iframePopupsInRootFrameAvailable) {
+        if (isIframe && options.general.showIframePopupsInRootFrame && DOM.getFullscreenElement() === null && iframePopupsInRootFrameAvailable) {
             popup = popups.iframe || await createIframePopupProxy(url, frameOffsetForwarder, disableIframePopupsInRootFrame);
             popups.iframe = popup;
         } else if (proxy) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -20,7 +20,7 @@
  */
 
 class PopupProxy {
-    constructor(id, depth, parentId, parentFrameId, url, getFrameOffset=null) {
+    constructor(id, depth, parentId, parentFrameId, url, getFrameOffset=null, setDisabled=null) {
         this._parentId = parentId;
         this._parentFrameId = parentFrameId;
         this._id = id;
@@ -28,6 +28,7 @@ class PopupProxy {
         this._url = url;
         this._apiSender = new FrontendApiSender();
         this._getFrameOffset = getFrameOffset;
+        this._setDisabled = setDisabled;
 
         this._frameOffset = null;
         this._frameOffsetPromise = null;
@@ -142,6 +143,10 @@ class PopupProxy {
         try {
             const offset = await this._frameOffsetPromise;
             this._frameOffset = offset !== null ? offset : [0, 0];
+            if (offset === null && this._setDisabled !== null) {
+                this._setDisabled();
+                return;
+            }
             this._frameOffsetUpdatedAt = now;
         } catch (e) {
             logError(e);

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DOM
  * apiGetMessageToken
  * apiInjectStylesheet
  */
@@ -271,7 +272,7 @@ class Popup {
     }
 
     _onFullscreenChanged() {
-        const parent = (Popup._getFullscreenElement() || document.body || null);
+        const parent = (DOM.getFullscreenElement() || document.body || null);
         if (parent !== null && this._container.parentNode !== parent) {
             parent.appendChild(this._container);
         }
@@ -363,16 +364,6 @@ class Popup {
         if (token === null || contentWindow === null) { return; }
 
         contentWindow.postMessage({action, params, token}, this._targetOrigin);
-    }
-
-    static _getFullscreenElement() {
-        return (
-            document.fullscreenElement ||
-            document.msFullscreenElement ||
-            document.mozFullScreenElement ||
-            document.webkitFullscreenElement ||
-            null
-        );
     }
 
     static _getPositionForHorizontalText(elementRect, width, height, viewport, offsetScale, optionsGeneral) {

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -71,7 +71,7 @@
     "applications": {
         "gecko": {
             "id": "alex@foosoft.net",
-            "strict_min_version": "52.0"
+            "strict_min_version": "53.0"
         }
     }
 }

--- a/ext/mixed/js/dom.js
+++ b/ext/mixed/js/dom.js
@@ -62,4 +62,14 @@ class DOM {
             default: return false;
         }
     }
+
+    static getFullscreenElement() {
+        return (
+            document.fullscreenElement ||
+            document.msFullscreenElement ||
+            document.mozFullScreenElement ||
+            document.webkitFullscreenElement ||
+            null
+        );
+    }
 }

--- a/test/data/html/test-document2.html
+++ b/test/data/html/test-document2.html
@@ -77,5 +77,22 @@ document.querySelector('#fullscreen-link1').addEventListener('click', () => togg
         </script>
     </div>
 
+    <div class="test">
+        <div class="description">&lt;iframe&gt; element inside of an open shadow DOM.</div>
+        <div id="shadow-iframe-container-open"></div>
+        <template id="shadow-iframe-container-open-content-template">
+            <iframe src="test-document2-frame1.html" allowfullscreen="true" style="width: 100%; height: 200px; border: 1px solid #d8d8d8;"></iframe>
+        </template>
+        <script>
+(() => {
+    const shadowIframeContainer = document.querySelector('#shadow-iframe-container-open');
+    const shadow = shadowIframeContainer.attachShadow({mode: 'open'});
+    const template = document.querySelector('#shadow-iframe-container-open-content-template').content;
+    const content = document.importNode(template, true);
+    shadow.appendChild(content);
+})();
+        </script>
+    </div>
+
 </body>
 </html>

--- a/test/data/html/test-document3-frame1.html
+++ b/test/data/html/test-document3-frame1.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Yomichan Manual Performance Tests</title>
+        <link rel="stylesheet" href="test-stylesheet.css" />
+    </head>
+<body><div class="content">
+
+    <div class="description">Add elements</div>
+
+    <div>
+        <a href="#" id="add-elements-1000">1000</a>
+        <a href="#" id="add-elements-10000">10000</a>
+        <a href="#" id="add-elements-100000">100000</a>
+        <a href="#" id="add-elements-1000000">1000000</a>
+        <script>
+document.querySelector('#add-elements-1000').addEventListener('click',    () => addElements(1000), false);
+document.querySelector('#add-elements-10000').addEventListener('click',   () => addElements(10000), false);
+document.querySelector('#add-elements-100000').addEventListener('click',  () => addElements(100000), false);
+document.querySelector('#add-elements-1000000').addEventListener('click', () => addElements(1000000), false);
+
+let counter = 0;
+
+function addElements(amount) {
+    const container = document.querySelector('#container');
+    for (let i = 0; i < amount; i++) {
+        const element = document.createElement('div');
+        element.textContent = 'ありがとう';
+        container.appendChild(element);
+    }
+
+    counter += amount;
+    document.querySelector('#counter').textContent = counter;
+}
+        </script>
+    </div>
+
+    <div id="counter"></div>
+    <div id="container"></div>
+
+</div></body>
+</html>

--- a/test/data/html/test-document3-frame2.html
+++ b/test/data/html/test-document3-frame2.html
@@ -1,0 +1,62 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Yomichan Manual Performance Tests</title>
+        <link rel="stylesheet" href="test-stylesheet.css" />
+    </head>
+<body><div class="content">
+
+    <div class="description">&lt;iframe&gt; element inside of an open shadow DOM.</div>
+
+    <div id="shadow-iframe-container-open"></div>
+    <template id="shadow-iframe-container-open-content-template">
+        <iframe src="test-document2-frame1.html" allowfullscreen="true" style="width: 100%; height: 50px; border: 1px solid #d8d8d8;"></iframe>
+    </template>
+    <script>
+(() => {
+    const shadowIframeContainer = document.querySelector('#shadow-iframe-container-open');
+    const shadow = shadowIframeContainer.attachShadow({mode: 'open'});
+    const template = document.querySelector('#shadow-iframe-container-open-content-template').content;
+    const content = document.importNode(template, true);
+    shadow.appendChild(content);
+})();
+    </script>
+
+    <div class="description">Add elements</div>
+
+    <div>
+        <a href="#" id="add-elements-1000">1000</a>
+        <a href="#" id="add-elements-10000">10000</a>
+        <a href="#" id="add-elements-100000">100000</a>
+        <a href="#" id="add-elements-1000000">1000000</a>
+    </div>
+
+    <div id="counter"></div>
+    <div id="container"></div>
+    <script>
+(() => {
+    document.querySelector('#add-elements-1000').addEventListener('click',    () => addElements(1000), false);
+    document.querySelector('#add-elements-10000').addEventListener('click',   () => addElements(10000), false);
+    document.querySelector('#add-elements-100000').addEventListener('click',  () => addElements(100000), false);
+    document.querySelector('#add-elements-1000000').addEventListener('click', () => addElements(1000000), false);
+
+    let counter = 0;
+
+    function addElements(amount) {
+        const container = document.querySelector('#container');
+        for (let i = 0; i < amount; i++) {
+            const element = document.createElement('div');
+            element.textContent = 'ありがとう';
+            container.appendChild(element);
+        }
+
+        counter += amount;
+        document.querySelector('#counter').textContent = counter;
+    }
+})();
+    </script>
+
+</div></body>
+</html>

--- a/test/data/html/test-document3.html
+++ b/test/data/html/test-document3.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width,initial-scale=1" />
+        <title>Yomichan Manual Performance Tests</title>
+        <link rel="icon" type="image/gif" href="data:image/gif;base64,R0lGODlhEAAQAKEBAAAAAP///////////yH5BAEKAAIALAAAAAAQABAAAAImFI6Zpt0B4YkS0TCpq07xbmEgcGVRUpLaI46ZG7ppalY0jDCwUAAAOw==" />
+        <link rel="stylesheet" href="test-stylesheet.css" />
+    </head>
+<body>
+
+    <h1>Yomichan Manual Performance Tests</h1>
+    <p class="description">Testing Yomichan performance with artificially demanding cases in a real browser</p>
+
+    <div class="test">
+        <div class="description">&lt;iframe&gt; element.</div>
+        <iframe src="test-document3-frame1.html" allowfullscreen="true" style="width: 100%; height: 200px; border: 1px solid #d8d8d8;"></iframe>
+    </div>
+
+    <div class="test">
+        <div class="description">&lt;iframe&gt; element containing an &lt;iframe&gt; element inside of an open shadow DOM.</div>
+        <iframe src="test-document3-frame2.html" allowfullscreen="true" style="width: 100%; height: 200px; border: 1px solid #d8d8d8;"></iframe>
+    </div>
+
+</body>
+</html>


### PR DESCRIPTION
Support the following edge cases:

- Iframe is fullscreen: create a popup inside the iframe regardless of `options.general.showIframePopupsInRootFrame` value, but return it back when fullscreen is closed
- Iframe in open shadow dom: find the content window recursively and support positioning normally
- Iframe in closed shadow dom: fall back to popups inside iframe

Fixes https://github.com/FooSoft/yomichan/issues/432