### PR TITLE
Modifier key profile condition

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -97,6 +97,7 @@
                 "parseUrl": "readonly",
                 "areSetsEqual": "readonly",
                 "getSetIntersection": "readonly",
+                "getSetDifference": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly",
                 "EXTENSION_IS_BROWSER_EDGE": "readonly"

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -39,9 +39,12 @@ function _profileConditionTestDomainList(url, domainList) {
 const _profileModifierKeys = [
     {optionValue: 'alt',   name: 'Alt'},
     {optionValue: 'ctrl',  name: 'Ctrl'},
-    {optionValue: 'meta',  name: 'Meta'},
     {optionValue: 'shift', name: 'Shift'}
 ];
+
+if (!hasOwn(window, 'netscape')) {
+    _profileModifierKeys.push({optionValue: 'meta',  name: 'Meta'});
+}
 
 const _profileModifierValueToName = new Map(
     _profileModifierKeys.map(({optionValue, name}) => [optionValue, name])

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -36,6 +36,21 @@ function _profileConditionTestDomainList(url, domainList) {
     return false;
 }
 
+const _profileModifierKeys = [
+    {optionValue: 'alt',   name: 'Alt'},
+    {optionValue: 'ctrl',  name: 'Ctrl'},
+    {optionValue: 'meta',  name: 'Meta'},
+    {optionValue: 'shift', name: 'Shift'}
+];
+
+const _profileModifierValueToName = new Map(
+    _profileModifierKeys.map(({optionValue, name}) => [optionValue, name])
+);
+
+const _profileModifierNameToValue = new Map(
+    _profileModifierKeys.map(({optionValue, name}) => [name, optionValue])
+);
+
 const profileConditionsDescriptor = {
     popupLevel: {
         name: 'Popup Level',
@@ -105,21 +120,45 @@ const profileConditionsDescriptor = {
         name: 'Modifier Key',
         description: 'Use profile depending on the active modifier keys.',
         type: 'select',
-        defaultValue: 'alt',
-        values: [
-            ['alt', 'Alt'],
-            ['ctrl', 'Ctrl'],
-            ['meta', 'Meta'],
-            ['shift', 'Shift']
-        ],
-        defaultOperator: 'has',
+        values: _profileModifierKeys,
+        defaultOperator: 'is',
         operators: {
+            is: {
+                name: 'is',
+                placeholder: 'Press one or more modifier keys here',
+                defaultValue: '',
+                type: 'keyMulti',
+                transform: (optionValue) => optionValue
+                    .split(' + ')
+                    .filter((v) => v.length > 0)
+                    .map((v) => _profileModifierNameToValue.get(v)),
+                transformReverse: (transformedOptionValue) => transformedOptionValue
+                    .map((v) => _profileModifierValueToName.get(v))
+                    .join(' + '),
+                test: ({modifierKeys}, optionValue) => areSetsEqual(new Set(modifierKeys), new Set(optionValue))
+            },
+            isNot: {
+                name: 'is not',
+                placeholder: 'Press one or more modifier keys here',
+                defaultValue: '',
+                type: 'keyMulti',
+                transform: (optionValue) => optionValue
+                    .split(' + ')
+                    .filter((v) => v.length > 0)
+                    .map((v) => _profileModifierNameToValue.get(v)),
+                transformReverse: (transformedOptionValue) => transformedOptionValue
+                    .map((v) => _profileModifierValueToName.get(v))
+                    .join(' + '),
+                test: ({modifierKeys}, optionValue) => !areSetsEqual(new Set(modifierKeys), new Set(optionValue))
+            },
             has: {
                 name: 'has',
+                defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
             },
             hasNot: {
                 name: 'doesn\'t have',
+                defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
             }
         }

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -100,5 +100,27 @@ const profileConditionsDescriptor = {
                 test: ({url}, transformedOptionValue) => (transformedOptionValue !== null && transformedOptionValue.test(url))
             }
         }
+    },
+    modifierKey: {
+        name: 'Modifier Key',
+        description: 'Use profile depending on the active modifier keys.',
+        type: 'select',
+        values: [
+            ['alt', 'Alt'],
+            ['ctrl', 'Ctrl'],
+            ['meta', 'Meta'],
+            ['shift', 'Shift']
+        ],
+        defaultOperator: 'equal',
+        operators: {
+            equal: {
+                name: '=',
+                test: ({modifierKeys}, optionValue) => (modifierKeys.includes(optionValue))
+            },
+            notEqual: {
+                name: '\u2260',
+                test: ({modifierKeys}, optionValue) => (!modifierKeys.includes(optionValue))
+            }
+        }
     }
 };

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -122,7 +122,6 @@ const profileConditionsDescriptor = {
     modifierKeys: {
         name: 'Modifier Keys',
         description: 'Use profile depending on the active modifier keys.',
-        type: 'select',
         values: _profileModifierKeys,
         defaultOperator: 'are',
         operators: {
@@ -156,11 +155,13 @@ const profileConditionsDescriptor = {
             },
             include: {
                 name: 'include',
+                type: 'select',
                 defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
             },
             notInclude: {
                 name: 'don\'t include',
+                type: 'select',
                 defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
             }

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -105,21 +105,22 @@ const profileConditionsDescriptor = {
         name: 'Modifier Key',
         description: 'Use profile depending on the active modifier keys.',
         type: 'select',
+        defaultValue: 'alt',
         values: [
             ['alt', 'Alt'],
             ['ctrl', 'Ctrl'],
             ['meta', 'Meta'],
             ['shift', 'Shift']
         ],
-        defaultOperator: 'equal',
+        defaultOperator: 'has',
         operators: {
-            equal: {
-                name: '=',
-                test: ({modifierKeys}, optionValue) => (modifierKeys.includes(optionValue))
+            has: {
+                name: 'has',
+                test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
             },
-            notEqual: {
-                name: '\u2260',
-                test: ({modifierKeys}, optionValue) => (!modifierKeys.includes(optionValue))
+            hasNot: {
+                name: 'doesn\'t have',
+                test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
             }
         }
     }

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -116,15 +116,15 @@ const profileConditionsDescriptor = {
             }
         }
     },
-    modifierKey: {
-        name: 'Modifier Key',
+    modifierKeys: {
+        name: 'Modifier Keys',
         description: 'Use profile depending on the active modifier keys.',
         type: 'select',
         values: _profileModifierKeys,
-        defaultOperator: 'is',
+        defaultOperator: 'are',
         operators: {
-            is: {
-                name: 'is',
+            are: {
+                name: 'are',
                 placeholder: 'Press one or more modifier keys here',
                 defaultValue: '',
                 type: 'keyMulti',
@@ -137,8 +137,8 @@ const profileConditionsDescriptor = {
                     .join(' + '),
                 test: ({modifierKeys}, optionValue) => areSetsEqual(new Set(modifierKeys), new Set(optionValue))
             },
-            isNot: {
-                name: 'is not',
+            areNot: {
+                name: 'are not',
                 placeholder: 'Press one or more modifier keys here',
                 defaultValue: '',
                 type: 'keyMulti',
@@ -151,13 +151,13 @@ const profileConditionsDescriptor = {
                     .join(' + '),
                 test: ({modifierKeys}, optionValue) => !areSetsEqual(new Set(modifierKeys), new Set(optionValue))
             },
-            has: {
-                name: 'has',
+            include: {
+                name: 'include',
                 defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
             },
-            hasNot: {
-                name: 'doesn\'t have',
+            notInclude: {
+                name: 'don\'t include',
                 defaultValue: 'alt',
                 test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
             }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -17,6 +17,7 @@
 
 /* global
  * ClipboardMonitor
+ * DOM
  * Display
  * QueryParser
  * apiClipboardGet
@@ -178,7 +179,7 @@ class DisplaySearch extends Display {
     }
 
     onKeyDown(e) {
-        const key = Display.getKeyFromEvent(e);
+        const key = DOM.getKeyFromEvent(e);
         const ignoreKeys = this._onKeyDownIgnoreKeys;
 
         const activeModifierMap = new Map([

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -257,11 +257,11 @@ ConditionsUI.Condition = class Condition {
 
         this.input.empty();
         if (inputType === 'select') {
-            this.updateSelectElement(objects);
+            this.inputInner = this.createSelectElement(objects);
         } else if (inputType === 'keyMulti') {
-            this.updateInputKeyMulti(objects);
+            this.inputInner = this.createInputKeyMultiElement(objects);
         } else {
-            this.updateInputElement(objects);
+            this.inputInner = this.createInputElement(objects);
         }
         this.inputInner.appendTo(this.input);
         this.inputInner.on('change', this.onInputChanged.bind(this));
@@ -271,8 +271,8 @@ ConditionsUI.Condition = class Condition {
         this.inputInner.val(this.condition.value);
     }
 
-    updateInputElement(objects) {
-        this.inputInner = ConditionsUI.instantiateTemplate('#condition-input-text-template');
+    createInputElement(objects) {
+        const inputInner = ConditionsUI.instantiateTemplate('#condition-input-text-template');
 
         const props = new Map([
             ['placeholder', ''],
@@ -294,13 +294,16 @@ ConditionsUI.Condition = class Condition {
         }
 
         for (const [prop, value] of props.entries()) {
-            this.inputInner.prop(prop, value);
+            inputInner.prop(prop, value);
         }
+
+        return inputInner;
     }
 
-    updateInputKeyMulti(objects) {
-        this.updateInputElement(objects);
-        this.inputInner.prop('readonly', true);
+    createInputKeyMultiElement(objects) {
+        const inputInner = this.createInputElement(objects);
+
+        inputInner.prop('readonly', true);
 
         let values = [];
         for (const object of objects) {
@@ -315,8 +318,8 @@ ConditionsUI.Condition = class Condition {
             const pressedKeyEventName = DOM.getKeyFromEvent(originalEvent);
             if (pressedKeyEventName === 'Escape' || pressedKeyEventName === 'Backspace') {
                 pressedKeyIndices.clear();
-                this.inputInner.val('');
-                this.inputInner.change();
+                inputInner.val('');
+                inputInner.change();
                 return;
             }
 
@@ -344,15 +347,17 @@ ConditionsUI.Condition = class Condition {
             }
 
             const inputValue = [...pressedKeyIndices].map((i) => values[i].name).join(' + ');
-            this.inputInner.val(inputValue);
-            this.inputInner.change();
+            inputInner.val(inputValue);
+            inputInner.change();
         };
 
-        this.inputInner.on('keydown', onKeyDown);
+        inputInner.on('keydown', onKeyDown);
+
+        return inputInner;
     }
 
-    updateSelectElement(objects) {
-        this.inputInner = ConditionsUI.instantiateTemplate('#condition-input-select-template');
+    createSelectElement(objects) {
+        const inputInner = ConditionsUI.instantiateTemplate('#condition-input-select-template');
 
         const data = new Map([
             ['values', []],
@@ -372,13 +377,15 @@ ConditionsUI.Condition = class Condition {
             const option = ConditionsUI.instantiateTemplate('#condition-input-option-template');
             option.attr('value', optionValue);
             option.text(name);
-            option.appendTo(this.inputInner);
+            option.appendTo(inputInner);
         }
 
         const defaultValue = data.get('defaultValue');
         if (defaultValue !== null) {
-            this.inputInner.val(defaultValue);
+            inputInner.val(defaultValue);
         }
+
+        return inputInner;
     }
 
     validateValue(value) {

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -327,16 +327,13 @@ ConditionsUI.Condition = class Condition {
             // https://developer.mozilla.org/en-US/docs/Web/API/KeyboardEvent/metaKey
             // https://askubuntu.com/questions/567731/why-is-shift-alt-being-mapped-to-meta
             // It works with mouse events on some platforms, so try to determine if metaKey is pressed
-            if (
-                // Firefox / Linux
-                pressedKeyEventName === 'OS' ||
-                // Chrome / Linux (hack; only works when Shift and Alt are not pressed)
-                pressedKeyEventName === 'Meta' && getSetDifference(new Set(['shift', 'alt']), pressedModifiers).size !== 0
-            ) {
-                const foundIndex = values.findIndex(({optionValue}) => optionValue === 'meta');
-                if (foundIndex !== -1) {
-                    pressedKeyIndices.add(foundIndex);
-                }
+            // hack; only works when Shift and Alt are not pressed
+            const isMetaKeyChrome = (
+                pressedKeyEventName === 'Meta' &&
+                getSetDifference(new Set(['shift', 'alt']), pressedModifiers).size !== 0
+            );
+            if (isMetaKeyChrome) {
+                pressedModifiers.add('meta');
             }
 
             for (const modifier of pressedModifiers) {

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -194,9 +194,7 @@ ConditionsUI.Condition = class Condition {
     }
 
     cleanup() {
-        if (this.inputInner !== null) {
-            this.inputInner.off('change');
-        }
+        this.inputInner.off('change');
         this.typeSelect.off('change');
         this.operatorSelect.off('change');
         this.removeButton.off('click');

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -117,7 +117,7 @@
                     <div class="input-group-btn"><select class="form-control btn btn-default condition-type"><optgroup label="Type"></optgroup></select></div>
                     <div class="input-group-btn"><select class="form-control btn btn-default condition-operator"><optgroup label="Operator"></optgroup></select></div>
                     <div class="condition-line-break"></div>
-                    <div class="condition-input"><input type="text" class="form-control" /></div>
+                    <div class="condition-input"></div>
                     <div class="input-group-btn"><button class="btn btn-danger condition-remove" title="Remove"><span class="glyphicon glyphicon-remove"></span></button></div>
                 </div></template>
                 <template id="condition-group-separator-template"><div class="input-group">
@@ -126,6 +126,9 @@
                 <template id="condition-group-options-template"><div class="condition-group-options">
                     <button class="btn btn-default condition-add"><span class="glyphicon glyphicon-plus"></span></button>
                 </div></template>
+                <template id="condition-input-text-template"><input type="text" class="form-control condition-input-inner" /></template>
+                <template id="condition-input-select-template"><select class="form-control condition-input-inner"></select></template>
+                <template id="condition-input-option-template"><option></option></template>
             </div>
 
             <div>

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -283,7 +283,8 @@ class Frontend {
     async getOptionsContext() {
         const url = this._getUrl !== null ? await this._getUrl() : window.location.href;
         const depth = this.popup.depth;
-        return {depth, url};
+        const modifierKeys = [...this._activeModifiers];
+        return {depth, url, modifierKeys};
     }
 
     _showPopupContent(textSource, optionsContext, type=null, details=null) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -50,6 +50,9 @@ class Frontend {
         );
         this._textScanner.onSearchSource = this.onSearchSource.bind(this);
 
+        this._activeModifiers = new Set();
+        this._optionsUpdatePending = false;
+
         this._windowMessageHandlers = new Map([
             ['popupClose', () => this._textScanner.clearSelection(false)],
             ['selectionCopy', () => document.execCommand('copy')]
@@ -90,6 +93,7 @@ class Frontend {
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
 
             this._textScanner.on('clearSelection', this.onClearSelection.bind(this));
+            this._textScanner.on('updateActiveModifiers', this.onUpdateActiveModifiers.bind(this));
 
             this._updateContentScale();
             this._broadcastRootPopupInformation();
@@ -173,12 +177,21 @@ class Frontend {
         }
     }
 
+    async updatePendingOptions() {
+        if (this._optionsUpdatePending) {
+            this._optionsUpdatePending = false;
+            await this.updateOptions();
+        }
+    }
+
     async setTextSource(textSource) {
         await this.onSearchSource(textSource, 'script');
         this._textScanner.setCurrentTextSource(textSource);
     }
 
     async onSearchSource(textSource, cause) {
+        await this.updatePendingOptions();
+
         let results = null;
 
         try {
@@ -254,6 +267,17 @@ class Frontend {
     onClearSelection({passive}) {
         this.popup.hide(!passive);
         this.popup.clearAutoPlayTimer();
+        this.updatePendingOptions();
+    }
+
+    async onUpdateActiveModifiers({modifiers}) {
+        if (areSetsEqual(modifiers, this._activeModifiers)) { return; }
+        this._activeModifiers = modifiers;
+        if (await this.popup.isVisible()) {
+            this._optionsUpdatePending = true;
+            return;
+        }
+        await this.updateOptions();
     }
 
     async getOptionsContext() {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -93,7 +93,7 @@ class Frontend {
             chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
 
             this._textScanner.on('clearSelection', this.onClearSelection.bind(this));
-            this._textScanner.on('updateActiveModifiers', this.onUpdateActiveModifiers.bind(this));
+            this._textScanner.on('activeModifiersChanged', this.onActiveModifiersChanged.bind(this));
 
             this._updateContentScale();
             this._broadcastRootPopupInformation();
@@ -270,7 +270,7 @@ class Frontend {
         this.updatePendingOptions();
     }
 
-    async onUpdateActiveModifiers({modifiers}) {
+    async onActiveModifiersChanged({modifiers}) {
         if (areSetsEqual(modifiers, this._activeModifiers)) { return; }
         this._activeModifiers = modifiers;
         if (await this.popup.isVisible()) {

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -146,6 +146,12 @@ function getSetIntersection(set1, set2) {
     return result;
 }
 
+function getSetDifference(set1, set2) {
+    return new Set(
+        [...set1].filter((value) => !set2.has(value))
+    );
+}
+
 
 /*
  * Async utilities

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -338,7 +338,7 @@ class Display {
     }
 
     onKeyDown(e) {
-        const key = Display.getKeyFromEvent(e);
+        const key = DOM.getKeyFromEvent(e);
         const handler = this._onKeyDownHandlers.get(key);
         if (typeof handler === 'function') {
             if (handler(e)) {
@@ -962,11 +962,6 @@ class Display {
         const elementRect = element.getBoundingClientRect();
         const documentRect = document.documentElement.getBoundingClientRect();
         return elementRect.top - documentRect.top;
-    }
-
-    static getKeyFromEvent(event) {
-        const key = event.key;
-        return (typeof key === 'string' ? (key.length === 1 ? key.toUpperCase() : key) : '');
     }
 
     async _getNoteContext() {

--- a/ext/mixed/js/dom.js
+++ b/ext/mixed/js/dom.js
@@ -63,6 +63,20 @@ class DOM {
         }
     }
 
+    static getActiveModifiers(event) {
+        const modifiers = new Set();
+        if (event.altKey) { modifiers.add('alt'); }
+        if (event.ctrlKey) { modifiers.add('ctrl'); }
+        if (event.metaKey) { modifiers.add('meta'); }
+        if (event.shiftKey) { modifiers.add('shift'); }
+        return modifiers;
+    }
+
+    static getKeyFromEvent(event) {
+        const key = event.key;
+        return (typeof key === 'string' ? (key.length === 1 ? key.toUpperCase() : key) : '');
+    }
+
     static getFullscreenElement() {
         return (
             document.fullscreenElement ||

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -71,7 +71,7 @@ class TextScanner extends EventDispatcher {
         }
 
         const modifiers = DOM.getActiveModifiers(e);
-        this.trigger('updateActiveModifiers', {modifiers});
+        this.trigger('activeModifiersChanged', {modifiers});
 
         const scanningOptions = this.options.scanning;
         const scanningModifier = scanningOptions.modifier;

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -70,6 +70,9 @@ class TextScanner extends EventDispatcher {
             return;
         }
 
+        const modifiers = this.getActiveModifiers(e);
+        this.trigger('updateActiveModifiers', {modifiers});
+
         const scanningOptions = this.options.scanning;
         const scanningModifier = scanningOptions.modifier;
         if (!(
@@ -356,6 +359,15 @@ class TextScanner extends EventDispatcher {
         } else {
             this.textSourceCurrentSelected = false;
         }
+    }
+
+    getActiveModifiers(mouseEvent) {
+        const modifiers = new Set();
+        if (mouseEvent.altKey) { modifiers.add('alt'); }
+        if (mouseEvent.ctrlKey) { modifiers.add('ctrl'); }
+        if (mouseEvent.metaKey) { modifiers.add('meta'); }
+        if (mouseEvent.shiftKey) { modifiers.add('shift'); }
+        return modifiers;
     }
 
     static isScanningModifierPressed(scanningModifier, mouseEvent) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -70,7 +70,7 @@ class TextScanner extends EventDispatcher {
             return;
         }
 
-        const modifiers = this.getActiveModifiers(e);
+        const modifiers = DOM.getActiveModifiers(e);
         this.trigger('updateActiveModifiers', {modifiers});
 
         const scanningOptions = this.options.scanning;
@@ -359,15 +359,6 @@ class TextScanner extends EventDispatcher {
         } else {
             this.textSourceCurrentSelected = false;
         }
-    }
-
-    getActiveModifiers(mouseEvent) {
-        const modifiers = new Set();
-        if (mouseEvent.altKey) { modifiers.add('alt'); }
-        if (mouseEvent.ctrlKey) { modifiers.add('ctrl'); }
-        if (mouseEvent.metaKey) { modifiers.add('meta'); }
-        if (mouseEvent.shiftKey) { modifiers.add('shift'); }
-        return modifiers;
     }
 
     static isScanningModifierPressed(scanningModifier, mouseEvent) {


### PR DESCRIPTION
Fixes https://github.com/FooSoft/yomichan/issues/412

Adds a new profile condition that lets you specify a modifier key or an exact set of modifier keys that must or must not be pressed in order to activate a profile when scanning.

The set of active modifiers is changed when you move the mouse cursor and press or release Shift, Alt, Ctrl or Meta. If a popup is open when you do this, a boolean is stored that will cause the profile to be updated on the next popup close or scan.

I'm not completely sure about adding support for `Meta` because its support is so inconsistent across browsers. I only tested on Linux, and Chrome was the only browser where it worked. I still have a condition for Firefox/Linux but I'll remove it if I don't find a way to detect if it's pressed when scanning.

The modifier keys are checked from the mouse event because it's difficult to track pressed keys when focus shifts between popups and page content.

Not sure what should be done with query parser. I was planning to add some profile identifier query parameter for search page, but that's already kind of supported by the URL RegExp condition as long as unknown parameters aren't removed when dynamically changing the URL. It has some discoverability issues, though. Probably not a concern for this PR, currently modifers are just ignored on the search page.