### PR TITLE
Add support for additional types of event listeners

### DIFF
--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -250,15 +250,35 @@ class EventListenerCollection {
         return this._eventListeners.length;
     }
 
-    addEventListener(node, type, listener, options) {
-        node.addEventListener(type, listener, options);
-        this._eventListeners.push([node, type, listener, options]);
+    addEventListener(object, ...args) {
+        object.addEventListener(...args);
+        this._eventListeners.push(['removeEventListener', object, ...args]);
+    }
+
+    addListener(object, ...args) {
+        object.addListener(args);
+        this._eventListeners.push(['addListener', object, args]);
+    }
+
+    on(object, ...args) {
+        object.on(args);
+        this._eventListeners.push(['off', object, args]);
     }
 
     removeAllEventListeners() {
         if (this._eventListeners.length === 0) { return; }
-        for (const [node, type, listener, options] of this._eventListeners) {
-            node.removeEventListener(type, listener, options);
+        for (const [type, object, ...args] of this._eventListeners) {
+            switch (type) {
+                case 'removeEventListener':
+                    object.removeEventListener(...args);
+                    break;
+                case 'removeListener':
+                    object.removeListener(...args);
+                    break;
+                case 'off':
+                    object.off(...args);
+                    break;
+            }
         }
         this._eventListeners = [];
     }

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -257,18 +257,18 @@ class EventListenerCollection {
 
     addListener(object, ...args) {
         object.addListener(args);
-        this._eventListeners.push(['addListener', object, args]);
+        this._eventListeners.push(['removeListener', object, ...args]);
     }
 
     on(object, ...args) {
         object.on(args);
-        this._eventListeners.push(['off', object, args]);
+        this._eventListeners.push(['off', object, ...args]);
     }
 
     removeAllEventListeners() {
         if (this._eventListeners.length === 0) { return; }
-        for (const [type, object, ...args] of this._eventListeners) {
-            switch (type) {
+        for (const [removeFunctionName, object, ...args] of this._eventListeners) {
+            switch (removeFunctionName) {
                 case 'removeEventListener':
                     object.removeEventListener(...args);
                     break;
@@ -278,6 +278,8 @@ class EventListenerCollection {
                 case 'off':
                     object.off(...args);
                     break;
+                default:
+                    throw new Error(`Unknown remove function: ${removeFunctionName}`);
             }
         }
         this._eventListeners = [];


### PR DESCRIPTION
There are some times where it would be convenient for `EventListenerCollection` to support different event listener styles, so this adds that. Not used yet, but may be soon.