### PR TITLE
Don't parent the popup frame to elements which cause unload

### DIFF
--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -281,7 +281,7 @@ class Popup {
     }
 
     _onFullscreenChanged() {
-        const parent = (DOM.getFullscreenElement() || document.body || null);
+        const parent = this._getFrameParentElement();
         if (parent !== null && this._container.parentNode !== parent) {
             parent.appendChild(this._container);
         }
@@ -373,6 +373,22 @@ class Popup {
         if (token === null || contentWindow === null) { return; }
 
         contentWindow.postMessage({action, params, token}, this._targetOrigin);
+    }
+
+    _getFrameParentElement() {
+        const defaultParent = document.body;
+        const fullscreenElement = DOM.getFullscreenElement();
+        if (fullscreenElement === null || fullscreenElement.shadowRoot) {
+            return defaultParent;
+        }
+
+        switch (fullscreenElement.nodeName.toUpperCase()) {
+            case 'IFRAME':
+            case 'FRAME':
+                return defaultParent;
+        }
+
+        return fullscreenElement;
     }
 
     static _getPositionForHorizontalText(elementRect, width, height, viewport, offsetScale, optionsGeneral) {


### PR DESCRIPTION
Fixes some bugs which cause the popup frame to unload when the fullscreen element is changed. The fullscreen element may be reported as an `<iframe>` or an element with a shadow DOM. If the popup frame is parented to one of these elements, it is unloaded. There are potentially others that this could happen on, but his handles a few edge cases in test-document2.html.

This does not handle elements with closed shadow DOMs, as those aren't (supposed to be) detectable. So it is still possible for the frame to unload. However, this issue needs to be addressed eventually for #441 and some other tasks I'm working on.