### PR TITLE
Remove Frontend inheritance

### DIFF
--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -86,6 +86,7 @@ class QueryParser extends TextScanner {
 
     setOptions(options) {
         super.setOptions(options);
+        super.setEnabled(true);
         this.queryParser.dataset.termSpacing = `${options.parsing.termSpacing}`;
     }
 

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -66,11 +66,10 @@ class SettingsPopupPreview {
         this.popup.setCustomOuterCss = this.popupSetCustomOuterCss.bind(this);
 
         this.frontend = new Frontend(this.popup);
-
         this.frontend.getOptionsContext = async () => this.optionsContext;
-        this.frontend.setDisabledOverride(true);
-
         await this.frontend.prepare();
+        this.frontend.setDisabledOverride(true);
+        this.frontend.canClearSelection = false;
 
         // Update search
         this.updateSearch();

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -68,8 +68,7 @@ class SettingsPopupPreview {
         this.frontend = new Frontend(this.popup);
 
         this.frontend.getOptionsContext = async () => this.optionsContext;
-        this.frontend.setEnabled = () => {};
-        this.frontend.clearSelection = () => {};
+        this.frontend.setDisabledOverride(true);
 
         await this.frontend.prepare();
 
@@ -169,8 +168,7 @@ class SettingsPopupPreview {
         const source = new TextSourceRange(range, range.toString(), null, null);
 
         try {
-            await this.frontend.onSearchSource(source, 'script');
-            this.frontend.setCurrentTextSource(source);
+            await this.frontend.setTextSource(source);
         } finally {
             source.cleanup();
         }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -62,6 +62,14 @@ class Frontend {
         ]);
     }
 
+    get canClearSelection() {
+        return this._textScanner.canClearSelection;
+    }
+
+    set canClearSelection(value) {
+        this._textScanner.canClearSelection = value;
+    }
+
     async prepare() {
         try {
             await this.updateOptions();
@@ -268,7 +276,6 @@ class Frontend {
 
     _updateTextScannerEnabled() {
         const enabled = (
-            this._options !== null &&
             this._options.general.enable &&
             this.popup.depth <= this._options.scanning.popupNestingMaxDepth &&
             !this._disabledOverride

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -35,7 +35,7 @@ class Frontend {
 
         this._disabledOverride = false;
 
-        this.options = null;
+        this._options = null;
 
         this._pageZoomFactor = 1.0;
         this._contentScale = 1.0;
@@ -144,12 +144,12 @@ class Frontend {
 
     async updateOptions() {
         const optionsContext = await this.getOptionsContext();
-        this.options = await apiOptionsGet(optionsContext);
-        this._textScanner.setOptions(this.options);
+        this._options = await apiOptionsGet(optionsContext);
+        this._textScanner.setOptions(this._options);
         this._updateTextScannerEnabled();
 
         const ignoreNodes = ['.scan-disable', '.scan-disable *'];
-        if (!this.options.scanning.enableOnPopupExpressions) {
+        if (!this._options.scanning.enableOnPopupExpressions) {
             ignoreNodes.push('.source-text', '.source-text *');
         }
         this._textScanner.ignoreNodes = ignoreNodes.join(',');
@@ -187,14 +187,14 @@ class Frontend {
             }
         } catch (e) {
             if (this._orphaned) {
-                if (textSource !== null && this.options.scanning.modifier !== 'none') {
+                if (textSource !== null && this._options.scanning.modifier !== 'none') {
                     this._showPopupContent(textSource, await this.getOptionsContext(), 'orphaned');
                 }
             } else {
                 yomichan.logError(e);
             }
         } finally {
-            if (results === null && this.options.scanning.autoHideResults) {
+            if (results === null && this._options.scanning.autoHideResults) {
                 this._textScanner.clearSelection(false);
             }
         }
@@ -204,7 +204,7 @@ class Frontend {
 
     showContent(textSource, focus, definitions, type, optionsContext) {
         const {url} = optionsContext;
-        const sentence = docSentenceExtract(textSource, this.options.anki.sentenceExt);
+        const sentence = docSentenceExtract(textSource, this._options.anki.sentenceExt);
         this._showPopupContent(
             textSource,
             optionsContext,
@@ -218,7 +218,7 @@ class Frontend {
     }
 
     async findTerms(textSource, optionsContext) {
-        this._textScanner.setTextSourceScanLength(textSource, this.options.scanning.length);
+        this._textScanner.setTextSourceScanLength(textSource, this._options.scanning.length);
 
         const searchText = textSource.text();
         if (searchText.length === 0) { return null; }
@@ -268,9 +268,9 @@ class Frontend {
 
     _updateTextScannerEnabled() {
         const enabled = (
-            this.options !== null &&
-            this.options.general.enable &&
-            this.popup.depth <= this.options.scanning.popupNestingMaxDepth &&
+            this._options !== null &&
+            this._options.general.enable &&
+            this.popup.depth <= this._options.scanning.popupNestingMaxDepth &&
             !this._disabledOverride
         );
         this._enabledEventListeners.removeAllEventListeners();
@@ -281,7 +281,7 @@ class Frontend {
     }
 
     _updateContentScale() {
-        const {popupScalingFactor, popupScaleRelativeToPageZoom, popupScaleRelativeToVisualViewport} = this.options.general;
+        const {popupScalingFactor, popupScaleRelativeToPageZoom, popupScaleRelativeToVisualViewport} = this._options.general;
         let contentScale = popupScalingFactor;
         if (popupScaleRelativeToPageZoom) {
             contentScale /= this._pageZoomFactor;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -48,7 +48,7 @@ class Frontend {
             () => this.popup.isProxy() ? [] : [this.popup.getContainer()],
             [(x, y) => this.popup.containsPoint(x, y)]
         );
-        this._textScanner.onSearchSource = (...args) => this.onSearchSource(...args);
+        this._textScanner.onSearchSource = this.onSearchSource.bind(this);
 
         this._windowMessageHandlers = new Map([
             ['popupClose', () => this._textScanner.clearSelection(false)],

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -139,8 +139,7 @@ class Frontend {
 
     setDisabledOverride(disabled) {
         this._disabledOverride = disabled;
-        if (this.options === null) { return; }
-        this._textScanner.setEnabled(this.options.general.enable, this._canEnable());
+        this._updateTextScannerEnabled();
     }
 
     async setPopup(popup) {
@@ -152,7 +151,8 @@ class Frontend {
     async updateOptions() {
         const optionsContext = await this.getOptionsContext();
         this.options = await apiOptionsGet(optionsContext);
-        this._textScanner.setOptions(this.options, this._canEnable());
+        this._textScanner.setOptions(this.options);
+        this._updateTextScannerEnabled();
 
         const ignoreNodes = ['.scan-disable', '.scan-disable *'];
         if (!this.options.scanning.enableOnPopupExpressions) {
@@ -272,6 +272,16 @@ class Frontend {
         return this._lastShowPromise;
     }
 
+    _updateTextScannerEnabled() {
+        const enabled = (
+            this.options !== null &&
+            this.options.general.enable &&
+            this.popup.depth <= this.options.scanning.popupNestingMaxDepth &&
+            !this._disabledOverride
+        );
+        this._textScanner.setEnabled(enabled);
+    }
+
     _updateContentScale() {
         const {popupScalingFactor, popupScaleRelativeToPageZoom, popupScaleRelativeToVisualViewport} = this.options.general;
         let contentScale = popupScalingFactor;
@@ -302,10 +312,6 @@ class Frontend {
             frameId: this.popup.frameId,
             title: document.title
         });
-    }
-
-    _canEnable() {
-        return this.popup.depth <= this.options.scanning.popupNestingMaxDepth && !this._disabledOverride;
     }
 
     async _updatePopupPosition() {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -233,9 +233,9 @@ class TextScanner extends EventDispatcher {
     }
 
     hookEvents() {
-        let eventListenerInfos = this.getMouseEventListeners();
+        const eventListenerInfos = this.getMouseEventListeners();
         if (this.options.scanning.touchInputEnabled) {
-            eventListenerInfos = eventListenerInfos.concat(this.getTouchEventListeners());
+            eventListenerInfos.push(...this.getTouchEventListeners());
         }
 
         for (const [node, type, listener, options] of eventListenerInfos) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -45,6 +45,16 @@ class TextScanner extends EventDispatcher {
         this.preventNextMouseDown = false;
         this.preventNextClick = false;
         this.preventScroll = false;
+
+        this._canClearSelection = true;
+    }
+
+    get canClearSelection() {
+        return this._canClearSelection;
+    }
+
+    set canClearSelection(value) {
+        this._canClearSelection = value;
     }
 
     onMouseOver(e) {
@@ -323,6 +333,7 @@ class TextScanner extends EventDispatcher {
     }
 
     clearSelection(passive) {
+        if (!this._canClearSelection) { return; }
         if (this.textSourceCurrent !== null) {
             if (this.textSourceCurrentSelected) {
                 this.textSourceCurrent.deselect();

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -222,9 +222,9 @@ class TextScanner extends EventDispatcher {
         }
     }
 
-    setEnabled(enabled, canEnable) {
+    setEnabled(enabled) {
         this.eventListeners.removeAllEventListeners();
-        this.enabled = enabled && canEnable;
+        this.enabled = enabled;
         if (this.enabled) {
             this.hookEvents();
         } else {
@@ -264,9 +264,8 @@ class TextScanner extends EventDispatcher {
         ];
     }
 
-    setOptions(options, canEnable=true) {
+    setOptions(options) {
         this.options = options;
-        this.setEnabled(this.options.general.enable, canEnable);
     }
 
     async searchAt(x, y, cause) {


### PR DESCRIPTION
Follow-up of #484. `QueryParser` still inherits, which can be addressed in the future.

* Simplified `setEnabled` and `setOptions` APIs. `setOptions` now only takes one argument (`options`), and `setEnabled` now only takes one argument (`enabled`).
* Fixed a bug where `QueryParser` would not work when `options.general.enable` was false.
* `onWindowMessage` handler is now added, removed, and tracked by `Frontend`. The change takes place whenever `setEnabled` is changed.
* A few refactorings, including using `Array.push` instead of `concat`, making `Frontend.options` private, and using `.bind` instead of an arrow function.