### PR TITLE
Frontend refactor (part 1)

### DIFF
--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -84,11 +84,8 @@ class QueryParser extends TextScanner {
 
     getMouseEventListeners() {
         return [
-            [this.node, 'click', this.onClick.bind(this)],
-            [this.node, 'mousedown', this.onMouseDown.bind(this)],
-            [this.node, 'mousemove', this.onMouseMove.bind(this)],
-            [this.node, 'mouseover', this.onMouseOver.bind(this)],
-            [this.node, 'mouseout', this.onMouseOut.bind(this)]
+            ...super.getMouseEventListeners(),
+            [this.node, 'click', this.onClick.bind(this)]
         ];
     }
 

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -44,10 +44,6 @@ class QueryParser extends TextScanner {
         await this.queryParserGenerator.prepare();
     }
 
-    onError(error) {
-        yomichan.logError(error);
-    }
-
     onClick(e) {
         super.onClick(e);
         this.searchAt(e.clientX, e.clientY, 'click');

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -44,8 +44,7 @@ class QueryParser extends TextScanner {
         await this.queryParserGenerator.prepare();
     }
 
-    onClick(e) {
-        super.onClick(e);
+    onClick2(e) {
         this.searchAt(e.clientX, e.clientY, 'click');
     }
 
@@ -81,18 +80,7 @@ class QueryParser extends TextScanner {
     getMouseEventListeners() {
         return [
             ...super.getMouseEventListeners(),
-            [this.node, 'click', this.onClick.bind(this)]
-        ];
-    }
-
-    getTouchEventListeners() {
-        return [
-            [this.node, 'auxclick', this.onAuxClick.bind(this)],
-            [this.node, 'touchstart', this.onTouchStart.bind(this)],
-            [this.node, 'touchend', this.onTouchEnd.bind(this)],
-            [this.node, 'touchcancel', this.onTouchCancel.bind(this)],
-            [this.node, 'touchmove', this.onTouchMove.bind(this), {passive: false}],
-            [this.node, 'contextmenu', this.onContextMenu.bind(this)]
+            [this.node, 'click', this.onClick2.bind(this)]
         ];
     }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -125,7 +125,7 @@ class DisplaySearch extends Display {
         yomichan.logError(error);
     }
 
-    onSearchClear() {
+    onEscape() {
         if (this.query === null) {
             return;
         }

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -69,7 +69,7 @@ class SettingsPopupPreview {
 
         this.frontend.getOptionsContext = async () => this.optionsContext;
         this.frontend.setEnabled = () => {};
-        this.frontend.onSearchClear = () => {};
+        this.frontend.clearSelection = () => {};
 
         await this.frontend.prepare();
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -92,7 +92,7 @@ class DisplayFloat extends Display {
         this._orphaned = true;
     }
 
-    onSearchClear() {
+    onEscape() {
         window.parent.postMessage('popupClose', '*');
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -269,7 +269,9 @@ class Frontend extends TextScanner {
             contentScale /= this._pageZoomFactor;
         }
         if (popupScaleRelativeToVisualViewport) {
-            contentScale /= Frontend._getVisualViewportScale();
+            const visualViewport = window.visualViewport;
+            const visualViewportScale = (visualViewport !== null && typeof visualViewport === 'object' ? visualViewport.scale : 1.0);
+            contentScale /= visualViewportScale;
         }
         if (contentScale === this._contentScale) { return; }
 
@@ -301,10 +303,5 @@ class Frontend extends TextScanner {
         if (textSource !== null && await this.popup.isVisible()) {
             this._showPopupContent(textSource, await this.getOptionsContext());
         }
-    }
-
-    static _getVisualViewportScale() {
-        const visualViewport = window.visualViewport;
-        return visualViewport !== null && typeof visualViewport === 'object' ? visualViewport.scale : 1.0;
     }
 }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -84,7 +84,7 @@ class Frontend extends TextScanner {
             this._updateContentScale();
             this._broadcastRootPopupInformation();
         } catch (e) {
-            this.onError(e);
+            yomichan.logError(e);
         }
     }
 
@@ -188,7 +188,7 @@ class Frontend extends TextScanner {
                     this._showPopupContent(textSource, await this.getOptionsContext(), 'orphaned');
                 }
             } else {
-                this.onError(e);
+                yomichan.logError(e);
             }
         } finally {
             if (results === null && this.options.scanning.autoHideResults) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -49,7 +49,7 @@ class Frontend extends TextScanner {
         this._lastShowPromise = Promise.resolve();
 
         this._windowMessageHandlers = new Map([
-            ['popupClose', () => this.onSearchClear(true)],
+            ['popupClose', () => this.clearSelection(false)],
             ['selectionCopy', () => document.execCommand('copy')]
         ]);
 
@@ -78,6 +78,8 @@ class Frontend extends TextScanner {
             yomichan.on('optionsUpdated', this.updateOptions.bind(this));
             yomichan.on('zoomChanged', this.onZoomChanged.bind(this));
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
+
+            this.on('clearSelection', this.onClearSelection.bind(this));
 
             this._updateContentScale();
             this._broadcastRootPopupInformation();
@@ -140,7 +142,7 @@ class Frontend extends TextScanner {
     }
 
     async setPopup(popup) {
-        this.onSearchClear(false);
+        this.clearSelection(true);
         this.popup = popup;
         await popup.setOptionsContext(await this.getOptionsContext(), this._id);
     }
@@ -190,7 +192,7 @@ class Frontend extends TextScanner {
             }
         } finally {
             if (results === null && this.options.scanning.autoHideResults) {
-                this.onSearchClear(true);
+                this.clearSelection(false);
             }
         }
 
@@ -238,10 +240,9 @@ class Frontend extends TextScanner {
         return {definitions, type: 'kanji'};
     }
 
-    onSearchClear(changeFocus) {
-        this.popup.hide(changeFocus);
+    onClearSelection({passive}) {
+        this.popup.hide(!passive);
         this.popup.clearAutoPlayTimer();
-        super.onSearchClear(changeFocus);
     }
 
     async getOptionsContext() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -69,7 +69,7 @@ class Display {
 
         this._onKeyDownHandlers = new Map([
             ['Escape', () => {
-                this.onSearchClear();
+                this.onEscape();
                 return true;
             }],
             ['PageUp', (e) => {
@@ -183,7 +183,7 @@ class Display {
         throw new Error('Override me');
     }
 
-    onSearchClear() {
+    onEscape() {
         throw new Error('Override me');
     }
 

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -223,16 +223,11 @@ class TextScanner extends EventDispatcher {
     }
 
     setEnabled(enabled, canEnable) {
-        if (enabled && canEnable) {
-            if (!this.enabled) {
-                this.hookEvents();
-                this.enabled = true;
-            }
+        this.eventListeners.removeAllEventListeners();
+        this.enabled = enabled && canEnable;
+        if (this.enabled) {
+            this.hookEvents();
         } else {
-            if (this.enabled) {
-                this.eventListeners.removeAllEventListeners();
-                this.enabled = false;
-            }
             this.clearSelection(true);
         }
     }

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -33,6 +33,7 @@ class TextScanner extends EventDispatcher {
         this.scanTimerPromise = null;
         this.causeCurrent = null;
         this.textSourceCurrent = null;
+        this.textSourceCurrentSelected = false;
         this.pendingLookup = false;
         this.options = null;
 
@@ -301,10 +302,7 @@ class TextScanner extends EventDispatcher {
                 const result = await this.onSearchSource(textSource, cause);
                 if (result !== null) {
                     this.causeCurrent = cause;
-                    this.textSourceCurrent = textSource;
-                    if (this.options.scanning.selectText) {
-                        textSource.select();
-                    }
+                    this.setCurrentTextSource(textSource);
                 }
                 this.pendingLookup = false;
             } finally {
@@ -336,10 +334,11 @@ class TextScanner extends EventDispatcher {
 
     clearSelection(passive) {
         if (this.textSourceCurrent !== null) {
-            if (this.options.scanning.selectText) {
+            if (this.textSourceCurrentSelected) {
                 this.textSourceCurrent.deselect();
             }
             this.textSourceCurrent = null;
+            this.textSourceCurrentSelected = false;
         }
         this.trigger('clearSelection', {passive});
     }
@@ -349,7 +348,13 @@ class TextScanner extends EventDispatcher {
     }
 
     setCurrentTextSource(textSource) {
-        return this.textSourceCurrent = textSource;
+        this.textSourceCurrent = textSource;
+        if (this.options.scanning.selectText) {
+            this.textSourceCurrent.select();
+            this.textSourceCurrentSelected = true;
+        } else {
+            this.textSourceCurrentSelected = false;
+        }
     }
 
     static isScanningModifierPressed(scanningModifier, mouseEvent) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -202,10 +202,6 @@ class TextScanner extends EventDispatcher {
         throw new Error('Override me');
     }
 
-    onError(error) {
-        yomichan.logError(error);
-    }
-
     async scanTimerWait() {
         const delay = this.options.scanning.delay;
         const promise = promiseTimeout(delay, true);
@@ -311,7 +307,7 @@ class TextScanner extends EventDispatcher {
                 }
             }
         } catch (e) {
-            this.onError(e);
+            yomichan.logError(e);
         }
     }
 

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -21,8 +21,9 @@
  * docRangeFromPoint
  */
 
-class TextScanner {
+class TextScanner extends EventDispatcher {
     constructor(node, ignoreElements, ignorePoints) {
+        super();
         this.node = node;
         this.ignoreElements = ignoreElements;
         this.ignorePoints = ignorePoints;
@@ -92,7 +93,7 @@ class TextScanner {
 
         if (DOM.isMouseButtonDown(e, 'primary')) {
             this.scanTimerClear();
-            this.onSearchClear(true);
+            this.clearSelection(false);
         }
     }
 
@@ -235,7 +236,7 @@ class TextScanner {
                 this.eventListeners.removeAllEventListeners();
                 this.enabled = false;
             }
-            this.onSearchClear(false);
+            this.clearSelection(true);
         }
     }
 
@@ -333,13 +334,14 @@ class TextScanner {
         }
     }
 
-    onSearchClear(_) {
+    clearSelection(passive) {
         if (this.textSourceCurrent !== null) {
             if (this.options.scanning.selectText) {
                 this.textSourceCurrent.deselect();
             }
             this.textSourceCurrent = null;
         }
+        this.trigger('clearSelection', {passive});
     }
 
     getCurrentTextSource() {


### PR DESCRIPTION
This is kind of a follow up of #467, #481, and https://github.com/FooSoft/yomichan/pull/464#issuecomment-618715392. This will likely be a multi-part process, as mentioned in #480. It should make the overall changes easier to digest since there are fewer at once.

This change is intended to begin some refactoring of the `Frontend`, `TextScanner`, and `QueryParser` classes. These are a few of the remaining classes which haven't been covered by #258 yet, so the effort is moving towards that end as well.

* `_getVisualViewportScale` removed and inlined.
  This code was only used once, so it wasn't a big deal. Part of the effort of reducing the use of private statics.
* `QueryParser.getMouseEventListeners` implementation updated to match `Frontend`'s.
* `QueryParser.getTouchEventListeners` override removed.
  The custom `onClick` override has been renamed to avoid a naming collision and has been updated in `getMouseEventListeners`.
* `Display.onSearchClear` renamed to `onEscape`.
  Improved semantics which more accurately reflect what is occurring. It never really clears any search. This was modified because it eventually resulted in calling `TextScanner.onSearchClear`.
* `TextScanner.onSearchClear` renamed to `clearSelection`.
  Improved semantics because this was not used exclusively an event handler. Added an `'clearSelection'` event to support subclasses adding custom behaviour (closing popup).
* Text is now deselected only if it was selected initially.
  Technically the option value for `this.options.scanning.selectText` could change during the time between selection and deselection. This makes the deselection only occur if a corresponding selection actually occurred.
* `onError` custom handlers replaced with `yomichan.logError`.
  At least with the current use cases, there isn't really any reason to have an overridable `onError` instead of just `yomichan.logError` everywhere. This simplifies the code a bit; less jumping around when reading what's going on.