### PR TITLE
Load frame content using contentDocument.location.href instead of src attribute

### DIFF
--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -336,9 +336,9 @@ class Popup {
         const {secret, token} = await this._initializeFrame(this._frame, this._targetOrigin, this._frameId, (frame) => {
             frame.removeAttribute('src');
             frame.removeAttribute('srcdoc');
-            frame.setAttribute('src', chrome.runtime.getURL('/fg/float.html'));
             this._observeFullscreen(true);
             this._onFullscreenChanged();
+            frame.contentDocument.location.href = chrome.runtime.getURL('/fg/float.html');
         });
         this._frameSecret = secret;
         this._frameToken = token;


### PR DESCRIPTION
Resolves #441 and part of #353.

The changes made to the handshake were made with this eventuality in mind, so the final change is just swapping a single line. Effectively an un-revert of 36605f74c3d48a98500d198636112454b36063f6.