### PR TITLE
Fix high pitch calculation

### DIFF
--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -116,7 +116,11 @@ const jp = (() => {
     // Mora functions
 
     function isMoraPitchHigh(moraIndex, pitchAccentPosition) {
-        return pitchAccentPosition === 0 ? (moraIndex > 0) : (moraIndex < pitchAccentPosition);
+        switch (pitchAccentPosition) {
+            case 0: return (moraIndex > 0);
+            case 1: return (moraIndex < 1);
+            default: return (moraIndex > 0 && moraIndex < pitchAccentPosition);
+        }
     }
 
     function getKanaMorae(text) {

--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -434,17 +434,17 @@ function testIsMoraPitchHigh() {
         [[2, 1], false],
         [[3, 1], false],
 
-        [[0, 2], true],
+        [[0, 2], false],
         [[1, 2], true],
         [[2, 2], false],
         [[3, 2], false],
 
-        [[0, 3], true],
+        [[0, 3], false],
         [[1, 3], true],
         [[2, 3], true],
         [[3, 3], false],
 
-        [[0, 4], true],
+        [[0, 4], false],
         [[1, 4], true],
         [[2, 4], true],
         [[3, 4], true]


### PR DESCRIPTION
Fixes #469.

I created [this](https://toasted-nutbread.github.io/japanese-pitch-accent-table/) for testing, which contains data which comes up in Google searches for "[Japanese pitch accent table](https://www.google.com/search?q=Japanese+pitch+accent+table&tbm=isch)". https://imgur.com/oEjxhWU