### PR TITLE
Text selection fixes

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -301,6 +301,11 @@ class DisplaySearch extends Display {
         this.queryParser.setText(interpretedQuery);
     }
 
+    async setContent(type, details) {
+        this.query.blur();
+        await super.setContent(type, details);
+    }
+
     setIntroVisible(visible, animate) {
         if (this.introVisible === visible) {
             return;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -257,6 +257,8 @@ class Frontend {
         const definitions = await apiKanjiFind(searchText, optionsContext);
         if (definitions.length === 0) { return null; }
 
+        textSource.setEndOffset(1);
+
         return {definitions, type: 'kanji'};
     }
 


### PR DESCRIPTION
- https://github.com/FooSoft/yomichan/commit/96c137ac166e92b4d69758ebf3f6c5758d074512 fixes a bug introduced in https://github.com/FooSoft/yomichan/pull/500
- https://github.com/FooSoft/yomichan/commit/68cc57c47a64aa0a58052d72e6d37bcaf5e45a0f fixes an issue on Firefox where the search input can stay focused and/or selected while scanning text with QueryParser and the QueryParser text stays unselected. It started happening some time after I updated to version 76, but it could also be some recent change in Yomichan.