### PR TITLE
Dom text scanner fixes

### DIFF
--- a/ext/fg/js/dom-text-scanner.js
+++ b/ext/fg/js/dom-text-scanner.js
@@ -60,6 +60,15 @@ class DOMTextScanner {
     }
 
     /**
+     * Gets the remaining number of characters that weren't scanned in the last seek() call.
+     * This value is usually 0 unless the end of the document was reached.
+     * @returns An integer.
+     */
+    get remainder() {
+        return this._remainder;
+    }
+
+    /**
      * Gets the accumulated content string resulting from calls to seek().
      * @returns A string.
      */

--- a/ext/fg/js/dom-text-scanner.js
+++ b/ext/fg/js/dom-text-scanner.js
@@ -85,6 +85,7 @@ class DOMTextScanner {
 
         const generateLayoutContent = this._generateLayoutContent;
         let node = this._node;
+        let lastNode = node;
         let resetOffset = this._resetOffset;
         let newlines = 0;
         while (node !== null) {
@@ -92,6 +93,7 @@ class DOMTextScanner {
             const nodeType = node.nodeType;
 
             if (nodeType === TEXT_NODE) {
+                lastNode = node;
                 if (!(
                     forward ?
                     this._seekTextNodeForward(node, resetOffset) :
@@ -101,6 +103,8 @@ class DOMTextScanner {
                     break;
                 }
             } else if (nodeType === ELEMENT_NODE) {
+                lastNode = node;
+                this._offset = 0;
                 [enterable, newlines] = DOMTextScanner.getElementSeekInfo(node);
                 if (newlines > this._newlines && generateLayoutContent) {
                     this._newlines = newlines;
@@ -121,7 +125,7 @@ class DOMTextScanner {
             resetOffset = true;
         }
 
-        this._node = node;
+        this._node = lastNode;
         this._resetOffset = resetOffset;
 
         return this;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "test": "npm run test-lint && npm run test-code",
         "test-lint": "eslint . && node ./test/lint/global-declarations.js",
-        "test-code": "node ./test/test-schema.js && node ./test/test-dictionary.js && node ./test/test-database.js && node ./test/test-document.js && node ./test/test-object-property-accessor.js && node ./test/test-japanese.js && node ./test/test-text-source-map.js"
+        "test-code": "node ./test/test-schema.js && node ./test/test-dictionary.js && node ./test/test-database.js && node ./test/test-document.js && node ./test/test-object-property-accessor.js && node ./test/test-japanese.js && node ./test/test-text-source-map.js && node ./test/test-dom-text-scanner.js"
     },
     "repository": {
         "type": "git",

--- a/test/data/html/test-dom-text-scanner.html
+++ b/test/data/html/test-dom-text-scanner.html
@@ -85,7 +85,7 @@
             "expected": {
                 "node": "span:nth-of-type(2)::text",
                 "offset": 6,
-                "content": "小ぢんまり1\n小ぢんまり2"
+                "content": "小ぢんまり1 小ぢんまり2"
             }
         }'
     >

--- a/test/test-dom-text-scanner.js
+++ b/test/test-dom-text-scanner.js
@@ -103,7 +103,8 @@ async function testDomTextScanner(dom, {DOMTextScanner}) {
                 expected: {
                     node: expectedNode,
                     offset: expectedOffset,
-                    content: expectedContent
+                    content: expectedContent,
+                    remainder: expectedRemainder
                 }
             } = testDataItem;
 
@@ -115,10 +116,11 @@ async function testDomTextScanner(dom, {DOMTextScanner}) {
                 const scanner = new DOMTextScanner(node, offset, forcePreserveWhitespace, generateLayoutContent);
                 scanner.seek(length);
 
-                const {node: actualNode1, offset: actualOffset1, content: actualContent1} = scanner;
+                const {node: actualNode1, offset: actualOffset1, content: actualContent1, remainder: actualRemainder1} = scanner;
                 assert.strictEqual(actualContent1, expectedContent);
                 assert.strictEqual(actualOffset1, expectedOffset);
                 assert.strictEqual(actualNode1, expectedNode);
+                assert.strictEqual(actualRemainder1, expectedRemainder || 0);
             }
 
             // Substring tests


### PR DESCRIPTION
* Fixes a test.
* Actually enables the tests.
* Updates `DOMTextScanner._node` to never become `null`, since this can cause issues with how it will be used elsewhere in the code.
* Adds public `remainder` getter.