### PR TITLE
Text scanner refactor

### DIFF
--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -37,7 +37,7 @@ class QueryParser {
         this._textScanner = new TextScanner({
             node: this._queryParser,
             ignoreElements: () => [],
-            ignorePoints: [],
+            ignorePoints: null,
             search: this._search.bind(this)
         });
     }

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -34,12 +34,12 @@ class QueryParser {
         this._queryParser = document.querySelector('#query-parser-content');
         this._queryParserSelect = document.querySelector('#query-parser-select-container');
         this._queryParserGenerator = new QueryParserGenerator();
-        this._textScanner = new TextScanner(
-            this._queryParser,
-            () => [],
-            [],
-            this._search.bind(this)
-        );
+        this._textScanner = new TextScanner({
+            node: this._queryParser,
+            ignoreElements: () => [],
+            ignorePoints: [],
+            search: this._search.bind(this)
+        });
     }
 
     async prepare() {

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -37,9 +37,9 @@ class QueryParser {
         this._textScanner = new TextScanner(
             this._queryParser,
             () => [],
-            []
+            [],
+            this._search.bind(this)
         );
-        this._textScanner.onSearchSource = this._onSearchSource.bind(this);
     }
 
     async prepare() {
@@ -74,7 +74,7 @@ class QueryParser {
         this._textScanner.searchAt(e.clientX, e.clientY, 'click');
     }
 
-    async _onSearchSource(textSource, cause) {
+    async _search(textSource, cause) {
         if (textSource === null) { return null; }
 
         const searchText = this._textScanner.getTextSourceContent(textSource, this._options.scanning.length);

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -78,7 +78,7 @@ class QueryParser {
         if (textSource === null) { return null; }
 
         const searchText = this._textScanner.getTextSourceContent(textSource, this._options.scanning.length);
-        if (searchText.length === 0) { return; }
+        if (searchText.length === 0) { return null; }
 
         const {definitions, length} = await apiTermsFind(searchText, {}, this._getOptionsContext());
         if (definitions.length === 0) { return null; }

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -37,7 +37,7 @@ class QueryParser {
         this._textScanner = new TextScanner({
             node: this._queryParser,
             ignoreElements: () => [],
-            ignorePoints: null,
+            ignorePoint: null,
             search: this._search.bind(this)
         });
     }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -42,7 +42,7 @@ class Frontend {
         this._textScanner = new TextScanner({
             node: window,
             ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
-            ignorePoints: [(x, y) => this._popup.containsPoint(x, y)],
+            ignorePoints: (x, y) => this._popup.containsPoint(x, y),
             search: this._search.bind(this)
         });
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -42,7 +42,7 @@ class Frontend {
         this._textScanner = new TextScanner({
             node: window,
             ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
-            ignorePoints: (x, y) => this._popup.containsPoint(x, y),
+            ignorePoint: (x, y) => this._popup.containsPoint(x, y),
             search: this._search.bind(this)
         });
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -39,12 +39,12 @@ class Frontend {
         this._enabledEventListeners = new EventListenerCollection();
         this._activeModifiers = new Set();
         this._optionsUpdatePending = false;
-        this._textScanner = new TextScanner(
-            window,
-            () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
-            [(x, y) => this._popup.containsPoint(x, y)],
-            this._search.bind(this)
-        );
+        this._textScanner = new TextScanner({
+            node: window,
+            ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
+            ignorePoints: [(x, y) => this._popup.containsPoint(x, y)],
+            search: this._search.bind(this)
+        });
 
         this._windowMessageHandlers = new Map([
             ['popupClose', () => this._textScanner.clearSelection(false)],

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -42,9 +42,9 @@ class Frontend {
         this._textScanner = new TextScanner(
             window,
             () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
-            [(x, y) => this._popup.containsPoint(x, y)]
+            [(x, y) => this._popup.containsPoint(x, y)],
+            this._search.bind(this)
         );
-        this._textScanner.onSearchSource = this._onSearchSource.bind(this);
 
         this._windowMessageHandlers = new Map([
             ['popupClose', () => this._textScanner.clearSelection(false)],
@@ -107,7 +107,7 @@ class Frontend {
     }
 
     async setTextSource(textSource) {
-        await this._onSearchSource(textSource, 'script');
+        await this._search(textSource, 'script');
         this._textScanner.setCurrentTextSource(textSource);
     }
 
@@ -137,7 +137,7 @@ class Frontend {
         const textSourceCurrent = this._textScanner.getCurrentTextSource();
         const causeCurrent = this._textScanner.causeCurrent;
         if (textSourceCurrent !== null && causeCurrent !== null) {
-            await this._onSearchSource(textSourceCurrent, causeCurrent);
+            await this._search(textSourceCurrent, causeCurrent);
         }
     }
 
@@ -204,7 +204,7 @@ class Frontend {
         await this.updateOptions();
     }
 
-    async _onSearchSource(textSource, cause) {
+    async _search(textSource, cause) {
         await this._updatePendingOptions();
 
         let results = null;

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -296,10 +296,8 @@ class TextScanner extends EventDispatcher {
                 return;
             }
 
-            for (const ignorePointFn of this._ignorePoints) {
-                if (await ignorePointFn(x, y)) {
-                    return;
-                }
+            if (typeof this._ignorePoints === 'function' && await this._ignorePoints(x, y)) {
+                return;
             }
 
             const textSource = docRangeFromPoint(x, y, this._options.scanning.deepDomScan);

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -22,11 +22,11 @@
  */
 
 class TextScanner extends EventDispatcher {
-    constructor({node, ignoreElements, ignorePoints, search}) {
+    constructor({node, ignoreElements, ignorePoint, search}) {
         super();
         this._node = node;
         this._ignoreElements = ignoreElements;
-        this._ignorePoints = ignorePoints;
+        this._ignorePoint = ignorePoint;
         this._search = search;
 
         this._ignoreNodes = null;
@@ -92,7 +92,7 @@ class TextScanner extends EventDispatcher {
                 return;
             }
 
-            if (typeof this._ignorePoints === 'function' && await this._ignorePoints(x, y)) {
+            if (typeof this._ignorePoint === 'function' && await this._ignorePoint(x, y)) {
                 return;
             }
 

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -22,11 +22,12 @@
  */
 
 class TextScanner extends EventDispatcher {
-    constructor(node, ignoreElements, ignorePoints) {
+    constructor(node, ignoreElements, ignorePoints, search) {
         super();
         this._node = node;
         this._ignoreElements = ignoreElements;
         this._ignorePoints = ignorePoints;
+        this._search = search;
 
         this._ignoreNodes = null;
 
@@ -221,10 +222,6 @@ class TextScanner extends EventDispatcher {
         e.preventDefault(); // Disable scroll
     }
 
-    async onSearchSource(_textSource, _cause) {
-        throw new Error('Override me');
-    }
-
     async _scanTimerWait() {
         const delay = this._options.scanning.delay;
         const promise = promiseTimeout(delay, true);
@@ -312,7 +309,7 @@ class TextScanner extends EventDispatcher {
                 }
 
                 this._pendingLookup = true;
-                const result = await this.onSearchSource(textSource, cause);
+                const result = await this._search(textSource, cause);
                 if (result !== null) {
                     this._causeCurrent = cause;
                     this.setCurrentTextSource(textSource);

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -22,7 +22,7 @@
  */
 
 class TextScanner extends EventDispatcher {
-    constructor(node, ignoreElements, ignorePoints, search) {
+    constructor({node, ignoreElements, ignorePoints, search}) {
         super();
         this._node = node;
         this._ignoreElements = ignoreElements;


### PR DESCRIPTION
* Fixes a bug with missing return value.
* Changes `TextScanner.onSearchSource` to a constructor argument.
* Simplifies `ignorePoints` function; is now optional.
* Groups public functions together.