### PR TITLE
Text scanning update

### DIFF
--- a/ext/fg/js/document.js
+++ b/ext/fg/js/document.js
@@ -159,7 +159,7 @@ function docSentenceExtract(source, extent) {
 
     const sourceLocal = source.clone();
     const position = sourceLocal.setStartOffset(extent);
-    sourceLocal.setEndOffset(position + extent);
+    sourceLocal.setEndOffset(extent * 2 - position, true);
     const content = sourceLocal.text();
 
     let quoteStack = [];

--- a/ext/fg/js/source.js
+++ b/ext/fg/js/source.js
@@ -46,10 +46,14 @@ class TextSourceRange {
         return this.content;
     }
 
-    setEndOffset(length) {
-        const state = TextSourceRange.seekForward(this.range.startContainer, this.range.startOffset, length);
+    setEndOffset(length, fromEnd=false) {
+        const state = (
+            fromEnd ?
+            TextSourceRange.seekForward(this.range.endContainer, this.range.endOffset, length) :
+            TextSourceRange.seekForward(this.range.startContainer, this.range.startOffset, length)
+        );
         this.range.setEnd(state.node, state.offset);
-        this.content = state.content;
+        this.content = (fromEnd ? this.content + state.content : state.content);
         return length - state.remainder;
     }
 

--- a/test/data/html/test-document1.html
+++ b/test/data/html/test-document1.html
@@ -103,6 +103,7 @@
         data-end-node-selector="img"
         data-end-offset="0"
         data-result-type="TextSourceElement"
+        data-sentence-extent="100"
         data-sentence="よみちゃん"
     >
         <img src="data:image/gif;base64,R0lGODdhBwAHAIABAAAAAP///ywAAAAABwAHAAACDIRvEaC32FpCbEkKCgA7" alt="よみちゃん" title="よみちゃん" style="width: 70px; height: 70px; image-rendering: crisp-edges; image-rendering: pixelated; display: block;" />


### PR DESCRIPTION
* Fixes a test with a missing parameter.
* Updates `docSentenceExtract` to not rescan text after moving the starting cursor. Instead, it scans bidirectionally away from the initial cursor. (This is related to what I commented on here: https://github.com/FooSoft/yomichan/pull/458#issuecomment-619281704)
* `TextSourceRange.setEndOffset` now has a `fromEnd` parameter to support the above. Since there are many other places using `setEndOffset`, I chose not to change those for now.