### PR TITLE
Popup refactor

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -41,7 +41,7 @@ class Frontend {
         this._optionsUpdatePending = false;
         this._textScanner = new TextScanner({
             node: window,
-            ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getContainer()],
+            ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getFrame()],
             ignorePoint: (x, y) => this._popup.containsPoint(x, y),
             search: this._search.bind(this)
         });

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -169,7 +169,7 @@ class PopupFactory {
 
     _convertPopupPointToRootPagePoint(popup, x, y) {
         if (popup.parent !== null) {
-            const popupRect = popup.parent.getContainerRect();
+            const popupRect = popup.parent.getFrameRect();
             x += popupRect.x;
             y += popupRect.y;
         }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -87,6 +87,7 @@ class PopupFactory {
             popup.setParent(parent);
         }
         this._popups.set(id, popup);
+        popup.prepare();
         return popup;
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -193,7 +193,7 @@ class Popup {
         this._childrenSupported = value;
     }
 
-    getContainer() {
+    getFrame() {
         return this._frame;
     }
 
@@ -493,7 +493,7 @@ class Popup {
     _focusParent() {
         if (this._parent !== null) {
             // Chrome doesn't like focusing iframe without contentWindow.
-            const contentWindow = this._parent._frame.contentWindow;
+            const contentWindow = this._parent.getFrame().contentWindow;
             if (contentWindow !== null) {
                 contentWindow.focus();
             }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -48,8 +48,6 @@ class Popup {
         this._frame.style.height = '0';
 
         this._fullscreenEventListeners = new EventListenerCollection();
-
-        this._updateVisibility();
     }
 
     // Public properties
@@ -77,6 +75,7 @@ class Popup {
     // Public functions
 
     prepare() {
+        this._updateVisibility();
         this._frame.addEventListener('mousedown', (e) => e.stopPropagation());
         this._frame.addEventListener('scroll', (e) => e.stopPropagation());
         this._frame.addEventListener('load', this._onFrameLoad.bind(this));

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -223,11 +223,11 @@ class Popup {
         return new Promise((resolve, reject) => {
             const tokenMap = new Map();
             let timer = null;
-            let containerLoadedResolve = null;
-            let containerLoadedReject = null;
-            const containerLoaded = new Promise((resolve2, reject2) => {
-                containerLoadedResolve = resolve2;
-                containerLoadedReject = reject2;
+            let frameLoadedResolve = null;
+            let frameLoadedReject = null;
+            const frameLoaded = new Promise((resolve2, reject2) => {
+                frameLoadedResolve = resolve2;
+                frameLoadedReject = reject2;
             });
 
             const postMessage = (action, params) => {
@@ -255,7 +255,7 @@ class Popup {
                     if (!isObject(message)) { return; }
                     const {action, params} = message;
                     if (!isObject(params)) { return; }
-                    await containerLoaded;
+                    await frameLoaded;
                     if (timer === null) { return; } // Done
 
                     switch (action) {
@@ -285,7 +285,7 @@ class Popup {
             };
 
             const onLoad = () => {
-                if (containerLoadedResolve === null) {
+                if (frameLoadedResolve === null) {
                     cleanup();
                     reject(new Error('Unexpected load event'));
                     return;
@@ -295,9 +295,9 @@ class Popup {
                     return;
                 }
 
-                containerLoadedResolve();
-                containerLoadedResolve = null;
-                containerLoadedReject = null;
+                frameLoadedResolve();
+                frameLoadedResolve = null;
+                frameLoadedReject = null;
             };
 
             const cleanup = () => {
@@ -305,10 +305,10 @@ class Popup {
                 clearTimeout(timer);
                 timer = null;
 
-                containerLoadedResolve = null;
-                if (containerLoadedReject !== null) {
-                    containerLoadedReject(new Error('Terminated'));
-                    containerLoadedReject = null;
+                frameLoadedResolve = null;
+                if (frameLoadedReject !== null) {
+                    frameLoadedReject(new Error('Terminated'));
+                    frameLoadedReject = null;
                 }
 
                 chrome.runtime.onMessage.removeListener(onMessage);
@@ -325,7 +325,7 @@ class Popup {
             frame.addEventListener('load', onLoad);
 
             // Prevent unhandled rejections
-            containerLoaded.catch(() => {}); // NOP
+            frameLoaded.catch(() => {}); // NOP
 
             setupFrame(frame);
         });

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -599,6 +599,8 @@ class Popup {
                 return false;
             case 'right':
                 return true;
+            default:
+                return false;
         }
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -36,16 +36,16 @@ class Popup {
         this._options = null;
         this._optionsContext = null;
         this._contentScale = 1.0;
-        this._frameSizeContentScale = null;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
         this._previousOptionsContextSource = null;
+
+        this._frameSizeContentScale = null;
         this._frameSecret = null;
         this._frameToken = null;
-
         this._frame = document.createElement('iframe');
         this._frame.className = 'yomichan-float';
-        this._frame.style.width = '0px';
-        this._frame.style.height = '0px';
+        this._frame.style.width = '0';
+        this._frame.style.height = '0';
 
         this._fullscreenEventListeners = new EventListenerCollection();
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -120,8 +120,8 @@ class Popup {
     }
 
     async containsPoint(x, y) {
-        for (let popup = this; popup !== null && popup.isVisibleSync(); popup = this._child) {
-            const rect = this._frame.getBoundingClientRect();
+        for (let popup = this; popup !== null && popup.isVisibleSync(); popup = popup._child) {
+            const rect = popup._frame.getBoundingClientRect();
             if (x >= rect.left && y >= rect.top && x < rect.right && y < rect.bottom) {
                 return true;
             }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -197,7 +197,7 @@ class Popup {
         return this._frame;
     }
 
-    getContainerRect() {
+    getFrameRect() {
         return this._frame.getBoundingClientRect();
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -507,10 +507,10 @@ class Popup {
         const color = [255, 255, 255];
         const {documentElement, body} = document;
         if (documentElement !== null) {
-            Popup._addColor(color, Popup._getColorInfo(window.getComputedStyle(documentElement).backgroundColor));
+            this._addColor(color, window.getComputedStyle(documentElement).backgroundColor);
         }
         if (body !== null) {
-            Popup._addColor(color, Popup._getColorInfo(window.getComputedStyle(body).backgroundColor));
+            this._addColor(color, window.getComputedStyle(body).backgroundColor);
         }
         const dark = (color[0] < 128 && color[1] < 128 && color[2] < 128);
         return dark ? 'dark' : 'light';
@@ -649,7 +649,10 @@ class Popup {
         return [position, size, after];
     }
 
-    static _addColor(target, color) {
+    _addColor(target, cssColor) {
+        if (typeof cssColor !== 'string') { return; }
+
+        const color = this._getColorInfo(cssColor);
         if (color === null) { return; }
 
         const a = color[3];
@@ -661,7 +664,7 @@ class Popup {
         }
     }
 
-    static _getColorInfo(cssColor) {
+    _getColorInfo(cssColor) {
         const m = /^\s*rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)\s*$/.exec(cssColor);
         if (m === null) { return null; }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -44,11 +44,8 @@ class Popup {
 
         this._container = document.createElement('iframe');
         this._container.className = 'yomichan-float';
-        this._container.addEventListener('mousedown', (e) => e.stopPropagation());
-        this._container.addEventListener('scroll', (e) => e.stopPropagation());
         this._container.style.width = '0px';
         this._container.style.height = '0px';
-        this._container.addEventListener('load', this._onFrameLoad.bind(this));
 
         this._fullscreenEventListeners = new EventListenerCollection();
 
@@ -78,6 +75,12 @@ class Popup {
     }
 
     // Public functions
+
+    prepare() {
+        this._container.addEventListener('mousedown', (e) => e.stopPropagation());
+        this._container.addEventListener('scroll', (e) => e.stopPropagation());
+        this._container.addEventListener('load', this._onFrameLoad.bind(this));
+    }
 
     isProxy() {
         return false;

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -437,18 +437,12 @@ class Popup {
         const optionsGeneral = this._options.general;
         const container = this._container;
         const containerRect = container.getBoundingClientRect();
-        const getPosition = (
-            writingMode === 'horizontal-tb' || optionsGeneral.popupVerticalTextPosition === 'default' ?
-            this._getPositionForHorizontalText :
-            this._getPositionForVerticalText
-        );
 
         const viewport = this._getViewport(optionsGeneral.popupScaleRelativeToVisualViewport);
         const scale = this._contentScale;
         const scaleRatio = this._containerSizeContentScale === null ? 1.0 : scale / this._containerSizeContentScale;
         this._containerSizeContentScale = scale;
-        let [x, y, width, height, below] = getPosition.call(
-            this,
+        const getPositionArgs = [
             elementRect,
             Math.max(containerRect.width * scaleRatio, optionsGeneral.popupWidth * scale),
             Math.max(containerRect.height * scaleRatio, optionsGeneral.popupHeight * scale),
@@ -456,6 +450,11 @@ class Popup {
             scale,
             optionsGeneral,
             writingMode
+        ];
+        let [x, y, width, height, below] = (
+            writingMode === 'horizontal-tb' || optionsGeneral.popupVerticalTextPosition === 'default' ?
+            this._getPositionForHorizontalText(...getPositionArgs) :
+            this._getPositionForVerticalText(...getPositionArgs)
         );
 
         const fullWidth = (optionsGeneral.popupDisplayMode === 'full-width');


### PR DESCRIPTION
* Converts private static functions to non-static.
* Adds `prepare`.
* Replaces variables with "container" with "frame" in order to have a more consistent and accurate terminology.

Note: if `prepare` is ever made `async`, this will incur some changes to `PopupProxyHost/PopupFactory.getOrCreatePopup`, since it will have to await in multiple places.

I am also thinking that it might be good to move `_injectStylesheet` into `dynamicLoader`.