### PR TITLE
Popup init update

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -98,6 +98,7 @@ class Backend {
             ['commandExec', {handler: this._onApiCommandExec.bind(this), async: false}],
             ['audioGetUri', {handler: this._onApiAudioGetUri.bind(this), async: true}],
             ['screenshotGet', {handler: this._onApiScreenshotGet.bind(this), async: true}],
+            ['sendMessageToFrame', {handler: this._onApiSendMessageToFrame.bind(this), async: false}],
             ['broadcastTab', {handler: this._onApiBroadcastTab.bind(this), async: false}],
             ['frameInformationGet', {handler: this._onApiFrameInformationGet.bind(this), async: true}],
             ['injectStylesheet', {handler: this._onApiInjectStylesheet.bind(this), async: true}],
@@ -598,6 +599,17 @@ class Backend {
         return new Promise((resolve) => {
             chrome.tabs.captureVisibleTab(windowId, options, (dataUrl) => resolve(dataUrl));
         });
+    }
+
+    _onApiSendMessageToFrame({frameId, action, params}, sender) {
+        if (!(sender && sender.tab)) {
+            return false;
+        }
+
+        const tabId = sender.tab.id;
+        const callback = () => this.checkLastError(chrome.runtime.lastError);
+        chrome.tabs.sendMessage(tabId, {action, params}, {frameId}, callback);
+        return true;
     }
 
     _onApiBroadcastTab({action, params}, sender) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -73,8 +73,6 @@ class Backend {
         const apiForwarder = new BackendApiForwarder();
         apiForwarder.prepare();
 
-        this.messageToken = yomichan.generateId(16);
-
         this._defaultBrowserActionTitle = null;
         this._isPrepared = false;
         this._prepareError = false;
@@ -107,7 +105,6 @@ class Backend {
             ['getDisplayTemplatesHtml', {handler: this._onApiGetDisplayTemplatesHtml.bind(this), async: true}],
             ['getQueryParserTemplatesHtml', {handler: this._onApiGetQueryParserTemplatesHtml.bind(this), async: true}],
             ['getZoom', {handler: this._onApiGetZoom.bind(this), async: true}],
-            ['getMessageToken', {handler: this._onApiGetMessageToken.bind(this), async: false}],
             ['getDefaultAnkiFieldTemplates', {handler: this._onApiGetDefaultAnkiFieldTemplates.bind(this), async: false}],
             ['getAnkiDeckNames', {handler: this._onApiGetAnkiDeckNames.bind(this), async: true}],
             ['getAnkiModelNames', {handler: this._onApiGetAnkiModelNames.bind(this), async: true}],
@@ -741,10 +738,6 @@ class Backend {
                 }
             });
         });
-    }
-
-    _onApiGetMessageToken() {
-        return this.messageToken;
     }
 
     _onApiGetDefaultAnkiFieldTemplates() {

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -56,5 +56,6 @@ async function popupNestedInitialize(id, depth, parentFrameId, url) {
 
 (async () => {
     apiForwardLogsToBackend();
-    new DisplayFloat();
+    const display = new DisplayFloat();
+    await display.prepare();
 })();

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -86,15 +86,27 @@ class DisplayFloat extends Display {
 
     onMessage(e) {
         const data = e.data;
-        if (typeof data !== 'object' || data === null) { return; } // Invalid data
+        if (typeof data !== 'object' || data === null) {
+            this._logMessageError(e, 'Invalid data');
+            return;
+        }
 
         const action = data.action;
-        if (typeof action !== 'string') { return; } // Invalid data
+        if (typeof action !== 'string') {
+            this._logMessageError(e, 'Invalid data');
+            return;
+        }
 
         const handlerInfo = this._windowMessageHandlers.get(action);
-        if (typeof handlerInfo === 'undefined') { return; } // Invalid handler
+        if (typeof handlerInfo === 'undefined') {
+            this._logMessageError(e, `Invalid action: ${JSON.stringify(action)}`);
+            return;
+        }
 
-        if (handlerInfo.authenticate !== false && !this._isMessageAuthenticated(data)) { return; } // Invalid authentication
+        if (handlerInfo.authenticate !== false && !this._isMessageAuthenticated(data)) {
+            this._logMessageError(e, 'Invalid authentication');
+            return;
+        }
 
         const handler = handlerInfo.handler;
         handler(data.params);
@@ -148,6 +160,10 @@ class DisplayFloat extends Display {
         } catch (e) {
             return '';
         }
+    }
+
+    _logMessageError(event, type) {
+        yomichan.logWarning(new Error(`Popup received invalid message from origin ${JSON.stringify(event.origin)}: ${type}`));
     }
 
     _initialize(params) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -59,6 +59,8 @@ class DisplayFloat extends Display {
 
         yomichan.on('orphaned', this.onOrphaned.bind(this));
         window.addEventListener('message', this.onMessage.bind(this), false);
+
+        apiBroadcastTab('popupPrepared', {secret: this._secret});
     }
 
     async prepare(popupInfo, optionsContext, childrenSupported, scale) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -19,6 +19,7 @@
  * Display
  * apiBroadcastTab
  * apiGetMessageToken
+ * apiSendMessageToFrame
  * popupNestedInitialize
  */
 
@@ -47,6 +48,7 @@ class DisplayFloat extends Display {
         ]);
 
         this._windowMessageHandlers = new Map([
+            ['initialize', {handler: this._initialize.bind(this), authenticate: false}],
             ['setOptionsContext', {handler: ({optionsContext}) => this.setOptionsContext(optionsContext)}],
             ['setContent', {handler: ({type, details}) => this.setContent(type, details)}],
             ['clearAutoPlayTimer', {handler: () => this.clearAutoPlayTimer()}],
@@ -165,6 +167,19 @@ class DisplayFloat extends Display {
         } catch (e) {
             return '';
         }
+    }
+
+    _initialize(params) {
+        if (this._token !== null) { return; } // Already initialized
+        if (!isObject(params)) { return; } // Invalid data
+
+        const secret = params.secret;
+        if (secret !== this._secret) { return; } // Invalid authentication
+
+        const {token, frameId} = params;
+        this._token = token;
+
+        apiSendMessageToFrame(frameId, 'popupInitialized', {secret, token});
     }
 
     _isMessageAuthenticated(message) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -31,8 +31,6 @@ class DisplayFloat extends Display {
 
         this._orphaned = false;
         this._prepareInvoked = false;
-        this._messageToken = null;
-        this._messageTokenPromise = null;
 
         this._onKeyDownHandlers = new Map([
             ['C', (e) => {
@@ -104,45 +102,14 @@ class DisplayFloat extends Display {
         const data = e.data;
         if (typeof data !== 'object' || data === null) { return; } // Invalid data
 
-        const token = data.token;
-        if (typeof token !== 'string') { return; } // Invalid data
-
-        if (this._messageToken === null) {
-            // Async
-            this.getMessageToken()
-                .then(
-                    () => { this.handleAction(token, data); },
-                    () => {}
-                );
-        } else {
-            // Sync
-            this.handleAction(token, data);
-        }
-    }
-
-    async getMessageToken() {
-        // this._messageTokenPromise is used to ensure that only one call to apiGetMessageToken is made.
-        if (this._messageTokenPromise === null) {
-            this._messageTokenPromise = apiGetMessageToken();
-        }
-        const messageToken = await this._messageTokenPromise;
-        if (this._messageToken === null) {
-            this._messageToken = messageToken;
-        }
-        this._messageTokenPromise = null;
-    }
-
-    handleAction(token, {action, params}) {
-        if (token !== this._messageToken) {
-            // Invalid token
-            return;
-        }
+        const action = data.action;
+        if (typeof action !== 'string') { return; } // Invalid data
 
         const handlerInfo = this._windowMessageHandlers.get(action);
-        if (typeof handlerInfo === 'undefined') { return; }
+        if (typeof handlerInfo === 'undefined') { return; } // Invalid handler
 
-        const {handler} = handlerInfo;
-        handler(params);
+        const handler = handlerInfo.handler;
+        handler(data.params);
     }
 
     autoPlayAudio() {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -46,12 +46,12 @@ class DisplayFloat extends Display {
         ]);
 
         this._windowMessageHandlers = new Map([
-            ['setOptionsContext', ({optionsContext}) => this.setOptionsContext(optionsContext)],
-            ['setContent', ({type, details}) => this.setContent(type, details)],
-            ['clearAutoPlayTimer', () => this.clearAutoPlayTimer()],
-            ['setCustomCss', ({css}) => this.setCustomCss(css)],
-            ['prepare', ({popupInfo, optionsContext, childrenSupported, scale}) => this.prepare(popupInfo, optionsContext, childrenSupported, scale)],
-            ['setContentScale', ({scale}) => this.setContentScale(scale)]
+            ['setOptionsContext', {handler: ({optionsContext}) => this.setOptionsContext(optionsContext)}],
+            ['setContent', {handler: ({type, details}) => this.setContent(type, details)}],
+            ['clearAutoPlayTimer', {handler: () => this.clearAutoPlayTimer()}],
+            ['setCustomCss', {handler: ({css}) => this.setCustomCss(css)}],
+            ['prepare', {handler: ({popupInfo, optionsContext, childrenSupported, scale}) => this.prepare(popupInfo, optionsContext, childrenSupported, scale)}],
+            ['setContentScale', {handler: ({scale}) => this.setContentScale(scale)}]
         ]);
 
         yomichan.on('orphaned', this.onOrphaned.bind(this));
@@ -138,9 +138,10 @@ class DisplayFloat extends Display {
             return;
         }
 
-        const handler = this._windowMessageHandlers.get(action);
-        if (typeof handler !== 'function') { return; }
+        const handlerInfo = this._windowMessageHandlers.get(action);
+        if (typeof handlerInfo === 'undefined') { return; }
 
+        const {handler} = handlerInfo;
         handler(params);
     }
 

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -31,7 +31,7 @@ class DisplayFloat extends Display {
         this._token = null;
 
         this._orphaned = false;
-        this._prepareInvoked = false;
+        this._initializedNestedPopups = false;
 
         this._onKeyDownHandlers = new Map([
             ['C', (e) => {
@@ -164,16 +164,14 @@ class DisplayFloat extends Display {
     }
 
     async _configure({messageId, frameId, popupId, optionsContext, childrenSupported, scale}) {
-        if (this._prepareInvoked) { return; }
-        this._prepareInvoked = true;
-
         this.optionsContext = optionsContext;
 
         await this.updateOptions();
 
-        if (childrenSupported) {
+        if (childrenSupported && !this._initializedNestedPopups) {
             const {depth, url} = optionsContext;
             popupNestedInitialize(popupId, depth, frameId, url);
+            this._initializedNestedPopups = true;
         }
 
         this.setContentScale(scale);

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -27,6 +27,9 @@ class DisplayFloat extends Display {
         super(document.querySelector('#spinner'), document.querySelector('#definitions'));
         this.autoPlayAudioTimer = null;
 
+        this._secret = yomichan.generateId(16);
+        this._token = null;
+
         this._popupId = null;
 
         this._orphaned = false;
@@ -108,6 +111,8 @@ class DisplayFloat extends Display {
         const handlerInfo = this._windowMessageHandlers.get(action);
         if (typeof handlerInfo === 'undefined') { return; } // Invalid handler
 
+        if (handlerInfo.authenticate !== false && !this._isMessageAuthenticated(data)) { return; } // Invalid authentication
+
         const handler = handlerInfo.handler;
         handler(data.params);
     }
@@ -160,5 +165,13 @@ class DisplayFloat extends Display {
         } catch (e) {
             return '';
         }
+    }
+
+    _isMessageAuthenticated(message) {
+        return (
+            this._token !== null &&
+            this._token === message.token &&
+            this._secret === message.secret
+        );
     }
 }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -18,7 +18,6 @@
 /* global
  * Display
  * apiBroadcastTab
- * apiGetMessageToken
  * apiSendMessageToFrame
  * popupNestedInitialize
  */

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -53,6 +53,10 @@ class DisplayFloat extends Display {
             ['setCustomCss', {handler: ({css}) => this.setCustomCss(css)}],
             ['setContentScale', {handler: ({scale}) => this.setContentScale(scale)}]
         ]);
+    }
+
+    async prepare() {
+        await super.prepare();
 
         yomichan.on('orphaned', this.onOrphaned.bind(this));
         window.addEventListener('message', this.onMessage.bind(this), false);
@@ -165,7 +169,6 @@ class DisplayFloat extends Display {
 
         this.optionsContext = optionsContext;
 
-        await super.prepare();
         await this.updateOptions();
 
         if (childrenSupported) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -304,32 +304,29 @@ class Popup {
         this._containerSecret = secret;
         this._containerToken = token;
 
+        // Configure
+        const messageId = yomichan.generateId(16);
         const popupPreparedPromise = yomichan.getTemporaryListenerResult(
             chrome.runtime.onMessage,
-            ({action, params}, {resolve}) => {
+            (message, {resolve}) => {
                 if (
-                    action === 'popupPrepareCompleted' &&
-                    isObject(params) &&
-                    params.targetPopupId === this._id
+                    isObject(message) &&
+                    message.action === 'popupConfigured' &&
+                    isObject(message.params) &&
+                    message.params.messageId === messageId
                 ) {
                     resolve();
                 }
             }
         );
-
-        const parentFrameId = (typeof this._frameId === 'number' ? this._frameId : null);
-        this._invokeApi('prepare', {
-            popupInfo: {
-                id: this._id,
-                parentFrameId
-            },
+        this._invokeApi('configure', {
+            messageId,
+            frameId: this._frameId,
+            popupId: this._id,
             optionsContext: this._optionsContext,
             childrenSupported: this._childrenSupported,
             scale: this._contentScale
         });
-        this._observeFullscreen(true);
-        this._onFullscreenChanged();
-        this._injectStyles();
 
         return popupPreparedPromise;
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -375,6 +375,8 @@ class Popup {
         this._container.removeAttribute('src');
         this._container.removeAttribute('srcdoc');
 
+        this._containerSecret = null;
+        this._containerToken = null;
         this._injectPromise = null;
         this._injectPromiseComplete = false;
     }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -288,6 +288,10 @@ class Popup {
                     return;
                 }
 
+                if (Popup.isFrameAboutBlank(frame)) {
+                    return;
+                }
+
                 containerLoadedResolve();
                 containerLoadedResolve = null;
                 containerLoadedReject = null;
@@ -765,6 +769,17 @@ class Popup {
         // Add to map
         injectedStylesheets.set(id, styleNode);
         return styleNode;
+    }
+
+    static isFrameAboutBlank(frame) {
+        try {
+            const contentDocument = frame.contentDocument;
+            if (contentDocument === null) { return false; }
+            const url = contentDocument.location.href;
+            return /^about:blank(?:[#?]|$)/.test(url);
+        } catch (e) {
+            return false;
+        }
     }
 }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -328,6 +328,8 @@ class Popup {
         this._injectStyles();
 
         const {secret, token} = await this._initializeFrame(this._container, this._targetOrigin, this._frameId, (frame) => {
+            frame.removeAttribute('src');
+            frame.removeAttribute('srcdoc');
             frame.setAttribute('src', chrome.runtime.getURL('/fg/float.html'));
             this._observeFullscreen(true);
             this._onFullscreenChanged();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -17,7 +17,6 @@
 
 /* global
  * DOM
- * apiGetMessageToken
  * apiInjectStylesheet
  * apiOptionsGet
  */
@@ -39,7 +38,6 @@ class Popup {
         this._contentScale = 1.0;
         this._containerSizeContentScale = null;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
-        this._messageToken = null;
         this._previousOptionsContextSource = null;
         this._containerSecret = null;
         this._containerToken = null;
@@ -296,10 +294,6 @@ class Popup {
     }
 
     async _createInjectPromise() {
-        if (this._messageToken === null) {
-            this._messageToken = await apiGetMessageToken();
-        }
-
         this._injectStyles();
 
         const {secret, token} = await this._initializeFrame(this._container, this._targetOrigin, this._frameId, (frame) => {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -76,6 +76,10 @@ function apiScreenshotGet(options) {
     return _apiInvoke('screenshotGet', {options});
 }
 
+function apiSendMessageToFrame(frameId, action, params) {
+    return _apiInvoke('sendMessageToFrame', {frameId, action, params});
+}
+
 function apiBroadcastTab(action, params) {
     return _apiInvoke('broadcastTab', {action, params});
 }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -112,10 +112,6 @@ function apiGetZoom() {
     return _apiInvoke('getZoom');
 }
 
-function apiGetMessageToken() {
-    return _apiInvoke('getMessageToken');
-}
-
 function apiGetDefaultAnkiFieldTemplates() {
     return _apiInvoke('getDefaultAnkiFieldTemplates');
 }


### PR DESCRIPTION
This PR changes the way that the popup and frame are initialized. The goal is to remove the use of [`Backend.messageToken`](https://github.com/FooSoft/yomichan/blob/d4ae9aa501ece99ea6c5e6b8fb01c3005f5b7f03/ext/bg/js/backend.js#L76) as the mechanism for ensuring message authenticity. There are two reasons for this:
* Manifest v3 discourages storing state in the service worker, as it will be started/stopped without notice. `messageToken` is effectively a state, and if it's unexpectedly changed, that could have negative consequences. (#455)
* Since the popup can be unloaded, the initialization sequence will need to be re-executed. This could also cause issues with a stale state. (#441)

Follow-up of #488, #490

(Apologies in advance for yet another lengthy description.)

## Changes

* Adds an `sendMessageToFrame` API, which sends a message to a specific frameId in the same tab.
* Removes the `getMessageToken` API.
* `DisplayFloat._windowMessageHandlers` now stores additional information about the handler. The main change is that message authentication is opt-out. If the `authenticate` field is set to `false`, the sender is not validated before running the handler.
* The old `Popup.prepare` has been split into three different steps: `prepare`, `initialize`, and `configure`.
  * The new `prepare` sets up event listeners and is called in `float-main.js`'s entry point.
  * `initialize` is an authentication step (described in more detail later) to ensure messages are coming from Yomichan and nothing else.
  * `configure` assigns various settings and information.

## Initialization

The new initialization process replaces the old `messageToken` mechanism. It is effectively a handshake operation, which is described below.

(Note: I have tried to lay the steps out sequentially, but it is really a two-part parallel operation, since both the content script and the frame are running simultaneously.)

1. `Popup` sets up the frame to load, i.e. by setting `src` and adding the `<iframe>` element to the document.
2. In the frame, `DisplayFloat` now has a new unique ID field named `secret` which is constant for its lifetime.
3. Once the `DisplayFloat` has been fully `prepare`'d, it uses `apiBroadcastTab` to broadcast a `prepareCompleted` message with its `secret` data. (This broadcast is only seen by the extension code for that tab.)
4. `Popup` waits for a `prepareCompleted` message.
   * When `Popup` receives a `prepareCompleted` message, it posts an `initialize` message directly to the frame's `contentWindow`. This message contains both the `secret` another new unique ID called `token`. (This message is only seen by the extension code for that `frameId`.)
5. When `DisplayFloat` receives an `initialize` message, it checks if the `secret` matches its secret.
   * If the `secret` does not match, the message is discarded and processing stops.
   * If the `secret` does match, `DisplayFloat` stores the `token` from the message. `DisplayFloat` sends an `initializeCompleted` message to the `frameId` which sent the the `initialize` message, with both the `secret` and `token`. **`DisplayFloat` is now authenticated.**
6. When `Popup` receives `initializeCompleted`, it checks to see if the `secret` and `token` matches.
   * If the `secret` and `token` don't both match, the message is discarded and processing stops.
   * If the `secret` and `token` both match, `Popup` stores both values. **`Popup` is now authenticated.**
7. Initialization is now complete. All future message exchanges use these unique IDs to verify the message is coming from the right source.
8. There is also a timeout and handling for error/unexpected states.

## Explanation

The reason why this works is due to the secure messaging channel provided by the WebExtension framework. The underlying content page never sees any messages posted to it, so it would never be able to determine what the `secret`/`token` is. Therefore, it will never be able to send messages to the frame.

The use of `contentWindow.postMessage` in step 4 is used as filtering mechanism in case multiple popups are initializing at the same time. This way, the message is guaranteed to _only_ be sent to the frame which `Popup` is attempting to initialize. Contrasted with a `apiBroadcastTab` or `sendMessageToFrame`, both of those functions have no way of knowing that the `frameId` corresponds to the `<iframe>` element.

(Aside: this may also make it possible to improve the `FrameOffsetForwarder`, since there is now a direct mapping of `frameId` to `<iframe>`. Out of scope for this change though.)