### PR TITLE
Fix modifier key condition data

### DIFF
--- a/ext/bg/js/conditions.js
+++ b/ext/bg/js/conditions.js
@@ -59,10 +59,11 @@ function conditionsNormalizeOptionValue(descriptors, type, operator, optionValue
     let inputTransformedValue = null;
     if (isInput) {
         for (const descriptor of descriptorArray) {
-            inputTransformedValue = conditionsValidateOptionInputValue(
-                descriptor,
-                inputTransformedValue !== null ? inputTransformedValue : transformedValue
-            );
+            let value = inputTransformedValue !== null ? inputTransformedValue : transformedValue;
+            value = conditionsValidateOptionInputValue(descriptor, value);
+            if (value !== null) {
+                inputTransformedValue = value;
+            }
         }
 
         if (inputTransformedValue !== null) {

--- a/ext/bg/js/conditions.js
+++ b/ext/bg/js/conditions.js
@@ -25,10 +25,12 @@ function conditionsValidateOptionValue(object, value, isInput=false) {
         value = object.transformInput(value);
     } else if (hasOwn(object, 'transform')) {
         value = object.transform(value);
+    } else {
+        return value;
+    }
 
-        if (hasOwn(object, 'validateTransformed') && !object.validateTransformed(value)) {
-            throw new Error('Invalid value for condition');
-        }
+    if (hasOwn(object, 'validateTransformed') && !object.validateTransformed(value)) {
+        throw new Error('Invalid value for condition');
     }
 
     return value;

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -128,9 +128,9 @@ const profileConditionsDescriptor = {
             are: {
                 name: 'are',
                 placeholder: 'Press one or more modifier keys here',
-                defaultValue: '',
+                defaultValue: [],
                 type: 'keyMulti',
-                transform: (optionValue) => optionValue
+                transformInput: (optionValue) => optionValue
                     .split(' + ')
                     .filter((v) => v.length > 0)
                     .map((v) => _profileModifierNameToValue.get(v)),
@@ -142,9 +142,9 @@ const profileConditionsDescriptor = {
             areNot: {
                 name: 'are not',
                 placeholder: 'Press one or more modifier keys here',
-                defaultValue: '',
+                defaultValue: [],
                 type: 'keyMulti',
-                transform: (optionValue) => optionValue
+                transformInput: (optionValue) => optionValue
                     .split(' + ')
                     .filter((v) => v.length > 0)
                     .map((v) => _profileModifierNameToValue.get(v)),

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -104,11 +104,11 @@ ConditionsUI.Container = class Container {
             if (hasOwn(conditionDescriptor.operators, operator)) {
                 const operatorDescriptor = conditionDescriptor.operators[operator];
                 if (hasOwn(operatorDescriptor, 'defaultValue')) {
-                    return {value: operatorDescriptor.defaultValue, fromOperator: true};
+                    return {value: this.isolate(operatorDescriptor.defaultValue), fromOperator: true};
                 }
             }
             if (hasOwn(conditionDescriptor, 'defaultValue')) {
-                return {value: conditionDescriptor.defaultValue, fromOperator: false};
+                return {value: this.isolate(conditionDescriptor.defaultValue), fromOperator: false};
             }
         }
         return {fromOperator: false};
@@ -205,6 +205,10 @@ ConditionsUI.Condition = class Condition {
         this.parent.save();
     }
 
+    isolate(object) {
+        return this.parent.isolate(object);
+    }
+
     updateTypes() {
         const conditionDescriptors = this.parent.parent.conditionDescriptors;
         const optionGroup = this.typeSelect.find('optgroup');
@@ -266,9 +270,9 @@ ConditionsUI.Condition = class Condition {
         this.inputInner.appendTo(this.input);
         this.inputInner.on('change', this.onInputChanged.bind(this));
 
-        const {valid} = this.validateValue(this.condition.value);
+        const {valid, value} = this.validateConditionValue(this.condition.value);
         this.inputInner.toggleClass('is-invalid', !valid);
-        this.inputInner.val(this.condition.value);
+        this.inputInner.val(value);
     }
 
     createInputElement(objects) {
@@ -366,7 +370,7 @@ ConditionsUI.Condition = class Condition {
                 data.set('values', object.values);
             }
             if (hasOwn(object, 'defaultValue')) {
-                data.set('defaultValue', object.defaultValue);
+                data.set('defaultValue', this.isolate(object.defaultValue));
             }
         }
 
@@ -379,33 +383,35 @@ ConditionsUI.Condition = class Condition {
 
         const defaultValue = data.get('defaultValue');
         if (defaultValue !== null) {
-            inputInner.val(defaultValue);
+            inputInner.val(this.isolate(defaultValue));
         }
 
         return inputInner;
     }
 
-    validateValue(value) {
+    validateConditionValue(value, isInput=false) {
         const conditionDescriptors = this.parent.parent.conditionDescriptors;
         let valid = true;
+        let transformedValue = value;
         try {
-            value = conditionsNormalizeOptionValue(
+            [value, transformedValue] = conditionsNormalizeOptionValue(
                 conditionDescriptors,
                 this.condition.type,
                 this.condition.operator,
-                value
+                value,
+                isInput
             );
         } catch (e) {
             valid = false;
         }
-        return {valid, value};
+        return {valid, value, transformedValue};
     }
 
     onInputChanged() {
-        const {valid, value} = this.validateValue(this.inputInner.val());
+        const {valid, value, transformedValue} = this.validateConditionValue(this.inputInner.val(), true);
         this.inputInner.toggleClass('is-invalid', !valid);
         this.inputInner.val(value);
-        this.condition.value = value;
+        this.condition.value = transformedValue;
         this.save();
     }
 

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -270,7 +270,7 @@ ConditionsUI.Condition = class Condition {
         this.inputInner.appendTo(this.input);
         this.inputInner.on('change', this.onInputChanged.bind(this));
 
-        const {valid, value} = this.validateConditionValue(this.condition.value);
+        const {valid, value} = this.validateValue(this.condition.value);
         this.inputInner.toggleClass('is-invalid', !valid);
         this.inputInner.val(value);
     }
@@ -389,7 +389,7 @@ ConditionsUI.Condition = class Condition {
         return inputInner;
     }
 
-    validateConditionValue(value, isInput=false) {
+    validateValue(value, isInput=false) {
         const conditionDescriptors = this.parent.parent.conditionDescriptors;
         let valid = true;
         let transformedValue = value;
@@ -408,7 +408,7 @@ ConditionsUI.Condition = class Condition {
     }
 
     onInputChanged() {
-        const {valid, value, transformedValue} = this.validateConditionValue(this.inputInner.val(), true);
+        const {valid, value, transformedValue} = this.validateValue(this.inputInner.val(), true);
         this.inputInner.toggleClass('is-invalid', !valid);
         this.inputInner.val(value);
         this.condition.value = transformedValue;

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -392,9 +392,9 @@ ConditionsUI.Condition = class Condition {
     validateValue(value, isInput=false) {
         const conditionDescriptors = this.parent.parent.conditionDescriptors;
         let valid = true;
-        let transformedValue = value;
+        let inputTransformedValue = null;
         try {
-            [value, transformedValue] = conditionsNormalizeOptionValue(
+            [value, inputTransformedValue] = conditionsNormalizeOptionValue(
                 conditionDescriptors,
                 this.condition.type,
                 this.condition.operator,
@@ -404,14 +404,14 @@ ConditionsUI.Condition = class Condition {
         } catch (e) {
             valid = false;
         }
-        return {valid, value, transformedValue};
+        return {valid, value, inputTransformedValue};
     }
 
     onInputChanged() {
-        const {valid, value, transformedValue} = this.validateValue(this.inputInner.val(), true);
+        const {valid, value, inputTransformedValue} = this.validateValue(this.inputInner.val(), true);
         this.inputInner.toggleClass('is-invalid', !valid);
         this.inputInner.val(value);
-        this.condition.value = transformedValue;
+        this.condition.value = inputTransformedValue !== null ? inputTransformedValue : value;
         this.save();
     }
 


### PR DESCRIPTION
Fixes https://github.com/FooSoft/yomichan/issues/503.

Saves the transformed value of the input as a profile condition instead of the transformed and reversed value. Since the default value changes from `''` to `[]`, all default values have to be isolated.

Can be used in the future by supplying `transformInput` into the descriptor in place of `transform`.