### PR TITLE
Add helpful link for markers in settings.html

### DIFF
--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -847,6 +847,8 @@
                             As Anki requires the first field in the model to be unique, it is recommended
                             that you set it to <code>{expression}</code> for term flashcards and <code>{character}</code> for
                             Kanji flashcards. You can use multiple markers per field by typing them in directly.
+                            See <a href="https://foosoft.net/projects/yomichan#flashcard-configuration" target="_blank" rel="noopener">Flashcard Configuration</a>
+                            on the Yomichan homepage for descriptions of the available markers.
                         </p>
 
                         <ul class="nav nav-tabs">


### PR DESCRIPTION
Add a link to the flashcard marker definitions on the yomichan homepage in settings.html to help users who are setting up Anki integration.