### PR TITLE
Api invoke with progress

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -115,7 +115,8 @@ class Backend {
             ['purgeDatabase', {handler: this._onApiPurgeDatabase.bind(this), async: true}],
             ['getMedia', {handler: this._onApiGetMedia.bind(this), async: true}],
             ['log', {handler: this._onApiLog.bind(this), async: false}],
-            ['logIndicatorClear', {handler: this._onApiLogIndicatorClear.bind(this), async: false}]
+            ['logIndicatorClear', {handler: this._onApiLogIndicatorClear.bind(this), async: false}],
+            ['createActionPort', {handler: this._onApiCreateActionPort.bind(this), async: false}]
         ]);
 
         this._commandHandlers = new Map([
@@ -784,6 +785,26 @@ class Backend {
         if (this._logErrorLevel === null) { return; }
         this._logErrorLevel = null;
         this._updateBadge();
+    }
+
+    _onApiCreateActionPort(params, sender) {
+        let tabId;
+        if (!(
+            sender &&
+            sender.tab &&
+            (typeof (tabId = sender.tab.id)) === 'number'
+        )) {
+            throw new Error('Invalid sender');
+        }
+
+        const frameId = sender.frameId;
+        const id = yomichan.generateId(16);
+        const portName = `action-port-${id}`;
+
+        chrome.tabs.connect(tabId, {name: portName, frameId});
+        // TODO : setup handlers
+
+        return portName;
     }
 
     // Command handlers

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -118,6 +118,7 @@ class Backend {
             ['logIndicatorClear', {handler: this._onApiLogIndicatorClear.bind(this), async: false}],
             ['createActionPort', {handler: this._onApiCreateActionPort.bind(this), async: false}]
         ]);
+        this._messageHandlersWithProgress = new Map();
 
         this._commandHandlers = new Map([
             ['search', this._onCommandSearch.bind(this)],
@@ -801,13 +802,69 @@ class Backend {
         const id = yomichan.generateId(16);
         const portName = `action-port-${id}`;
 
-        chrome.tabs.connect(tabId, {name: portName, frameId});
-        // TODO : setup handlers
+        const port = chrome.tabs.connect(tabId, {name: portName, frameId});
+        try {
+            this._createActionListenerPort(port, sender, this._messageHandlersWithProgress);
+        } catch (e) {
+            port.disconnect();
+            throw e;
+        }
 
         return portName;
     }
 
     // Command handlers
+
+    _createActionListenerPort(port, sender, handlers) {
+        let hasStarted = false;
+
+        const onProgress = (data) => {
+            try {
+                if (port === null) { return; }
+                port.postMessage({type: 'progress', data});
+            } catch (e) {
+                // NOP
+            }
+        };
+
+        const onMessage = async ({action, params}) => {
+            if (hasStarted) { return; }
+            hasStarted = true;
+            port.onMessage.removeListener(onMessage);
+
+            try {
+                port.postMessage({type: 'ack'});
+
+                const messageHandler = handlers.get(action);
+                if (typeof messageHandler === 'undefined') {
+                    throw new Error('Invalid action');
+                }
+                const {handler, async} = messageHandler;
+
+                const promiseOrResult = handler(params, sender, onProgress);
+                const result = async ? await promiseOrResult : promiseOrResult;
+                port.postMessage({type: 'complete', data: result});
+            } catch (e) {
+                if (port !== null) {
+                    port.postMessage({type: 'error', data: e});
+                }
+                cleanup();
+            }
+        };
+
+        const cleanup = () => {
+            if (port === null) { return; }
+            if (!hasStarted) {
+                port.onMessage.removeListener(onMessage);
+            }
+            port.onDisconnect.removeListener(cleanup);
+            port = null;
+            handlers = null;
+        };
+
+        port.onMessage.addListener(onMessage);
+        port.onDisconnect.addListener(cleanup);
+    }
 
     _getErrorLevelValue(errorLevel) {
         switch (errorLevel) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -789,14 +789,9 @@ class Backend {
     }
 
     _onApiCreateActionPort(params, sender) {
-        let tabId;
-        if (!(
-            sender &&
-            sender.tab &&
-            (typeof (tabId = sender.tab.id)) === 'number'
-        )) {
-            throw new Error('Invalid sender');
-        }
+        if (!sender || !sender.tab) { throw new Error('Invalid sender'); }
+        const tabId = sender.tab.id;
+        if (typeof tabId !== 'number') { throw new Error('Sender has invalid tab ID'); }
 
         const frameId = sender.frameId;
         const id = yomichan.generateId(16);

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -152,6 +152,48 @@ function apiLogIndicatorClear() {
     return _apiInvoke('logIndicatorClear');
 }
 
+function _apiCreateActionPort(timeout=5000) {
+    return new Promise((resolve, reject) => {
+        let timer = null;
+        let portNameResolve;
+        let portNameReject;
+        const portNamePromise = new Promise((resolve2, reject2) => {
+            portNameResolve = resolve2;
+            portNameReject = reject2;
+        });
+
+        const onConnect = async (port) => {
+            try {
+                const portName = await portNamePromise;
+                if (port.name !== portName || timer === null) { return; }
+            } catch (e) {
+                return;
+            }
+
+            clearTimeout(timer);
+            timer = null;
+
+            chrome.runtime.onConnect.removeListener(onConnect);
+            resolve(port);
+        };
+
+        const onError = (e) => {
+            if (timer !== null) {
+                clearTimeout(timer);
+                timer = null;
+            }
+            chrome.runtime.onConnect.removeListener(onConnect);
+            portNameReject(e);
+            reject(e);
+        };
+
+        timer = setTimeout(() => onError(new Error('Timeout')), timeout);
+
+        chrome.runtime.onConnect.addListener(onConnect);
+        _apiInvoke('createActionPort').then(portNameResolve, onError);
+    });
+}
+
 function _apiInvoke(action, params={}) {
     const data = {action, params};
     return new Promise((resolve, reject) => {


### PR DESCRIPTION
In order to convert [some of the remaining `util*` functions](https://github.com/FooSoft/yomichan/blob/a49e4ccc4e5c7defb30bd88535c18137acf9812c/ext/bg/js/util.js#L69-L83) that use `utilBackend` into `api*` functions, it is necessary to have a mechanism for `api` calls with progress callbacks. This change implements such a mechanism.

The mechanism works using two steps:
1. The frontend sends a request to the backend to open a persistent communication [Port](https://developer.chrome.com/extensions/runtime#type-Port). The backend opens a port and initializes it with a handler map.
2. After the frontend receives this port, it sends an `{action, params}` message to that port. The port `ack`'s the message and then runs the handler. Progress messages are delivered to the port, as well as a completion or error message based on the execution of the handler.

This change does not implement any handlers, as I tried to keep the scope fairly limited.