### PR TITLE
Popup proxy host refactor

### DIFF
--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -31,7 +31,7 @@ async function injectSearchFrontend() {
         '/fg/js/frontend-api-receiver.js',
         '/fg/js/frame-offset-forwarder.js',
         '/fg/js/popup.js',
-        '/fg/js/popup-proxy-host.js',
+        '/fg/js/popup-factory.js',
         '/fg/js/frontend.js',
         '/fg/js/content-script-main.js'
     ]);

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -56,10 +56,10 @@ class SettingsPopupPreview {
         window.apiOptionsGet = this.apiOptionsGet.bind(this);
 
         // Overwrite frontend
-        const popupHost = new PopupFactory();
-        await popupHost.prepare();
+        const popupFactory = new PopupFactory();
+        await popupFactory.prepare();
 
-        this.popup = popupHost.getOrCreatePopup();
+        this.popup = popupFactory.getOrCreatePopup();
         this.popup.setChildrenSupported(false);
 
         this.popupSetCustomOuterCssOld = this.popup.setCustomOuterCss;

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -20,6 +20,7 @@
  * Popup
  * PopupFactory
  * TextSourceRange
+ * apiFrameInformationGet
  * apiOptionsGet
  */
 
@@ -56,7 +57,9 @@ class SettingsPopupPreview {
         window.apiOptionsGet = this.apiOptionsGet.bind(this);
 
         // Overwrite frontend
-        const popupFactory = new PopupFactory();
+        const {frameId} = await apiFrameInformationGet();
+
+        const popupFactory = new PopupFactory(frameId);
         await popupFactory.prepare();
 
         this.popup = popupFactory.getOrCreatePopup();

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -18,7 +18,7 @@
 /* global
  * Frontend
  * Popup
- * PopupProxyHost
+ * PopupFactory
  * TextSourceRange
  * apiOptionsGet
  */
@@ -56,7 +56,7 @@ class SettingsPopupPreview {
         window.apiOptionsGet = this.apiOptionsGet.bind(this);
 
         // Overwrite frontend
-        const popupHost = new PopupProxyHost();
+        const popupHost = new PopupFactory();
         await popupHost.prepare();
 
         this.popup = popupHost.getOrCreatePopup();

--- a/ext/bg/settings-popup-preview.html
+++ b/ext/bg/settings-popup-preview.html
@@ -127,7 +127,7 @@
         <script src="/fg/js/frontend-api-receiver.js"></script>
         <script src="/fg/js/popup.js"></script>
         <script src="/fg/js/source.js"></script>
-        <script src="/fg/js/popup-proxy-host.js"></script>
+        <script src="/fg/js/popup-factory.js"></script>
         <script src="/fg/js/frontend.js"></script>
         <script src="/bg/js/settings/popup-preview-frame.js"></script>
 

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -23,6 +23,7 @@
  * PopupProxy
  * apiBroadcastTab
  * apiForwardLogsToBackend
+ * apiFrameInformationGet
  * apiOptionsGet
  */
 
@@ -47,7 +48,14 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
 }
 
 async function getOrCreatePopup(depth) {
-    const popupFactory = new PopupFactory();
+    const {frameId} = await apiFrameInformationGet();
+    if (typeof frameId !== 'number') {
+        const error = new Error('Failed to get frameId');
+        yomichan.logError(error);
+        throw error;
+    }
+
+    const popupFactory = new PopupFactory(frameId);
     await popupFactory.prepare();
 
     const popup = popupFactory.getOrCreatePopup(null, null, depth);

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -47,10 +47,10 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
 }
 
 async function getOrCreatePopup(depth) {
-    const popupHost = new PopupFactory();
-    await popupHost.prepare();
+    const popupFactory = new PopupFactory();
+    await popupFactory.prepare();
 
-    const popup = popupHost.getOrCreatePopup(null, null, depth);
+    const popup = popupFactory.getOrCreatePopup(null, null, depth);
 
     return popup;
 }

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -97,20 +97,20 @@ async function createPopupProxy(depth, id, parentFrameId) {
     };
 
     let urlUpdatedAt = 0;
-    let proxyHostUrlCached = url;
-    const getProxyHostUrl = async () => {
+    let popupProxyUrlCached = url;
+    const getPopupProxyUrl = async () => {
         const now = Date.now();
         if (popups.proxy !== null && now - urlUpdatedAt > 500) {
-            proxyHostUrlCached = await popups.proxy.getHostUrl();
+            popupProxyUrlCached = await popups.proxy.getUrl();
             urlUpdatedAt = now;
         }
-        return proxyHostUrlCached;
+        return popupProxyUrlCached;
     };
 
     const applyOptions = async () => {
         const optionsContext = {
             depth: isSearchPage ? 0 : depth,
-            url: proxy ? await getProxyHostUrl() : window.location.href
+            url: proxy ? await getPopupProxyUrl() : window.location.href
         };
         const options = await apiOptionsGet(optionsContext);
 
@@ -132,7 +132,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
         }
 
         if (frontend === null) {
-            const getUrl = proxy ? getProxyHostUrl : null;
+            const getUrl = proxy ? getPopupProxyUrl : null;
             frontend = new Frontend(popup, getUrl);
             frontendPreparePromise = frontend.prepare();
             await frontendPreparePromise;

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -19,8 +19,8 @@
  * DOM
  * FrameOffsetForwarder
  * Frontend
+ * PopupFactory
  * PopupProxy
- * PopupProxyHost
  * apiBroadcastTab
  * apiForwardLogsToBackend
  * apiOptionsGet
@@ -47,7 +47,7 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
 }
 
 async function getOrCreatePopup(depth) {
-    const popupHost = new PopupProxyHost();
+    const popupHost = new PopupFactory();
     await popupHost.prepare();
 
     const popup = popupHost.getOrCreatePopup(null, null, depth);

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -21,7 +21,7 @@
  * apiFrameInformationGet
  */
 
-class PopupProxyHost {
+class PopupFactory {
     constructor() {
         this._popups = new Map();
         this._frameId = null;
@@ -126,14 +126,14 @@ class PopupProxyHost {
 
     async _onApiContainsPoint({id, x, y}) {
         const popup = this._getPopup(id);
-        [x, y] = PopupProxyHost._convertPopupPointToRootPagePoint(popup, x, y);
+        [x, y] = PopupFactory._convertPopupPointToRootPagePoint(popup, x, y);
         return await popup.containsPoint(x, y);
     }
 
     async _onApiShowContent({id, elementRect, writingMode, type, details, context}) {
         const popup = this._getPopup(id);
-        elementRect = PopupProxyHost._convertJsonRectToDOMRect(popup, elementRect);
-        if (!PopupProxyHost._popupCanShow(popup)) { return; }
+        elementRect = PopupFactory._convertJsonRectToDOMRect(popup, elementRect);
+        if (!PopupFactory._popupCanShow(popup)) { return; }
         return await popup.showContent(elementRect, writingMode, type, details, context);
     }
 
@@ -167,7 +167,7 @@ class PopupProxyHost {
     }
 
     static _convertJsonRectToDOMRect(popup, jsonRect) {
-        const [x, y] = PopupProxyHost._convertPopupPointToRootPagePoint(popup, jsonRect.x, jsonRect.y);
+        const [x, y] = PopupFactory._convertPopupPointToRootPagePoint(popup, jsonRect.x, jsonRect.y);
         return new DOMRect(x, y, jsonRect.width, jsonRect.height);
     }
 

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -35,17 +35,17 @@ class PopupFactory {
         this._frameId = frameId;
 
         const apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
-            ['getOrCreatePopup', this._onApiGetOrCreatePopup.bind(this)],
-            ['setOptionsContext', this._onApiSetOptionsContext.bind(this)],
-            ['hide', this._onApiHide.bind(this)],
-            ['isVisible', this._onApiIsVisibleAsync.bind(this)],
-            ['setVisibleOverride', this._onApiSetVisibleOverride.bind(this)],
-            ['containsPoint', this._onApiContainsPoint.bind(this)],
-            ['showContent', this._onApiShowContent.bind(this)],
-            ['setCustomCss', this._onApiSetCustomCss.bind(this)],
-            ['clearAutoPlayTimer', this._onApiClearAutoPlayTimer.bind(this)],
-            ['setContentScale', this._onApiSetContentScale.bind(this)],
-            ['getHostUrl', this._onApiGetHostUrl.bind(this)]
+            ['getOrCreatePopup',   {async: true,  handler: this._onApiGetOrCreatePopup.bind(this)}],
+            ['setOptionsContext',  {async: true,  handler: this._onApiSetOptionsContext.bind(this)}],
+            ['hide',               {async: true,  handler: this._onApiHide.bind(this)}],
+            ['isVisible',          {async: true,  handler: this._onApiIsVisibleAsync.bind(this)}],
+            ['setVisibleOverride', {async: true,  handler: this._onApiSetVisibleOverride.bind(this)}],
+            ['containsPoint',      {async: true,  handler: this._onApiContainsPoint.bind(this)}],
+            ['showContent',        {async: true,  handler: this._onApiShowContent.bind(this)}],
+            ['setCustomCss',       {async: true,  handler: this._onApiSetCustomCss.bind(this)}],
+            ['clearAutoPlayTimer', {async: true,  handler: this._onApiClearAutoPlayTimer.bind(this)}],
+            ['setContentScale',    {async: true,  handler: this._onApiSetContentScale.bind(this)}],
+            ['getHostUrl',         {async: true,  handler: this._onApiGetHostUrl.bind(this)}]
         ]));
         apiReceiver.prepare();
     }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -40,7 +40,7 @@ class PopupFactory {
             ['setCustomCss',       {async: false, handler: this._onApiSetCustomCss.bind(this)}],
             ['clearAutoPlayTimer', {async: false, handler: this._onApiClearAutoPlayTimer.bind(this)}],
             ['setContentScale',    {async: false, handler: this._onApiSetContentScale.bind(this)}],
-            ['getHostUrl',         {async: false, handler: this._onApiGetHostUrl.bind(this)}]
+            ['getUrl',             {async: false, handler: this._onApiGetUrl.bind(this)}]
         ]));
         apiReceiver.prepare();
     }
@@ -147,7 +147,7 @@ class PopupFactory {
         return popup.setContentScale(scale);
     }
 
-    _onApiGetHostUrl() {
+    _onApiGetUrl() {
         return window.location.href;
     }
 

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -126,14 +126,14 @@ class PopupFactory {
 
     async _onApiContainsPoint({id, x, y}) {
         const popup = this._getPopup(id);
-        [x, y] = PopupFactory._convertPopupPointToRootPagePoint(popup, x, y);
+        [x, y] = this._convertPopupPointToRootPagePoint(popup, x, y);
         return await popup.containsPoint(x, y);
     }
 
     async _onApiShowContent({id, elementRect, writingMode, type, details, context}) {
         const popup = this._getPopup(id);
-        elementRect = PopupFactory._convertJsonRectToDOMRect(popup, elementRect);
-        if (!PopupFactory._popupCanShow(popup)) { return; }
+        elementRect = this._convertJsonRectToDOMRect(popup, elementRect);
+        if (!this._popupCanShow(popup)) { return; }
         return await popup.showContent(elementRect, writingMode, type, details, context);
     }
 
@@ -166,12 +166,12 @@ class PopupFactory {
         return popup;
     }
 
-    static _convertJsonRectToDOMRect(popup, jsonRect) {
-        const [x, y] = PopupFactory._convertPopupPointToRootPagePoint(popup, jsonRect.x, jsonRect.y);
+    _convertJsonRectToDOMRect(popup, jsonRect) {
+        const [x, y] = this._convertPopupPointToRootPagePoint(popup, jsonRect.x, jsonRect.y);
         return new DOMRect(x, y, jsonRect.width, jsonRect.height);
     }
 
-    static _convertPopupPointToRootPagePoint(popup, x, y) {
+    _convertPopupPointToRootPagePoint(popup, x, y) {
         if (popup.parent !== null) {
             const popupRect = popup.parent.getContainerRect();
             x += popupRect.x;
@@ -180,7 +180,7 @@ class PopupFactory {
         return [x, y];
     }
 
-    static _popupCanShow(popup) {
+    _popupCanShow(popup) {
         return popup.parent === null || popup.parent.isVisibleSync();
     }
 }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -18,22 +18,17 @@
 /* global
  * FrontendApiReceiver
  * Popup
- * apiFrameInformationGet
  */
 
 class PopupFactory {
-    constructor() {
+    constructor(frameId) {
         this._popups = new Map();
-        this._frameId = null;
+        this._frameId = frameId;
     }
 
     // Public functions
 
     async prepare() {
-        const {frameId} = await apiFrameInformationGet();
-        if (typeof frameId !== 'number') { return; }
-        this._frameId = frameId;
-
         const apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
             ['getOrCreatePopup',   {async: false, handler: this._onApiGetOrCreatePopup.bind(this)}],
             ['setOptionsContext',  {async: true,  handler: this._onApiSetOptionsContext.bind(this)}],

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -42,7 +42,7 @@ class PopupFactory {
             ['setVisibleOverride', {async: true,  handler: this._onApiSetVisibleOverride.bind(this)}],
             ['containsPoint',      {async: true,  handler: this._onApiContainsPoint.bind(this)}],
             ['showContent',        {async: true,  handler: this._onApiShowContent.bind(this)}],
-            ['setCustomCss',       {async: true,  handler: this._onApiSetCustomCss.bind(this)}],
+            ['setCustomCss',       {async: false, handler: this._onApiSetCustomCss.bind(this)}],
             ['clearAutoPlayTimer', {async: false, handler: this._onApiClearAutoPlayTimer.bind(this)}],
             ['setContentScale',    {async: false, handler: this._onApiSetContentScale.bind(this)}],
             ['getHostUrl',         {async: false, handler: this._onApiGetHostUrl.bind(this)}]
@@ -137,7 +137,7 @@ class PopupFactory {
         return await popup.showContent(elementRect, writingMode, type, details, context);
     }
 
-    async _onApiSetCustomCss({id, css}) {
+    _onApiSetCustomCss({id, css}) {
         const popup = this._getPopup(id);
         return popup.setCustomCss(css);
     }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -35,17 +35,17 @@ class PopupFactory {
         this._frameId = frameId;
 
         const apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
-            ['getOrCreatePopup',   {async: true,  handler: this._onApiGetOrCreatePopup.bind(this)}],
+            ['getOrCreatePopup',   {async: false, handler: this._onApiGetOrCreatePopup.bind(this)}],
             ['setOptionsContext',  {async: true,  handler: this._onApiSetOptionsContext.bind(this)}],
-            ['hide',               {async: true,  handler: this._onApiHide.bind(this)}],
+            ['hide',               {async: false, handler: this._onApiHide.bind(this)}],
             ['isVisible',          {async: true,  handler: this._onApiIsVisibleAsync.bind(this)}],
             ['setVisibleOverride', {async: true,  handler: this._onApiSetVisibleOverride.bind(this)}],
             ['containsPoint',      {async: true,  handler: this._onApiContainsPoint.bind(this)}],
             ['showContent',        {async: true,  handler: this._onApiShowContent.bind(this)}],
             ['setCustomCss',       {async: true,  handler: this._onApiSetCustomCss.bind(this)}],
-            ['clearAutoPlayTimer', {async: true,  handler: this._onApiClearAutoPlayTimer.bind(this)}],
-            ['setContentScale',    {async: true,  handler: this._onApiSetContentScale.bind(this)}],
-            ['getHostUrl',         {async: true,  handler: this._onApiGetHostUrl.bind(this)}]
+            ['clearAutoPlayTimer', {async: false, handler: this._onApiClearAutoPlayTimer.bind(this)}],
+            ['setContentScale',    {async: false, handler: this._onApiSetContentScale.bind(this)}],
+            ['getHostUrl',         {async: false, handler: this._onApiGetHostUrl.bind(this)}]
         ]));
         apiReceiver.prepare();
     }
@@ -97,7 +97,7 @@ class PopupFactory {
 
     // API message handlers
 
-    async _onApiGetOrCreatePopup({id, parentId}) {
+    _onApiGetOrCreatePopup({id, parentId}) {
         const popup = this.getOrCreatePopup(id, parentId);
         return {
             id: popup.id
@@ -109,7 +109,7 @@ class PopupFactory {
         return await popup.setOptionsContext(optionsContext, source);
     }
 
-    async _onApiHide({id, changeFocus}) {
+    _onApiHide({id, changeFocus}) {
         const popup = this._getPopup(id);
         return popup.hide(changeFocus);
     }
@@ -142,17 +142,17 @@ class PopupFactory {
         return popup.setCustomCss(css);
     }
 
-    async _onApiClearAutoPlayTimer({id}) {
+    _onApiClearAutoPlayTimer({id}) {
         const popup = this._getPopup(id);
         return popup.clearAutoPlayTimer();
     }
 
-    async _onApiSetContentScale({id, scale}) {
+    _onApiSetContentScale({id, scale}) {
         const popup = this._getPopup(id);
         return popup.setContentScale(scale);
     }
 
-    async _onApiGetHostUrl() {
+    _onApiGetHostUrl() {
         return window.location.href;
     }
 

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -29,7 +29,7 @@ class PopupFactory {
     // Public functions
 
     async prepare() {
-        const apiReceiver = new FrontendApiReceiver(`popup-proxy-host#${this._frameId}`, new Map([
+        const apiReceiver = new FrontendApiReceiver(`popup-factory#${this._frameId}`, new Map([
             ['getOrCreatePopup',   {async: false, handler: this._onApiGetOrCreatePopup.bind(this)}],
             ['setOptionsContext',  {async: true,  handler: this._onApiSetOptionsContext.bind(this)}],
             ['hide',               {async: false, handler: this._onApiHide.bind(this)}],

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -115,7 +115,7 @@ class PopupProxy {
         if (typeof this._parentFrameId !== 'number') {
             return Promise.reject(new Error('Invalid frame'));
         }
-        return this._apiSender.invoke(action, params, `popup-proxy-host#${this._parentFrameId}`);
+        return this._apiSender.invoke(action, params, `popup-factory#${this._parentFrameId}`);
     }
 
     async _updateFrameOffset() {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -93,8 +93,8 @@ class PopupProxy {
         return await this._invokeHostApi('showContent', {id: this._id, elementRect, writingMode, type, details, context});
     }
 
-    async setCustomCss(css) {
-        return await this._invokeHostApi('setCustomCss', {id: this._id, css});
+    setCustomCss(css) {
+        this._invokeHostApi('setCustomCss', {id: this._id, css});
     }
 
     clearAutoPlayTimer() {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -105,8 +105,8 @@ class PopupProxy {
         this._invoke('setContentScale', {id: this._id, scale});
     }
 
-    async getHostUrl() {
-        return await this._invoke('getHostUrl', {});
+    async getUrl() {
+        return await this._invoke('getUrl', {});
     }
 
     // Private

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -101,7 +101,7 @@ class PopupProxy {
         this._invokeHostApi('clearAutoPlayTimer', {id: this._id});
     }
 
-    async setContentScale(scale) {
+    setContentScale(scale) {
         this._invokeHostApi('setContentScale', {id: this._id, scale});
     }
 

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -51,7 +51,7 @@ class PopupProxy {
     // Public functions
 
     async prepare() {
-        const {id} = await this._invokeHostApi('getOrCreatePopup', {id: this._id, parentId: this._parentId});
+        const {id} = await this._invoke('getOrCreatePopup', {id: this._id, parentId: this._parentId});
         this._id = id;
     }
 
@@ -60,19 +60,19 @@ class PopupProxy {
     }
 
     async setOptionsContext(optionsContext, source) {
-        return await this._invokeHostApi('setOptionsContext', {id: this._id, optionsContext, source});
+        return await this._invoke('setOptionsContext', {id: this._id, optionsContext, source});
     }
 
     hide(changeFocus) {
-        this._invokeHostApi('hide', {id: this._id, changeFocus});
+        this._invoke('hide', {id: this._id, changeFocus});
     }
 
     async isVisible() {
-        return await this._invokeHostApi('isVisible', {id: this._id});
+        return await this._invoke('isVisible', {id: this._id});
     }
 
     setVisibleOverride(visible) {
-        this._invokeHostApi('setVisibleOverride', {id: this._id, visible});
+        this._invoke('setVisibleOverride', {id: this._id, visible});
     }
 
     async containsPoint(x, y) {
@@ -80,7 +80,7 @@ class PopupProxy {
             await this._updateFrameOffset();
             [x, y] = this._applyFrameOffset(x, y);
         }
-        return await this._invokeHostApi('containsPoint', {id: this._id, x, y});
+        return await this._invoke('containsPoint', {id: this._id, x, y});
     }
 
     async showContent(elementRect, writingMode, type, details, context) {
@@ -90,28 +90,28 @@ class PopupProxy {
             [x, y] = this._applyFrameOffset(x, y);
         }
         elementRect = {x, y, width, height};
-        return await this._invokeHostApi('showContent', {id: this._id, elementRect, writingMode, type, details, context});
+        return await this._invoke('showContent', {id: this._id, elementRect, writingMode, type, details, context});
     }
 
     setCustomCss(css) {
-        this._invokeHostApi('setCustomCss', {id: this._id, css});
+        this._invoke('setCustomCss', {id: this._id, css});
     }
 
     clearAutoPlayTimer() {
-        this._invokeHostApi('clearAutoPlayTimer', {id: this._id});
+        this._invoke('clearAutoPlayTimer', {id: this._id});
     }
 
     setContentScale(scale) {
-        this._invokeHostApi('setContentScale', {id: this._id, scale});
+        this._invoke('setContentScale', {id: this._id, scale});
     }
 
     async getHostUrl() {
-        return await this._invokeHostApi('getHostUrl', {});
+        return await this._invoke('getHostUrl', {});
     }
 
     // Private
 
-    _invokeHostApi(action, params={}) {
+    _invoke(action, params={}) {
         if (typeof this._parentFrameId !== 'number') {
             return Promise.reject(new Error('Invalid frame'));
         }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -139,7 +139,7 @@ class Popup {
         this._invokeApi('setContent', {type, details});
     }
 
-    async setCustomCss(css) {
+    setCustomCss(css) {
         this._invokeApi('setCustomCss', {css});
     }
 

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -44,9 +44,9 @@
             "fg/js/frontend-api-receiver.js",
             "fg/js/popup.js",
             "fg/js/source.js",
+            "fg/js/popup-factory.js",
             "fg/js/frame-offset-forwarder.js",
             "fg/js/popup-proxy.js",
-            "fg/js/popup-proxy-host.js",
             "fg/js/frontend.js",
             "fg/js/content-script-main.js"
         ],


### PR DESCRIPTION
Various refactorings to `PopupProxyHost` and friends.

* Renamed `PopupProxyHost` to `PopupFactory` since that seems to better represent its use.
* Added support for non-async handlers to `FrontendApiReceiver`.
* Made use of `async` more consistent for some `Popup`/`PopupProxy` functions.
* Removed `static` from some private functions.
* Pass `frameId` into `PopupFactory`'s constructor rather than fetching it in `prepare`. All of the current use cases should have a valid `frameId`, so an error is now emitted if something goes wrong.