### PR TITLE
Support meta as scanning modifier

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -351,7 +351,7 @@
                                     },
                                     "modifier": {
                                         "type": "string",
-                                        "enum": ["none", "alt", "ctrl", "shift"],
+                                        "enum": ["none", "alt", "ctrl", "shift", "meta"],
                                         "default": "shift"
                                     },
                                     "deepDomScan": {

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -417,6 +417,7 @@
                         <option value="alt">Alt</option>
                         <option value="ctrl">Ctrl</option>
                         <option value="shift">Shift</option>
+                        <option data-hide-for-browser="firefox firefox-mobile" value="meta">Meta</option>
                     </select>
                 </div>
             </div>

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -366,6 +366,7 @@ class TextScanner extends EventDispatcher {
             case 'alt': return mouseEvent.altKey;
             case 'ctrl': return mouseEvent.ctrlKey;
             case 'shift': return mouseEvent.shiftKey;
+            case 'meta': return mouseEvent.metaKey;
             case 'none': return true;
             default: return false;
         }


### PR DESCRIPTION
It was added to profile conditions in https://github.com/FooSoft/yomichan/pull/487, so also support it as the scanning modifier key. Same thing applies here, it doesn't work on Firefox, so the option is conditionally hidden.