### PR TITLE
Update Popup and DisplayFloat optionsContext from Frontend

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -76,6 +76,8 @@ class DisplaySearch extends Display {
     async prepare() {
         try {
             await super.prepare();
+            await this.updateOptions();
+            yomichan.on('optionsUpdated', () => this.updateOptions());
             await this.queryParser.prepare();
 
             const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -233,7 +233,7 @@ class DisplaySearch extends Display {
             this.setIntroVisible(!valid, animate);
             this.updateSearchButton();
             if (valid) {
-                const {definitions} = await apiTermsFind(query, details, this.optionsContext);
+                const {definitions} = await apiTermsFind(query, details, this.getOptionsContext());
                 this.setContent('terms', {definitions, context: {
                     focus: false,
                     disableHistory: true,

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -20,6 +20,5 @@
  */
 
 (async () => {
-    const instance = new SettingsPopupPreview();
-    await instance.prepare();
+    new SettingsPopupPreview();
 })();

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -19,6 +19,6 @@
  * SettingsPopupPreview
  */
 
-(async () => {
+(() => {
     new SettingsPopupPreview();
 })();

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -60,7 +60,7 @@ class SettingsPopupPreview {
         this.popupSetCustomOuterCssOld = this.popup.setCustomOuterCss;
         this.popup.setCustomOuterCss = this.popupSetCustomOuterCss.bind(this);
 
-        this.frontend = new Frontend(this.popup);
+        this.frontend = new Frontend(this.popup, window.location.href);
 
         this.frontend.setEnabled = () => {};
         this.frontend.searchClear = () => {};

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -65,10 +65,9 @@ class SettingsPopupPreview {
         this.popupSetCustomOuterCssOld = this.popup.setCustomOuterCss;
         this.popup.setCustomOuterCss = this.popupSetCustomOuterCss.bind(this);
 
-        this.frontend = new Frontend(this.popup, null);
+        this.frontend = new Frontend(this.popup);
 
         this.frontend.getOptionsContext = async () => this.optionsContext;
-        this.frontend.getOptionsContextCached = () => this.optionsContext;
         this.frontend.setEnabled = () => {};
         this.frontend.onSearchClear = () => {};
 

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -32,19 +32,24 @@ class SettingsPopupPreview {
         this.popupShown = false;
         this.themeChangeTimeout = null;
         this.textSource = null;
+        this.optionsContext = null;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
 
         this._windowMessageHandlers = new Map([
+            ['prepare', ({optionsContext}) => this.prepare(optionsContext)],
             ['setText', ({text}) => this.setText(text)],
             ['setCustomCss', ({css}) => this.setCustomCss(css)],
-            ['setCustomOuterCss', ({css}) => this.setCustomOuterCss(css)]
+            ['setCustomOuterCss', ({css}) => this.setCustomOuterCss(css)],
+            ['updateOptionsContext', ({optionsContext}) => this.updateOptionsContext(optionsContext)]
         ]);
+
+        window.addEventListener('message', this.onMessage.bind(this), false);
     }
 
-    async prepare() {
-        // Setup events
-        window.addEventListener('message', this.onMessage.bind(this), false);
+    async prepare(optionsContext) {
+        this.optionsContext = optionsContext;
 
+        // Setup events
         document.querySelector('#theme-dark-checkbox').addEventListener('change', this.onThemeDarkCheckboxChanged.bind(this), false);
 
         // Overwrite API functions
@@ -60,10 +65,12 @@ class SettingsPopupPreview {
         this.popupSetCustomOuterCssOld = this.popup.setCustomOuterCss;
         this.popup.setCustomOuterCss = this.popupSetCustomOuterCss.bind(this);
 
-        this.frontend = new Frontend(this.popup, window.location.href);
+        this.frontend = new Frontend(this.popup, null);
 
+        this.frontend.getOptionsContext = async () => this.optionsContext;
+        this.frontend.getOptionsContextCached = () => this.optionsContext;
         this.frontend.setEnabled = () => {};
-        this.frontend.searchClear = () => {};
+        this.frontend.onSearchClear = () => {};
 
         await this.frontend.prepare();
 
@@ -143,6 +150,12 @@ class SettingsPopupPreview {
     setCustomOuterCss(css) {
         if (this.frontend === null) { return; }
         this.frontend.popup.setCustomOuterCss(css, false);
+    }
+
+    async updateOptionsContext(optionsContext) {
+        this.optionsContext = optionsContext;
+        await this.frontend.updateOptions();
+        await this.updateSearch();
     }
 
     async updateSearch() {

--- a/ext/bg/js/settings/popup-preview.js
+++ b/ext/bg/js/settings/popup-preview.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * getOptionsContext
  * wanakana
  */
 
@@ -57,6 +58,23 @@ function showAppearancePreview() {
     customOuterCss.on('input', () => {
         const action = 'setCustomOuterCss';
         const params = {css: customOuterCss.val()};
+        frame.contentWindow.postMessage({action, params}, targetOrigin);
+    });
+
+    const updateOptionsContext = () => {
+        const action = 'updateOptionsContext';
+        const params = {
+            optionsContext: getOptionsContext()
+        };
+        frame.contentWindow.postMessage({action, params}, targetOrigin);
+    };
+    yomichan.on('modifyingProfileChange', updateOptionsContext);
+
+    frame.addEventListener('load', () => {
+        const action = 'prepare';
+        const params = {
+            optionsContext: getOptionsContext()
+        };
         frame.contentWindow.postMessage({action, params}, targetOrigin);
     });
 

--- a/ext/bg/js/settings/profiles.js
+++ b/ext/bg/js/settings/profiles.js
@@ -188,9 +188,10 @@ async function onTargetProfileChanged() {
     }
 
     currentProfileIndex = index;
-    yomichan.trigger('modifyingProfileChange');
 
     await profileOptionsUpdateTarget(optionsFull);
+
+    yomichan.trigger('modifyingProfileChange');
 }
 
 async function onProfileAdd() {
@@ -200,10 +201,11 @@ async function onProfileAdd() {
     optionsFull.profiles.push(profile);
 
     currentProfileIndex = optionsFull.profiles.length - 1;
-    yomichan.trigger('modifyingProfileChange');
 
     await profileOptionsUpdateTarget(optionsFull);
     await settingsSaveOptions();
+
+    yomichan.trigger('modifyingProfileChange');
 }
 
 async function onProfileRemove(e) {
@@ -242,6 +244,8 @@ async function onProfileRemoveConfirm() {
 
     await profileOptionsUpdateTarget(optionsFull);
     await settingsSaveOptions();
+
+    yomichan.trigger('modifyingProfileChange');
 }
 
 function onProfileNameChanged() {
@@ -264,10 +268,11 @@ async function onProfileMove(offset) {
     }
 
     currentProfileIndex = index;
-    yomichan.trigger('modifyingProfileChange');
 
     await profileOptionsUpdateTarget(optionsFull);
     await settingsSaveOptions();
+
+    yomichan.trigger('modifyingProfileChange');
 }
 
 async function onProfileCopy() {

--- a/ext/bg/js/settings/profiles.js
+++ b/ext/bg/js/settings/profiles.js
@@ -188,6 +188,7 @@ async function onTargetProfileChanged() {
     }
 
     currentProfileIndex = index;
+    yomichan.trigger('modifyingProfileChange');
 
     await profileOptionsUpdateTarget(optionsFull);
 }
@@ -197,7 +198,10 @@ async function onProfileAdd() {
     const profile = utilBackgroundIsolate(optionsFull.profiles[currentProfileIndex]);
     profile.name = profileOptionsCreateCopyName(profile.name, optionsFull.profiles, 100);
     optionsFull.profiles.push(profile);
+
     currentProfileIndex = optionsFull.profiles.length - 1;
+    yomichan.trigger('modifyingProfileChange');
+
     await profileOptionsUpdateTarget(optionsFull);
     await settingsSaveOptions();
 }
@@ -260,6 +264,7 @@ async function onProfileMove(offset) {
     }
 
     currentProfileIndex = index;
+    yomichan.trigger('modifyingProfileChange');
 
     await profileOptionsUpdateTarget(optionsFull);
     await settingsSaveOptions();

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -88,22 +88,19 @@ async function createPopupProxy(depth, id, parentFrameId) {
 
     let urlUpdatedAt = 0;
     let proxyHostUrlCached = url;
-    const getUrl = async () => {
-        if (proxy) {
-            const now = Date.now();
-            if (popups.proxy !== null && now - urlUpdatedAt > 500) {
-                proxyHostUrlCached = await popups.proxy.getHostUrl();
-                urlUpdatedAt = now;
-            }
-            return proxyHostUrlCached;
+    const getProxyHostUrl = async () => {
+        const now = Date.now();
+        if (popups.proxy !== null && now - urlUpdatedAt > 500) {
+            proxyHostUrlCached = await popups.proxy.getHostUrl();
+            urlUpdatedAt = now;
         }
-        return window.location.href;
+        return proxyHostUrlCached;
     };
 
     const applyOptions = async () => {
         const optionsContext = {
             depth: isSearchPage ? 0 : depth,
-            url: await getUrl()
+            url: proxy ? await getProxyHostUrl() : window.location.href
         };
         const options = await apiOptionsGet(optionsContext);
 
@@ -125,6 +122,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
         }
 
         if (frontend === null) {
+            const getUrl = proxy ? getProxyHostUrl : null;
             frontend = new Frontend(popup, getUrl);
             frontendPreparePromise = frontend.prepare();
             await frontendPreparePromise;

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -86,8 +86,21 @@ async function createPopupProxy(depth, id, parentFrameId) {
         applyOptions();
     };
 
+    const getUrl = async () => {
+        if (proxy) {
+            if (popups.proxy !== null) {
+                return await popups.proxy.getHostUrl();
+            }
+            return url;
+        }
+        return window.location.href;
+    };
+
     const applyOptions = async () => {
-        const optionsContext = {depth: isSearchPage ? 0 : depth, url};
+        const optionsContext = {
+            depth: isSearchPage ? 0 : depth,
+            url: await getUrl()
+        };
         const options = await apiOptionsGet(optionsContext);
 
         if (!proxy && frameOffsetForwarder === null) {
@@ -108,7 +121,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
         }
 
         if (frontend === null) {
-            frontend = new Frontend(popup, url);
+            frontend = new Frontend(popup, getUrl);
             frontendPreparePromise = frontend.prepare();
             await frontendPreparePromise;
         } else {

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -25,7 +25,7 @@
  * apiOptionsGet
  */
 
-async function createIframePopupProxy(url, frameOffsetForwarder, setDisabled) {
+async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
     const rootPopupInformationPromise = yomichan.getTemporaryListenerResult(
         chrome.runtime.onMessage,
         ({action, params}, {resolve}) => {
@@ -39,7 +39,7 @@ async function createIframePopupProxy(url, frameOffsetForwarder, setDisabled) {
 
     const getFrameOffset = frameOffsetForwarder.getOffset.bind(frameOffsetForwarder);
 
-    const popup = new PopupProxy(popupId, 0, null, frameId, url, getFrameOffset, setDisabled);
+    const popup = new PopupProxy(popupId, 0, null, frameId, getFrameOffset, setDisabled);
     await popup.prepare();
 
     return popup;
@@ -54,8 +54,8 @@ async function getOrCreatePopup(depth) {
     return popup;
 }
 
-async function createPopupProxy(depth, id, parentFrameId, url) {
-    const popup = new PopupProxy(null, depth + 1, id, parentFrameId, url);
+async function createPopupProxy(depth, id, parentFrameId) {
+    const popup = new PopupProxy(null, depth + 1, id, parentFrameId);
     await popup.prepare();
 
     return popup;
@@ -97,10 +97,10 @@ async function createPopupProxy(depth, id, parentFrameId, url) {
 
         let popup;
         if (isIframe && options.general.showIframePopupsInRootFrame && DOM.getFullscreenElement() === null && iframePopupsInRootFrameAvailable) {
-            popup = popups.iframe || await createIframePopupProxy(url, frameOffsetForwarder, disableIframePopupsInRootFrame);
+            popup = popups.iframe || await createIframePopupProxy(frameOffsetForwarder, disableIframePopupsInRootFrame);
             popups.iframe = popup;
         } else if (proxy) {
-            popup = popups.proxy || await createPopupProxy(depth, id, parentFrameId, url);
+            popup = popups.proxy || await createPopupProxy(depth, id, parentFrameId);
             popups.proxy = popup;
         } else {
             popup = popups.normal || await getOrCreatePopup(depth);
@@ -108,7 +108,7 @@ async function createPopupProxy(depth, id, parentFrameId, url) {
         }
 
         if (frontend === null) {
-            frontend = new Frontend(popup);
+            frontend = new Frontend(popup, url);
             frontendPreparePromise = frontend.prepare();
             await frontendPreparePromise;
         } else {

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -86,12 +86,16 @@ async function createPopupProxy(depth, id, parentFrameId) {
         applyOptions();
     };
 
+    let urlUpdatedAt = 0;
+    let proxyHostUrlCached = url;
     const getUrl = async () => {
         if (proxy) {
-            if (popups.proxy !== null) {
-                return await popups.proxy.getHostUrl();
+            const now = Date.now();
+            if (popups.proxy !== null && now - urlUpdatedAt > 500) {
+                proxyHostUrlCached = await popups.proxy.getHostUrl();
+                urlUpdatedAt = now;
             }
-            return url;
+            return proxyHostUrlCached;
         }
         return window.location.href;
     };

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -68,6 +68,7 @@ class DisplayFloat extends Display {
         this.optionsContext = optionsContext;
 
         await super.prepare();
+        await this.updateOptions();
 
         if (childrenSupported) {
             const {depth, url} = optionsContext;

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -29,11 +29,6 @@ class DisplayFloat extends Display {
 
         this._popupId = null;
 
-        this.optionsContext = {
-            depth: 0,
-            url: window.location.href
-        };
-
         this._orphaned = false;
         this._prepareInvoked = false;
         this._messageToken = null;
@@ -51,10 +46,11 @@ class DisplayFloat extends Display {
         ]);
 
         this._windowMessageHandlers = new Map([
+            ['setOptionsContext', ({optionsContext}) => this.setOptionsContext(optionsContext)],
             ['setContent', ({type, details}) => this.setContent(type, details)],
             ['clearAutoPlayTimer', () => this.clearAutoPlayTimer()],
             ['setCustomCss', ({css}) => this.setCustomCss(css)],
-            ['prepare', ({popupInfo, url, childrenSupported, scale}) => this.prepare(popupInfo, url, childrenSupported, scale)],
+            ['prepare', ({popupInfo, optionsContext, childrenSupported, scale}) => this.prepare(popupInfo, optionsContext, childrenSupported, scale)],
             ['setContentScale', ({scale}) => this.setContentScale(scale)]
         ]);
 
@@ -62,18 +58,19 @@ class DisplayFloat extends Display {
         window.addEventListener('message', this.onMessage.bind(this), false);
     }
 
-    async prepare(popupInfo, url, childrenSupported, scale) {
+    async prepare(popupInfo, optionsContext, childrenSupported, scale) {
         if (this._prepareInvoked) { return; }
         this._prepareInvoked = true;
 
-        const {id, depth, parentFrameId} = popupInfo;
+        const {id, parentFrameId} = popupInfo;
         this._popupId = id;
-        this.optionsContext.depth = depth;
-        this.optionsContext.url = url;
+
+        this.optionsContext = optionsContext;
 
         await super.prepare();
 
         if (childrenSupported) {
+            const {depth, url} = optionsContext;
             popupNestedInitialize(id, depth, parentFrameId, url);
         }
 
@@ -156,6 +153,11 @@ class DisplayFloat extends Display {
             window.clearTimeout(this.autoPlayAudioTimer);
             this.autoPlayAudioTimer = null;
         }
+    }
+
+    async setOptionsContext(optionsContext) {
+        this.optionsContext = optionsContext;
+        await this.updateOptions();
     }
 
     setContentScale(scale) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -33,6 +33,8 @@ class Frontend extends TextScanner {
             [(x, y) => this.popup.containsPoint(x, y)]
         );
 
+        this._id = yomichan.generateId(16);
+
         this.popup = popup;
 
         this._url = url;
@@ -141,7 +143,7 @@ class Frontend extends TextScanner {
         this.onSearchClear(false);
         this.popup = popup;
         await popup.setOptions(this.options);
-        await popup.setOptionsContext(this.getOptionsContext());
+        await popup.setOptionsContext(this.getOptionsContext(), this._id);
     }
 
     async updateOptions() {
@@ -155,7 +157,7 @@ class Frontend extends TextScanner {
         this.ignoreNodes = ignoreNodes.join(',');
 
         await this.popup.setOptions(this.options);
-        await this.popup.setOptionsContext(this.getOptionsContext());
+        await this.popup.setOptionsContext(this.getOptionsContext(), this._id);
 
         this._updateContentScale();
 
@@ -248,11 +250,13 @@ class Frontend extends TextScanner {
     }
 
     _showPopupContent(textSource, type=null, details=null) {
+        const context = {optionsContext: this.getOptionsContext(), source: this._id};
         this._lastShowPromise = this.popup.showContent(
             textSource.getRect(),
             textSource.getWritingMode(),
             type,
-            details
+            details,
+            context
         );
         return this._lastShowPromise;
     }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -142,7 +142,6 @@ class Frontend extends TextScanner {
     async setPopup(popup) {
         this.onSearchClear(false);
         this.popup = popup;
-        await popup.setOptions(this.options);
         await popup.setOptionsContext(this.getOptionsContext(), this._id);
     }
 
@@ -156,7 +155,6 @@ class Frontend extends TextScanner {
         }
         this.ignoreNodes = ignoreNodes.join(',');
 
-        await this.popup.setOptions(this.options);
         await this.popup.setOptionsContext(this.getOptionsContext(), this._id);
 
         this._updateContentScale();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -26,7 +26,7 @@
  */
 
 class Frontend extends TextScanner {
-    constructor(popup) {
+    constructor(popup, url) {
         super(
             window,
             () => this.popup.isProxy() ? [] : [this.popup.getContainer()],
@@ -35,14 +35,11 @@ class Frontend extends TextScanner {
 
         this.popup = popup;
 
+        this._url = url;
+
         this._disabledOverride = false;
 
         this.options = null;
-
-        this.optionsContext = {
-            depth: popup.depth,
-            url: popup.url
-        };
 
         this._pageZoomFactor = 1.0;
         this._contentScale = 1.0;
@@ -144,6 +141,7 @@ class Frontend extends TextScanner {
         this.onSearchClear(false);
         this.popup = popup;
         await popup.setOptions(this.options);
+        await popup.setOptionsContext(this.getOptionsContext());
     }
 
     async updateOptions() {
@@ -157,6 +155,7 @@ class Frontend extends TextScanner {
         this.ignoreNodes = ignoreNodes.join(',');
 
         await this.popup.setOptions(this.options);
+        await this.popup.setOptionsContext(this.getOptionsContext());
 
         this._updateContentScale();
 
@@ -198,11 +197,10 @@ class Frontend extends TextScanner {
 
     showContent(textSource, focus, definitions, type) {
         const sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
-        const url = window.location.href;
         this._showPopupContent(
             textSource,
             type,
-            {definitions, context: {sentence, url, focus, disableHistory: true}}
+            {definitions, context: {sentence, url: this._url, focus, disableHistory: true}}
         );
     }
 
@@ -243,8 +241,10 @@ class Frontend extends TextScanner {
     }
 
     getOptionsContext() {
-        this.optionsContext.url = this.popup.url;
-        return this.optionsContext;
+        return {
+            depth: this.popup.depth,
+            url: this._url
+        };
     }
 
     _showPopupContent(textSource, type=null, details=null) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -38,6 +38,7 @@ class PopupProxyHost {
         this._apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
             ['getOrCreatePopup', this._onApiGetOrCreatePopup.bind(this)],
             ['setOptions', this._onApiSetOptions.bind(this)],
+            ['setOptionsContext', this._onApiSetOptionsContext.bind(this)],
             ['hide', this._onApiHide.bind(this)],
             ['isVisible', this._onApiIsVisibleAsync.bind(this)],
             ['setVisibleOverride', this._onApiSetVisibleOverride.bind(this)],
@@ -106,6 +107,11 @@ class PopupProxyHost {
     async _onApiSetOptions({id, options}) {
         const popup = this._getPopup(id);
         return await popup.setOptions(options);
+    }
+
+    async _onApiSetOptionsContext({id, optionsContext}) {
+        const popup = this._getPopup(id);
+        return await popup.setOptionsContext(optionsContext);
     }
 
     async _onApiHide({id, changeFocus}) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -37,7 +37,6 @@ class PopupProxyHost {
 
         this._apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
             ['getOrCreatePopup', this._onApiGetOrCreatePopup.bind(this)],
-            ['setOptions', this._onApiSetOptions.bind(this)],
             ['setOptionsContext', this._onApiSetOptionsContext.bind(this)],
             ['hide', this._onApiHide.bind(this)],
             ['isVisible', this._onApiIsVisibleAsync.bind(this)],
@@ -102,11 +101,6 @@ class PopupProxyHost {
         return {
             id: popup.id
         };
-    }
-
-    async _onApiSetOptions({id, options}) {
-        const popup = this._getPopup(id);
-        return await popup.setOptions(options);
     }
 
     async _onApiSetOptionsContext({id, optionsContext, source}) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -109,9 +109,9 @@ class PopupProxyHost {
         return await popup.setOptions(options);
     }
 
-    async _onApiSetOptionsContext({id, optionsContext}) {
+    async _onApiSetOptionsContext({id, optionsContext, source}) {
         const popup = this._getPopup(id);
-        return await popup.setOptionsContext(optionsContext);
+        return await popup.setOptionsContext(optionsContext, source);
     }
 
     async _onApiHide({id, changeFocus}) {
@@ -135,11 +135,11 @@ class PopupProxyHost {
         return await popup.containsPoint(x, y);
     }
 
-    async _onApiShowContent({id, elementRect, writingMode, type, details}) {
+    async _onApiShowContent({id, elementRect, writingMode, type, details, context}) {
         const popup = this._getPopup(id);
         elementRect = PopupProxyHost._convertJsonRectToDOMRect(popup, elementRect);
         if (!PopupProxyHost._popupCanShow(popup)) { return; }
-        return await popup.showContent(elementRect, writingMode, type, details);
+        return await popup.showContent(elementRect, writingMode, type, details, context);
     }
 
     async _onApiSetCustomCss({id, css}) {

--- a/ext/fg/js/popup-proxy-host.js
+++ b/ext/fg/js/popup-proxy-host.js
@@ -45,7 +45,8 @@ class PopupProxyHost {
             ['showContent', this._onApiShowContent.bind(this)],
             ['setCustomCss', this._onApiSetCustomCss.bind(this)],
             ['clearAutoPlayTimer', this._onApiClearAutoPlayTimer.bind(this)],
-            ['setContentScale', this._onApiSetContentScale.bind(this)]
+            ['setContentScale', this._onApiSetContentScale.bind(this)],
+            ['getHostUrl', this._onApiGetHostUrl.bind(this)]
         ]));
     }
 
@@ -149,6 +150,10 @@ class PopupProxyHost {
     async _onApiSetContentScale({id, scale}) {
         const popup = this._getPopup(id);
         return popup.setContentScale(scale);
+    }
+
+    async _onApiGetHostUrl() {
+        return window.location.href;
     }
 
     // Private functions

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -20,12 +20,11 @@
  */
 
 class PopupProxy {
-    constructor(id, depth, parentId, parentFrameId, url, getFrameOffset=null, setDisabled=null) {
+    constructor(id, depth, parentId, parentFrameId, getFrameOffset=null, setDisabled=null) {
         this._parentId = parentId;
         this._parentFrameId = parentFrameId;
         this._id = id;
         this._depth = depth;
-        this._url = url;
         this._apiSender = new FrontendApiSender();
         this._getFrameOffset = getFrameOffset;
         this._setDisabled = setDisabled;
@@ -49,10 +48,6 @@ class PopupProxy {
         return this._depth;
     }
 
-    get url() {
-        return this._url;
-    }
-
     // Public functions
 
     async prepare() {
@@ -66,6 +61,10 @@ class PopupProxy {
 
     async setOptions(options) {
         return await this._invokeHostApi('setOptions', {id: this._id, options});
+    }
+
+    async setOptionsContext(optionsContext) {
+        return await this._invokeHostApi('setOptionsContext', {id: this._id, optionsContext});
     }
 
     hide(changeFocus) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -63,8 +63,8 @@ class PopupProxy {
         return await this._invokeHostApi('setOptions', {id: this._id, options});
     }
 
-    async setOptionsContext(optionsContext) {
-        return await this._invokeHostApi('setOptionsContext', {id: this._id, optionsContext});
+    async setOptionsContext(optionsContext, source) {
+        return await this._invokeHostApi('setOptionsContext', {id: this._id, optionsContext, source});
     }
 
     hide(changeFocus) {
@@ -87,14 +87,14 @@ class PopupProxy {
         return await this._invokeHostApi('containsPoint', {id: this._id, x, y});
     }
 
-    async showContent(elementRect, writingMode, type=null, details=null) {
+    async showContent(elementRect, writingMode, type, details, context) {
         let {x, y, width, height} = elementRect;
         if (this._getFrameOffset !== null) {
             await this._updateFrameOffset();
             [x, y] = this._applyFrameOffset(x, y);
         }
         elementRect = {x, y, width, height};
-        return await this._invokeHostApi('showContent', {id: this._id, elementRect, writingMode, type, details});
+        return await this._invokeHostApi('showContent', {id: this._id, elementRect, writingMode, type, details, context});
     }
 
     async setCustomCss(css) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -105,6 +105,10 @@ class PopupProxy {
         this._invokeHostApi('setContentScale', {id: this._id, scale});
     }
 
+    async getHostUrl() {
+        return await this._invokeHostApi('getHostUrl', {});
+    }
+
     // Private
 
     _invokeHostApi(action, params={}) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -59,10 +59,6 @@ class PopupProxy {
         return true;
     }
 
-    async setOptions(options) {
-        return await this._invokeHostApi('setOptions', {id: this._id, options});
-    }
-
     async setOptionsContext(optionsContext, source) {
         return await this._invokeHostApi('setOptionsContext', {id: this._id, optionsContext, source});
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -33,6 +33,7 @@ class Popup {
         this._visible = false;
         this._visibleOverride = null;
         this._options = null;
+        this._optionsContext = null;
         this._contentScale = 1.0;
         this._containerSizeContentScale = null;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
@@ -72,10 +73,6 @@ class Popup {
         return this._frameId;
     }
 
-    get url() {
-        return window.location.href;
-    }
-
     // Public functions
 
     isProxy() {
@@ -85,6 +82,11 @@ class Popup {
     async setOptions(options) {
         this._options = options;
         this.updateTheme();
+    }
+
+    async setOptionsContext(optionsContext) {
+        this._optionsContext = optionsContext;
+        this._invokeApi('setOptionsContext', {optionsContext});
     }
 
     hide(changeFocus) {
@@ -219,10 +221,9 @@ class Popup {
             this._invokeApi('prepare', {
                 popupInfo: {
                     id: this._id,
-                    depth: this._depth,
                     parentFrameId
                 },
-                url: this.url,
+                optionsContext: this._optionsContext,
                 childrenSupported: this._childrenSupported,
                 scale: this._contentScale
             });

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -19,6 +19,7 @@
  * DOM
  * apiGetMessageToken
  * apiInjectStylesheet
+ * apiOptionsGet
  */
 
 class Popup {
@@ -80,14 +81,13 @@ class Popup {
         return false;
     }
 
-    async setOptions(options) {
-        this._options = options;
-        this.updateTheme();
-    }
-
     async setOptionsContext(optionsContext, source) {
         this._optionsContext = optionsContext;
         this._previousOptionsContextSource = source;
+
+        this._options = await apiOptionsGet(optionsContext);
+        this.updateTheme();
+
         this._invokeApi('setOptionsContext', {optionsContext});
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -38,6 +38,7 @@ class Popup {
         this._containerSizeContentScale = null;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
         this._messageToken = null;
+        this._previousOptionsContextSource = null;
 
         this._container = document.createElement('iframe');
         this._container.className = 'yomichan-float';
@@ -84,8 +85,9 @@ class Popup {
         this.updateTheme();
     }
 
-    async setOptionsContext(optionsContext) {
+    async setOptionsContext(optionsContext, source) {
         this._optionsContext = optionsContext;
+        this._previousOptionsContextSource = source;
         this._invokeApi('setOptionsContext', {optionsContext});
     }
 
@@ -122,8 +124,14 @@ class Popup {
         return false;
     }
 
-    async showContent(elementRect, writingMode, type=null, details=null) {
+    async showContent(elementRect, writingMode, type, details, context) {
         if (this._options === null) { throw new Error('Options not assigned'); }
+
+        const {optionsContext, source} = context;
+        if (source !== this._previousOptionsContextSource) {
+            await this.setOptionsContext(optionsContext, source);
+        }
+
         await this._show(elementRect, writingMode);
         if (type === null) { return; }
         this._invokeApi('setContent', {type, details});

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -177,8 +177,6 @@ class Display {
     async prepare() {
         await yomichan.prepare();
         await this.displayGenerator.prepare();
-        await this.updateOptions();
-        yomichan.on('optionsUpdated', () => this.updateOptions());
     }
 
     onError(_error) {


### PR DESCRIPTION
Resolves https://github.com/FooSoft/yomichan/issues/452.

Now setting `optionsContext` to `Popup` and `DisplayFloat` means also updating options. Because both use `optionsContext` separately from the `options` object, I simplified the code so that new options are fetched by the classes themselves. A bit different from the discussion in #452, but I thought it makes more sense this way.

Each time `optionsContext` is set to a `Popup`, it comes along with the unique ID of the `Frontend` that set it. This is needed when the `Frontend` using the `Popup` changes. For performance reasons, it's sent along with `Popup.showContent` arguments when scanning, but otherwise using `Popup.setOptionsContext`. Scanning checks if the `Frontend` ID has changed, but explicit calls don't because they're meant to be done only when the options can be expected to have changed.