### PR TITLE
Remove and unload the popup frame if an unexpected load occurs

### DIFF
--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -201,13 +201,19 @@ class Popup {
     // Private functions
 
     _inject() {
-        if (this._injectPromise === null) {
-            this._injectPromise = this._createInjectPromise();
-            this._injectPromise.then(
-                () => { this._injectPromiseComplete = true; },
-                () => { this._resetFrame(); });
+        let injectPromise = this._injectPromise;
+        if (injectPromise === null) {
+            injectPromise = this._createInjectPromise();
+            this._injectPromise = injectPromise;
+            injectPromise.then(
+                () => {
+                    if (injectPromise !== this._injectPromise) { return; }
+                    this._injectPromiseComplete = true;
+                },
+                () => { this._resetFrame(); }
+            );
         }
-        return this._injectPromise;
+        return injectPromise;
     }
 
     async _createInjectPromise() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -261,8 +261,6 @@ class Popup {
         this._container.removeAttribute('src');
         this._container.removeAttribute('srcdoc');
 
-        this._containerSecret = null;
-        this._containerToken = null;
         this._injectPromise = null;
         this._injectPromiseComplete = false;
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -255,7 +255,7 @@ class Popup {
     }
 
     _onFrameLoad() {
-        if (!(this._injectPromise !== null && this._injectPromiseComplete)) { return; }
+        if (!this._injectPromiseComplete) { return; }
         this._resetFrame();
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -31,6 +31,7 @@ class Popup {
         this._child = null;
         this._childrenSupported = true;
         this._injectPromise = null;
+        this._injectPromiseComplete = false;
         this._visible = false;
         this._visibleOverride = null;
         this._options = null;
@@ -47,6 +48,7 @@ class Popup {
         this._container.addEventListener('scroll', (e) => e.stopPropagation());
         this._container.style.width = '0px';
         this._container.style.height = '0px';
+        this._container.addEventListener('load', this._onFrameLoad.bind(this));
 
         this._fullscreenEventListeners = new EventListenerCollection();
 
@@ -201,6 +203,9 @@ class Popup {
     _inject() {
         if (this._injectPromise === null) {
             this._injectPromise = this._createInjectPromise();
+            this._injectPromise.then(
+                () => { this._injectPromiseComplete = true; },
+                () => { this._resetFrame(); });
         }
         return this._injectPromise;
     }
@@ -241,6 +246,25 @@ class Popup {
         this._injectStyles();
 
         return popupPreparedPromise;
+    }
+
+    _onFrameLoad() {
+        if (!(this._injectPromise !== null && this._injectPromiseComplete)) { return; }
+        this._resetFrame();
+    }
+
+    _resetFrame() {
+        const parent = this._container.parentNode;
+        if (parent !== null) {
+            parent.removeChild(this._container);
+        }
+        this._container.removeAttribute('src');
+        this._container.removeAttribute('srcdoc');
+
+        this._containerSecret = null;
+        this._containerToken = null;
+        this._injectPromise = null;
+        this._injectPromiseComplete = false;
     }
 
     async _injectStyles() {


### PR DESCRIPTION
If the popup emits an unexpected `load` event, the popup is removed from the page and unloaded. Such events can occur if the popup is unloaded (see: #441, #488), or new content is loaded, such as assigning `src` or `srcdoc`. This should, for the most part, prevent hijacking. Technically it would be even more secure to create a new iframe and forget about the old one, but that's not necessary at this point (and also out of scope for this change).