### PR TITLE
Frontend/popup proxy message refactoring

### DIFF
--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -37,11 +37,11 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
         }
     );
     apiBroadcastTab('rootPopupRequestInformationBroadcast');
-    const {popupId, frameId} = await rootPopupInformationPromise;
+    const {popupId, frameId: parentFrameId} = await rootPopupInformationPromise;
 
     const getFrameOffset = frameOffsetForwarder.getOffset.bind(frameOffsetForwarder);
 
-    const popup = new PopupProxy(popupId, 0, null, frameId, getFrameOffset, setDisabled);
+    const popup = new PopupProxy(popupId, 0, null, parentFrameId, getFrameOffset, setDisabled);
     await popup.prepare();
 
     return popup;

--- a/ext/fg/js/frontend-api-sender.js
+++ b/ext/fg/js/frontend-api-sender.js
@@ -17,7 +17,8 @@
 
 
 class FrontendApiSender {
-    constructor() {
+    constructor(target) {
+        this._target = target;
         this._senderId = yomichan.generateId(16);
         this._ackTimeout = 3000; // 3 seconds
         this._responseTimeout = 10000; // 10 seconds
@@ -27,7 +28,7 @@ class FrontendApiSender {
         this._port = null;
     }
 
-    invoke(action, params, target) {
+    invoke(action, params) {
         if (this._disconnected) {
             // attempt to reconnect the next time
             this._disconnected = false;
@@ -46,7 +47,7 @@ class FrontendApiSender {
             this._callbacks.set(id, info);
             info.timer = setTimeout(() => this._onError(id, 'Timeout (ack)'), this._ackTimeout);
 
-            this._port.postMessage({id, action, params, target, senderId: this._senderId});
+            this._port.postMessage({id, action, params, target: this._target, senderId: this._senderId});
         });
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -182,9 +182,6 @@ class Frontend {
     }
 
     _onRuntimeMessage({action, params}, sender, callback) {
-        const {targetPopupId} = params || {};
-        if (typeof targetPopupId !== 'undefined' && targetPopupId !== this._popup.id) { return; }
-
         const handler = this._runtimeMessageHandlers.get(action);
         if (typeof handler !== 'function') { return false; }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -47,14 +47,14 @@ class Frontend {
         });
 
         this._windowMessageHandlers = new Map([
-            ['popupClose', () => this._textScanner.clearSelection(false)],
-            ['selectionCopy', () => document.execCommand('copy')]
+            ['popupClose', this._onMessagePopupClose.bind(this)],
+            ['selectionCopy', this._onMessageSelectionCopy.bind()]
         ]);
 
         this._runtimeMessageHandlers = new Map([
-            ['popupSetVisibleOverride', ({visible}) => { this._popup.setVisibleOverride(visible); }],
-            ['rootPopupRequestInformationBroadcast', () => { this._broadcastRootPopupInformation(); }],
-            ['requestDocumentInformationBroadcast', ({uniqueId}) => { this._broadcastDocumentInformation(uniqueId); }]
+            ['popupSetVisibleOverride', this._onMessagePopupSetVisibleOverride.bind(this)],
+            ['rootPopupRequestInformationBroadcast', this._onMessageRootPopupRequestInformationBroadcast.bind(this)],
+            ['requestDocumentInformationBroadcast', this._onMessageRequestDocumentInformationBroadcast.bind(this)]
         ]);
     }
 
@@ -143,6 +143,28 @@ class Frontend {
 
     showContentCompleted() {
         return this._lastShowPromise;
+    }
+
+    // Message handlers
+
+    _onMessagePopupClose() {
+        this._textScanner.clearSelection(false);
+    }
+
+    _onMessageSelectionCopy() {
+        document.execCommand('copy');
+    }
+
+    _onMessagePopupSetVisibleOverride({visible}) {
+        this._popup.setVisibleOverride(visible);
+    }
+
+    _onMessageRootPopupRequestInformationBroadcast() {
+        this._broadcastRootPopupInformation();
+    }
+
+    _onMessageRequestDocumentInformationBroadcast({uniqueId}) {
+        this._broadcastDocumentInformation(uniqueId);
     }
 
     // Private

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -25,7 +25,7 @@ class PopupProxy {
         this._parentFrameId = parentFrameId;
         this._id = id;
         this._depth = depth;
-        this._apiSender = new FrontendApiSender();
+        this._apiSender = new FrontendApiSender(`popup-factory#${this._parentFrameId}`);
         this._getFrameOffset = getFrameOffset;
         this._setDisabled = setDisabled;
 
@@ -115,7 +115,7 @@ class PopupProxy {
         if (typeof this._parentFrameId !== 'number') {
             return Promise.reject(new Error('Invalid frame'));
         }
-        return this._apiSender.invoke(action, params, `popup-factory#${this._parentFrameId}`);
+        return this._apiSender.invoke(action, params);
     }
 
     async _updateFrameOffset() {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -20,10 +20,10 @@
  */
 
 class PopupProxy {
-    constructor(id, depth, parentId, parentFrameId, getFrameOffset=null, setDisabled=null) {
-        this._parentId = parentId;
+    constructor(id, depth, parentPopupId, parentFrameId, getFrameOffset=null, setDisabled=null) {
         this._id = id;
         this._depth = depth;
+        this._parentPopupId = parentPopupId;
         this._apiSender = new FrontendApiSender(`popup-factory#${parentFrameId}`);
         this._getFrameOffset = getFrameOffset;
         this._setDisabled = setDisabled;
@@ -50,7 +50,7 @@ class PopupProxy {
     // Public functions
 
     async prepare() {
-        const {id} = await this._invoke('getOrCreatePopup', {id: this._id, parentId: this._parentId});
+        const {id} = await this._invoke('getOrCreatePopup', {id: this._id, parentId: this._parentPopupId});
         this._id = id;
     }
 

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -22,10 +22,9 @@
 class PopupProxy {
     constructor(id, depth, parentId, parentFrameId, getFrameOffset=null, setDisabled=null) {
         this._parentId = parentId;
-        this._parentFrameId = parentFrameId;
         this._id = id;
         this._depth = depth;
-        this._apiSender = new FrontendApiSender(`popup-factory#${this._parentFrameId}`);
+        this._apiSender = new FrontendApiSender(`popup-factory#${parentFrameId}`);
         this._getFrameOffset = getFrameOffset;
         this._setDisabled = setDisabled;
 
@@ -112,9 +111,6 @@ class PopupProxy {
     // Private
 
     _invoke(action, params={}) {
-        if (typeof this._parentFrameId !== 'number') {
-            return Promise.reject(new Error('Invalid frame'));
-        }
         return this._apiSender.invoke(action, params);
     }
 


### PR DESCRIPTION
This commit is moving towards https://github.com/FooSoft/yomichan/pull/516#discussion_r421844037 and another issue related to where DisplayFloat sends its messages. DisplayFloat sends messages to the parent frame rather than the owner frame. This results in the `popupClose` and `selectionCopy` messages targeting the wrong Frontend instance. This commit provides some initial cleanup for both tasks.

* Removes an unused event filter. (`targetPopupId`)
* Clarified some parameters that `PopupProxy` uses.
  * `parentId` => `parentPopupId`
  * `parentFrameId` is no longer stored in a member field. Instead, it's passed to the constructor of `FrontendApiSender`.