### PR TITLE
Modifier key platform names

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -21,6 +21,7 @@
 
         <script src="/mixed/js/core.js"></script>
         <script src="/mixed/js/dom.js"></script>
+        <script src="/mixed/js/environment.js"></script>
         <script src="/mixed/js/japanese.js"></script>
 
         <script src="/bg/js/anki.js"></script>

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -36,135 +36,178 @@ function _profileConditionTestDomainList(url, domainList) {
     return false;
 }
 
-const _profileModifierKeys = [
-    {optionValue: 'alt',   name: 'Alt'},
-    {optionValue: 'ctrl',  name: 'Ctrl'},
-    {optionValue: 'shift', name: 'Shift'}
-];
+let profileConditionsDescriptor = null;
 
-if (!hasOwn(window, 'netscape')) {
-    _profileModifierKeys.push({optionValue: 'meta',  name: 'Meta'});
-}
+const profileConditionsDescriptorPromise = (async () => {
+    const {os} = await new Promise((resolve) => chrome.runtime.getPlatformInfo(resolve));
 
-const _profileModifierValueToName = new Map(
-    _profileModifierKeys.map(({optionValue, name}) => [optionValue, name])
-);
+    const windowsModifierKeys = [
+        ['alt', 'Alt'],
+        ['ctrl', 'Ctrl'],
+        ['shift', 'Shift'],
+        ['meta', 'Windows']
+    ];
 
-const _profileModifierNameToValue = new Map(
-    _profileModifierKeys.map(({optionValue, name}) => [name, optionValue])
-);
+    const macModifierKeys = [
+        ['alt', 'Option'],
+        ['ctrl', 'Control'],
+        ['shift', 'Shift'],
+        ['meta', 'Command']
+    ];
 
-const profileConditionsDescriptor = {
-    popupLevel: {
-        name: 'Popup Level',
-        description: 'Use profile depending on the level of the popup.',
-        placeholder: 'Number',
-        type: 'number',
-        step: 1,
-        defaultValue: 0,
-        defaultOperator: 'equal',
-        transform: (optionValue) => parseInt(optionValue, 10),
-        transformReverse: (transformedOptionValue) => `${transformedOptionValue}`,
-        validateTransformed: (transformedOptionValue) => Number.isFinite(transformedOptionValue),
-        operators: {
-            equal: {
-                name: '=',
-                test: ({depth}, optionValue) => (depth === optionValue)
-            },
-            notEqual: {
-                name: '\u2260',
-                test: ({depth}, optionValue) => (depth !== optionValue)
-            },
-            lessThan: {
-                name: '<',
-                test: ({depth}, optionValue) => (depth < optionValue)
-            },
-            greaterThan: {
-                name: '>',
-                test: ({depth}, optionValue) => (depth > optionValue)
-            },
-            lessThanOrEqual: {
-                name: '\u2264',
-                test: ({depth}, optionValue) => (depth <= optionValue)
-            },
-            greaterThanOrEqual: {
-                name: '\u2265',
-                test: ({depth}, optionValue) => (depth >= optionValue)
-            }
-        }
-    },
-    url: {
-        name: 'URL',
-        description: 'Use profile depending on the URL of the current website.',
-        defaultOperator: 'matchDomain',
-        operators: {
-            matchDomain: {
-                name: 'Matches Domain',
-                placeholder: 'Comma separated list of domains',
-                defaultValue: 'example.com',
-                transformCache: {},
-                transform: (optionValue) => optionValue.split(/[,;\s]+/).map((v) => v.trim().toLowerCase()).filter((v) => v.length > 0),
-                transformReverse: (transformedOptionValue) => transformedOptionValue.join(', '),
-                validateTransformed: (transformedOptionValue) => (transformedOptionValue.length > 0),
-                test: ({url}, transformedOptionValue) => _profileConditionTestDomainList(url, transformedOptionValue)
-            },
-            matchRegExp: {
-                name: 'Matches RegExp',
-                placeholder: 'Regular expression',
-                defaultValue: 'example\\.com',
-                transformCache: {},
-                transform: (optionValue) => new RegExp(optionValue, 'i'),
-                transformReverse: (transformedOptionValue) => transformedOptionValue.source,
-                test: ({url}, transformedOptionValue) => (transformedOptionValue !== null && transformedOptionValue.test(url))
-            }
-        }
-    },
-    modifierKeys: {
-        name: 'Modifier Keys',
-        description: 'Use profile depending on the active modifier keys.',
-        values: _profileModifierKeys,
-        defaultOperator: 'are',
-        operators: {
-            are: {
-                name: 'are',
-                placeholder: 'Press one or more modifier keys here',
-                defaultValue: [],
-                type: 'keyMulti',
-                transformInput: (optionValue) => optionValue
-                    .split(' + ')
-                    .filter((v) => v.length > 0)
-                    .map((v) => _profileModifierNameToValue.get(v)),
-                transformReverse: (transformedOptionValue) => transformedOptionValue
-                    .map((v) => _profileModifierValueToName.get(v))
-                    .join(' + '),
-                test: ({modifierKeys}, optionValue) => areSetsEqual(new Set(modifierKeys), new Set(optionValue))
-            },
-            areNot: {
-                name: 'are not',
-                placeholder: 'Press one or more modifier keys here',
-                defaultValue: [],
-                type: 'keyMulti',
-                transformInput: (optionValue) => optionValue
-                    .split(' + ')
-                    .filter((v) => v.length > 0)
-                    .map((v) => _profileModifierNameToValue.get(v)),
-                transformReverse: (transformedOptionValue) => transformedOptionValue
-                    .map((v) => _profileModifierValueToName.get(v))
-                    .join(' + '),
-                test: ({modifierKeys}, optionValue) => !areSetsEqual(new Set(modifierKeys), new Set(optionValue))
-            },
-            include: {
-                name: 'include',
-                type: 'select',
-                defaultValue: 'alt',
-                test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
-            },
-            notInclude: {
-                name: 'don\'t include',
-                type: 'select',
-                defaultValue: 'alt',
-                test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
-            }
-        }
+    const linuxModifierKeys = [
+        ['alt', 'Alt'],
+        ['ctrl', 'Ctrl'],
+        ['shift', 'Shift'],
+        ['meta', 'Super']
+    ];
+
+    let osModifierKeys;
+    switch (os) {
+        case 'win':
+            osModifierKeys = windowsModifierKeys;
+            break;
+        case 'mac':
+            osModifierKeys = macModifierKeys;
+            break;
+        case 'linux':
+        case 'openbsd':
+        case 'cros':
+        case 'android':
+            osModifierKeys = linuxModifierKeys;
+            break;
+        default:
+            throw new Error('Invalid OS');
     }
-};
+
+    const isFirefox = hasOwn(window, 'netscape');
+    const modifierKeyValues = [];
+
+    for (const [optionValue, name] of osModifierKeys) {
+        if (optionValue === 'meta' && isFirefox && os !== 'mac') { continue; }
+        modifierKeyValues.push({optionValue, name});
+    }
+
+    const modifierValueToName = new Map(
+        modifierKeyValues.map(({optionValue, name}) => [optionValue, name])
+    );
+
+    const modifierNameToValue = new Map(
+        modifierKeyValues.map(({optionValue, name}) => [name, optionValue])
+    );
+
+    profileConditionsDescriptor = {
+        popupLevel: {
+            name: 'Popup Level',
+            description: 'Use profile depending on the level of the popup.',
+            placeholder: 'Number',
+            type: 'number',
+            step: 1,
+            defaultValue: 0,
+            defaultOperator: 'equal',
+            transform: (optionValue) => parseInt(optionValue, 10),
+            transformReverse: (transformedOptionValue) => `${transformedOptionValue}`,
+            validateTransformed: (transformedOptionValue) => Number.isFinite(transformedOptionValue),
+            operators: {
+                equal: {
+                    name: '=',
+                    test: ({depth}, optionValue) => (depth === optionValue)
+                },
+                notEqual: {
+                    name: '\u2260',
+                    test: ({depth}, optionValue) => (depth !== optionValue)
+                },
+                lessThan: {
+                    name: '<',
+                    test: ({depth}, optionValue) => (depth < optionValue)
+                },
+                greaterThan: {
+                    name: '>',
+                    test: ({depth}, optionValue) => (depth > optionValue)
+                },
+                lessThanOrEqual: {
+                    name: '\u2264',
+                    test: ({depth}, optionValue) => (depth <= optionValue)
+                },
+                greaterThanOrEqual: {
+                    name: '\u2265',
+                    test: ({depth}, optionValue) => (depth >= optionValue)
+                }
+            }
+        },
+        url: {
+            name: 'URL',
+            description: 'Use profile depending on the URL of the current website.',
+            defaultOperator: 'matchDomain',
+            operators: {
+                matchDomain: {
+                    name: 'Matches Domain',
+                    placeholder: 'Comma separated list of domains',
+                    defaultValue: 'example.com',
+                    transformCache: {},
+                    transform: (optionValue) => optionValue.split(/[,;\s]+/).map((v) => v.trim().toLowerCase()).filter((v) => v.length > 0),
+                    transformReverse: (transformedOptionValue) => transformedOptionValue.join(', '),
+                    validateTransformed: (transformedOptionValue) => (transformedOptionValue.length > 0),
+                    test: ({url}, transformedOptionValue) => _profileConditionTestDomainList(url, transformedOptionValue)
+                },
+                matchRegExp: {
+                    name: 'Matches RegExp',
+                    placeholder: 'Regular expression',
+                    defaultValue: 'example\\.com',
+                    transformCache: {},
+                    transform: (optionValue) => new RegExp(optionValue, 'i'),
+                    transformReverse: (transformedOptionValue) => transformedOptionValue.source,
+                    test: ({url}, transformedOptionValue) => (transformedOptionValue !== null && transformedOptionValue.test(url))
+                }
+            }
+        },
+        modifierKeys: {
+            name: 'Modifier Keys',
+            description: 'Use profile depending on the active modifier keys.',
+            values: modifierKeyValues,
+            defaultOperator: 'are',
+            operators: {
+                are: {
+                    name: 'are',
+                    placeholder: 'Press one or more modifier keys here',
+                    defaultValue: [],
+                    type: 'keyMulti',
+                    transformInput: (optionValue) => optionValue
+                        .split(' + ')
+                        .filter((v) => v.length > 0)
+                        .map((v) => modifierNameToValue.get(v)),
+                    transformReverse: (transformedOptionValue) => transformedOptionValue
+                        .map((v) => modifierValueToName.get(v))
+                        .join(' + '),
+                    test: ({modifierKeys}, optionValue) => areSetsEqual(new Set(modifierKeys), new Set(optionValue))
+                },
+                areNot: {
+                    name: 'are not',
+                    placeholder: 'Press one or more modifier keys here',
+                    defaultValue: [],
+                    type: 'keyMulti',
+                    transformInput: (optionValue) => optionValue
+                        .split(' + ')
+                        .filter((v) => v.length > 0)
+                        .map((v) => modifierNameToValue.get(v)),
+                    transformReverse: (transformedOptionValue) => transformedOptionValue
+                        .map((v) => modifierValueToName.get(v))
+                        .join(' + '),
+                    test: ({modifierKeys}, optionValue) => !areSetsEqual(new Set(modifierKeys), new Set(optionValue))
+                },
+                include: {
+                    name: 'include',
+                    type: 'select',
+                    defaultValue: 'alt',
+                    test: ({modifierKeys}, optionValue) => modifierKeys.includes(optionValue)
+                },
+                notInclude: {
+                    name: 'don\'t include',
+                    type: 'select',
+                    defaultValue: 'alt',
+                    test: ({modifierKeys}, optionValue) => !modifierKeys.includes(optionValue)
+                }
+            }
+        }
+    };
+})();

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -135,6 +135,7 @@ const profileConditionsDescriptorPromise = (async () => {
                     placeholder: 'Press one or more modifier keys here',
                     defaultValue: [],
                     type: 'keyMulti',
+                    keySeparator: modifierSeparator,
                     transformInput: (optionValue) => optionValue
                         .split(modifierSeparator)
                         .filter((v) => v.length > 0)
@@ -149,6 +150,7 @@ const profileConditionsDescriptorPromise = (async () => {
                     placeholder: 'Press one or more modifier keys here',
                     defaultValue: [],
                     type: 'keyMulti',
+                    keySeparator: modifierSeparator,
                     transformInput: (optionValue) => optionValue
                         .split(modifierSeparator)
                         .filter((v) => v.length > 0)

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -45,7 +45,9 @@ const profileConditionsDescriptorPromise = (async () => {
     const environment = new Environment();
     await environment.prepare();
 
-    const modifierKeyValues = environment.getInfo().modifierKeys.map(
+    const modifiers = environment.getInfo().modifiers;
+    const modifierSeparator = modifiers.separator;
+    const modifierKeyValues = modifiers.keys.map(
         ({value, name}) => ({optionValue: value, name})
     );
 
@@ -134,12 +136,12 @@ const profileConditionsDescriptorPromise = (async () => {
                     defaultValue: [],
                     type: 'keyMulti',
                     transformInput: (optionValue) => optionValue
-                        .split(' + ')
+                        .split(modifierSeparator)
                         .filter((v) => v.length > 0)
                         .map((v) => modifierNameToValue.get(v)),
                     transformReverse: (transformedOptionValue) => transformedOptionValue
                         .map((v) => modifierValueToName.get(v))
-                        .join(' + '),
+                        .join(modifierSeparator),
                     test: ({modifierKeys}, optionValue) => areSetsEqual(new Set(modifierKeys), new Set(optionValue))
                 },
                 areNot: {
@@ -148,12 +150,12 @@ const profileConditionsDescriptorPromise = (async () => {
                     defaultValue: [],
                     type: 'keyMulti',
                     transformInput: (optionValue) => optionValue
-                        .split(' + ')
+                        .split(modifierSeparator)
                         .filter((v) => v.length > 0)
                         .map((v) => modifierNameToValue.get(v)),
                     transformReverse: (transformedOptionValue) => transformedOptionValue
                         .map((v) => modifierValueToName.get(v))
-                        .join(' + '),
+                        .join(modifierSeparator),
                     test: ({modifierKeys}, optionValue) => !areSetsEqual(new Set(modifierKeys), new Set(optionValue))
                 },
                 include: {

--- a/ext/bg/js/profile-conditions.js
+++ b/ext/bg/js/profile-conditions.js
@@ -15,6 +15,9 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* global
+ * Environment
+ */
 
 function _profileConditionTestDomain(urlDomain, domain) {
     return (
@@ -39,54 +42,12 @@ function _profileConditionTestDomainList(url, domainList) {
 let profileConditionsDescriptor = null;
 
 const profileConditionsDescriptorPromise = (async () => {
-    const {os} = await new Promise((resolve) => chrome.runtime.getPlatformInfo(resolve));
+    const environment = new Environment();
+    await environment.prepare();
 
-    const windowsModifierKeys = [
-        ['alt', 'Alt'],
-        ['ctrl', 'Ctrl'],
-        ['shift', 'Shift'],
-        ['meta', 'Windows']
-    ];
-
-    const macModifierKeys = [
-        ['alt', 'Option'],
-        ['ctrl', 'Control'],
-        ['shift', 'Shift'],
-        ['meta', 'Command']
-    ];
-
-    const linuxModifierKeys = [
-        ['alt', 'Alt'],
-        ['ctrl', 'Ctrl'],
-        ['shift', 'Shift'],
-        ['meta', 'Super']
-    ];
-
-    let osModifierKeys;
-    switch (os) {
-        case 'win':
-            osModifierKeys = windowsModifierKeys;
-            break;
-        case 'mac':
-            osModifierKeys = macModifierKeys;
-            break;
-        case 'linux':
-        case 'openbsd':
-        case 'cros':
-        case 'android':
-            osModifierKeys = linuxModifierKeys;
-            break;
-        default:
-            throw new Error('Invalid OS');
-    }
-
-    const isFirefox = hasOwn(window, 'netscape');
-    const modifierKeyValues = [];
-
-    for (const [optionValue, name] of osModifierKeys) {
-        if (optionValue === 'meta' && isFirefox && os !== 'mac') { continue; }
-        modifierKeyValues.push({optionValue, name});
-    }
+    const modifierKeyValues = environment.getInfo().modifierKeys.map(
+        ({value, name}) => ({optionValue: value, name})
+    );
 
     const modifierValueToName = new Map(
         modifierKeyValues.map(({optionValue, name}) => [optionValue, name])

--- a/ext/bg/js/settings/conditions-ui.js
+++ b/ext/bg/js/settings/conditions-ui.js
@@ -310,9 +310,13 @@ ConditionsUI.Condition = class Condition {
         inputInner.prop('readonly', true);
 
         let values = [];
+        let keySeparator = ' + ';
         for (const object of objects) {
             if (hasOwn(object, 'values')) {
                 values = object.values;
+            }
+            if (hasOwn(object, 'keySeparator')) {
+                keySeparator = object.keySeparator;
             }
         }
 
@@ -347,7 +351,7 @@ ConditionsUI.Condition = class Condition {
                 }
             }
 
-            const inputValue = [...pressedKeyIndices].map((i) => values[i].name).join(' + ');
+            const inputValue = [...pressedKeyIndices].map((i) => values[i].name).join(keySeparator);
             inputInner.val(inputValue);
             inputInner.change();
         };

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -16,13 +16,13 @@
  */
 
 /* global
- * Environment
  * ankiErrorShown
  * ankiFieldsToDict
  * ankiInitialize
  * ankiTemplatesInitialize
  * ankiTemplatesUpdateValue
  * apiForwardLogsToBackend
+ * apiGetEnvironmentInfo
  * apiOptionsSave
  * appearanceInitialize
  * audioSettingsInitialize
@@ -287,15 +287,13 @@ function showExtensionInformation() {
 }
 
 async function settingsPopulateModifierKeys() {
-    const environment = new Environment();
-    await environment.prepare();
-
     const scanModifierKeySelect = document.querySelector('#scan-modifier-key');
     scanModifierKeySelect.textContent = '';
 
+    const environment = await apiGetEnvironmentInfo();
     const modifierKeys = [
         {value: 'none', name: 'None'},
-        ...environment.getInfo().modifierKeys
+        ...environment.modifierKeys
     ];
     for (const {value, name} of modifierKeys) {
         const option = document.createElement('option');

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -293,7 +293,7 @@ async function settingsPopulateModifierKeys() {
     const environment = await apiGetEnvironmentInfo();
     const modifierKeys = [
         {value: 'none', name: 'None'},
-        ...environment.modifierKeys
+        ...environment.modifiers.keys
     ];
     for (const {value, name} of modifierKeys) {
         const option = document.createElement('option');

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * Environment
  * ankiErrorShown
  * ankiFieldsToDict
  * ankiInitialize
@@ -285,6 +286,25 @@ function showExtensionInformation() {
     node.textContent = `${manifest.name} v${manifest.version}`;
 }
 
+async function settingsPopulateModifierKeys() {
+    const environment = new Environment();
+    await environment.prepare();
+
+    const scanModifierKeySelect = document.querySelector('#scan-modifier-key');
+    scanModifierKeySelect.textContent = '';
+
+    const modifierKeys = [
+        {value: 'none', name: 'None'},
+        ...environment.getInfo().modifierKeys
+    ];
+    for (const {value, name} of modifierKeys) {
+        const option = document.createElement('option');
+        option.value = value;
+        option.textContent = name;
+        scanModifierKeySelect.appendChild(option);
+    }
+}
+
 
 async function onReady() {
     apiForwardLogsToBackend();
@@ -292,6 +312,7 @@ async function onReady() {
 
     showExtensionInformation();
 
+    await settingsPopulateModifierKeys();
     formSetupEventListeners();
     appearanceInitialize();
     await audioSettingsInitialize();

--- a/ext/bg/js/settings/profiles.js
+++ b/ext/bg/js/settings/profiles.js
@@ -23,6 +23,7 @@
  * getOptionsFullMutable
  * getOptionsMutable
  * profileConditionsDescriptor
+ * profileConditionsDescriptorPromise
  * settingsSaveOptions
  * utilBackgroundIsolate
  */
@@ -98,6 +99,7 @@ async function profileFormWrite(optionsFull) {
         profileConditionsContainer.cleanup();
     }
 
+    await profileConditionsDescriptorPromise;
     profileConditionsContainer = new ConditionsUI.Container(
         profileConditionsDescriptor,
         'popupLevel',
@@ -128,7 +130,7 @@ function profileOptionsPopulateSelect(select, profiles, currentValue, ignoreIndi
 }
 
 async function profileOptionsUpdateTarget(optionsFull) {
-    profileFormWrite(optionsFull);
+    await profileFormWrite(optionsFull);
 
     const optionsContext = getOptionsContext();
     const options = await getOptionsMutable(optionsContext);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -1131,6 +1131,7 @@
 
         <script src="/mixed/js/core.js"></script>
         <script src="/mixed/js/dom.js"></script>
+        <script src="/mixed/js/environment.js"></script>
         <script src="/mixed/js/api.js"></script>
         <script src="/mixed/js/japanese.js"></script>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -412,13 +412,7 @@
 
                 <div class="form-group">
                     <label for="scan-modifier-key">Scan modifier key</label>
-                    <select class="form-control" id="scan-modifier-key">
-                        <option value="none">None</option>
-                        <option value="alt">Alt</option>
-                        <option value="ctrl">Ctrl</option>
-                        <option value="shift">Shift</option>
-                        <option data-hide-for-browser="firefox firefox-mobile" value="meta">Meta</option>
-                    </select>
+                    <select class="form-control" id="scan-modifier-key"></select>
                 </div>
             </div>
 

--- a/ext/mixed/js/environment.js
+++ b/ext/mixed/js/environment.js
@@ -33,13 +33,13 @@ class Environment {
     async _loadEnvironmentInfo() {
         const browser = await this._getBrowser();
         const platform = await new Promise((resolve) => chrome.runtime.getPlatformInfo(resolve));
-        const modifierKeys = this._getModifierKeys(browser, platform.os);
+        const modifierInfo = this._getModifierInfo(browser, platform.os);
         return {
             browser,
             platform: {
                 os: platform.os
             },
-            modifierKeys
+            modifiers: modifierInfo
         };
     }
 
@@ -62,9 +62,11 @@ class Environment {
         }
     }
 
-    _getModifierKeys(browser, os) {
+    _getModifierInfo(browser, os) {
         let osModifierKeys;
+        let osModifierSeparator;
         if (os === 'win') {
+            osModifierSeparator = ' + ';
             osModifierKeys = [
                 ['alt', 'Alt'],
                 ['ctrl', 'Ctrl'],
@@ -72,13 +74,15 @@ class Environment {
                 ['meta', 'Windows']
             ];
         } else if (os === 'mac') {
+            osModifierSeparator = '';
             osModifierKeys = [
-                ['alt', 'Option'],
-                ['ctrl', 'Control'],
-                ['shift', 'Shift'],
-                ['meta', 'Command']
+                ['alt', '⌥'],
+                ['ctrl', '⌃'],
+                ['shift', '⇧'],
+                ['meta', '⌘']
             ];
         } else if (os === 'linux' || os === 'openbsd' || os === 'cros' || os === 'android') {
+            osModifierSeparator = ' + ';
             osModifierKeys = [
                 ['alt', 'Alt'],
                 ['ctrl', 'Ctrl'],
@@ -98,6 +102,6 @@ class Environment {
             modifierKeys.push({value, name});
         }
 
-        return modifierKeys;
+        return {keys: modifierKeys, separator: osModifierSeparator};
     }
 }

--- a/ext/mixed/js/environment.js
+++ b/ext/mixed/js/environment.js
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+class Environment {
+    constructor() {
+        this._cachedEnvironmentInfo = null;
+    }
+
+    async prepare() {
+        this._cachedEnvironmentInfo = await this._loadEnvironmentInfo();
+    }
+
+    getInfo() {
+        if (this._cachedEnvironmentInfo === null) { throw new Error('Not prepared'); }
+        return this._cachedEnvironmentInfo;
+    }
+
+    async _loadEnvironmentInfo() {
+        const browser = await this._getBrowser();
+        const platform = await new Promise((resolve) => chrome.runtime.getPlatformInfo(resolve));
+        const modifierKeys = this._getModifierKeys(browser, platform.os);
+        return {
+            browser,
+            platform: {
+                os: platform.os
+            },
+            modifierKeys
+        };
+    }
+
+    async _getBrowser() {
+        if (EXTENSION_IS_BROWSER_EDGE) {
+            return 'edge';
+        }
+        if (typeof browser !== 'undefined') {
+            try {
+                const info = await browser.runtime.getBrowserInfo();
+                if (info.name === 'Fennec') {
+                    return 'firefox-mobile';
+                }
+            } catch (e) {
+                // NOP
+            }
+            return 'firefox';
+        } else {
+            return 'chrome';
+        }
+    }
+
+    _getModifierKeys(browser, os) {
+        let osModifierKeys;
+        if (os === 'win') {
+            osModifierKeys = [
+                ['alt', 'Alt'],
+                ['ctrl', 'Ctrl'],
+                ['shift', 'Shift'],
+                ['meta', 'Windows']
+            ];
+        } else if (os === 'mac') {
+            osModifierKeys = [
+                ['alt', 'Option'],
+                ['ctrl', 'Control'],
+                ['shift', 'Shift'],
+                ['meta', 'Command']
+            ];
+        } else if (os === 'linux' || os === 'openbsd' || os === 'cros' || os === 'android') {
+            osModifierKeys = [
+                ['alt', 'Alt'],
+                ['ctrl', 'Ctrl'],
+                ['shift', 'Shift'],
+                ['meta', 'Super']
+            ];
+        } else {
+            throw new Error('Invalid OS');
+        }
+
+        const isFirefox = (browser === 'firefox' || browser === 'firefox-mobile');
+        const modifierKeys = [];
+
+        for (const [value, name] of osModifierKeys) {
+            // Firefox doesn't support event.metaKey on platforms other than macOS
+            if (value === 'meta' && isFirefox && os !== 'mac') { continue; }
+            modifierKeys.push({value, name});
+        }
+
+        return modifierKeys;
+    }
+}

--- a/ext/mixed/js/environment.js
+++ b/ext/mixed/js/environment.js
@@ -63,12 +63,12 @@ class Environment {
     }
 
     _getModifierInfo(browser, os) {
-        let osModifierKeys;
-        let osModifierSeparator;
+        let osKeys;
+        let separator;
         switch (os) {
             case 'win':
-                osModifierSeparator = ' + ';
-                osModifierKeys = [
+                separator = ' + ';
+                osKeys = [
                     ['alt', 'Alt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
@@ -76,8 +76,8 @@ class Environment {
                 ];
                 break;
             case 'mac':
-                osModifierSeparator = '';
-                osModifierKeys = [
+                separator = '';
+                osKeys = [
                     ['alt', '⌥'],
                     ['ctrl', '⌃'],
                     ['shift', '⇧'],
@@ -88,8 +88,8 @@ class Environment {
             case 'openbsd':
             case 'cros':
             case 'android':
-                osModifierSeparator = ' + ';
-                osModifierKeys = [
+                separator = ' + ';
+                osKeys = [
                     ['alt', 'Alt'],
                     ['ctrl', 'Ctrl'],
                     ['shift', 'Shift'],
@@ -101,14 +101,14 @@ class Environment {
         }
 
         const isFirefox = (browser === 'firefox' || browser === 'firefox-mobile');
-        const modifierKeys = [];
+        const keys = [];
 
-        for (const [value, name] of osModifierKeys) {
+        for (const [value, name] of osKeys) {
             // Firefox doesn't support event.metaKey on platforms other than macOS
             if (value === 'meta' && isFirefox && os !== 'mac') { continue; }
-            modifierKeys.push({value, name});
+            keys.push({value, name});
         }
 
-        return {keys: modifierKeys, separator: osModifierSeparator};
+        return {keys, separator};
     }
 }

--- a/ext/mixed/js/environment.js
+++ b/ext/mixed/js/environment.js
@@ -65,32 +65,39 @@ class Environment {
     _getModifierInfo(browser, os) {
         let osModifierKeys;
         let osModifierSeparator;
-        if (os === 'win') {
-            osModifierSeparator = ' + ';
-            osModifierKeys = [
-                ['alt', 'Alt'],
-                ['ctrl', 'Ctrl'],
-                ['shift', 'Shift'],
-                ['meta', 'Windows']
-            ];
-        } else if (os === 'mac') {
-            osModifierSeparator = '';
-            osModifierKeys = [
-                ['alt', '⌥'],
-                ['ctrl', '⌃'],
-                ['shift', '⇧'],
-                ['meta', '⌘']
-            ];
-        } else if (os === 'linux' || os === 'openbsd' || os === 'cros' || os === 'android') {
-            osModifierSeparator = ' + ';
-            osModifierKeys = [
-                ['alt', 'Alt'],
-                ['ctrl', 'Ctrl'],
-                ['shift', 'Shift'],
-                ['meta', 'Super']
-            ];
-        } else {
-            throw new Error('Invalid OS');
+        switch (os) {
+            case 'win':
+                osModifierSeparator = ' + ';
+                osModifierKeys = [
+                    ['alt', 'Alt'],
+                    ['ctrl', 'Ctrl'],
+                    ['shift', 'Shift'],
+                    ['meta', 'Windows']
+                ];
+                break;
+            case 'mac':
+                osModifierSeparator = '';
+                osModifierKeys = [
+                    ['alt', '⌥'],
+                    ['ctrl', '⌃'],
+                    ['shift', '⇧'],
+                    ['meta', '⌘']
+                ];
+                break;
+            case 'linux':
+            case 'openbsd':
+            case 'cros':
+            case 'android':
+                osModifierSeparator = ' + ';
+                osModifierKeys = [
+                    ['alt', 'Alt'],
+                    ['ctrl', 'Ctrl'],
+                    ['shift', 'Shift'],
+                    ['meta', 'Super']
+                ];
+                break;
+            default:
+                throw new Error(`Invalid OS: ${os}`);
         }
 
         const isFirefox = (browser === 'firefox' || browser === 'firefox-mobile');


### PR DESCRIPTION
Resolves https://github.com/FooSoft/yomichan/issues/504.

Things related to environment are extracted from backend into the `Environment` class because otherwise there would be a circular dependency between `Backend` and `profile-conditions.js`. The dependency issue could be fixed, but the modifier key definitions would probably still be too much bloat for `Backend` so they can be kept in a dedicated class.

I went with key symbols for macOS and names elsewhere, because the usage of the symbols seems so widespread on mac. Some examples (sourced from https://www.nngroup.com/articles/ui-copy/):

<img src="https://media.nngroup.com/media/editor/2019/01/16/accesskeys2.jpg" width="400">
<img src="https://media.nngroup.com/media/editor/2019/01/16/ever.jpg" width="400">

There also seems to be an `X` button in the Evernote screenshot, but I didn't add that for any OS yet.

I think it's fine to use `''` as a separator on macOS for now, but this could change in the future if a key name consists of multiple characters.

I'm not sure if https://github.com/FooSoft/yomichan/commit/de6135251c56fb3f2247540c3c4e1a229e228be2 could be done with datasets and CSS, but I went that way because it was simple. `settingsPopulateModifierKeys` could be in the wrong place.