### PR TITLE
Use both shadowRoot and openOrClosedShadowRoot

### DIFF
--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -105,7 +105,10 @@ class FrameOffsetForwarder {
                     return element;
                 }
 
-                const shadowRoot = element.shadowRoot;
+                const shadowRoot = (
+                    element.shadowRoot ||
+                    element.openOrClosedShadowRoot // Available to Firefox 63+ for WebExtensions
+                );
                 if (shadowRoot) {
                     for (const child of shadowRoot.children) {
                         if (child.nodeType === ELEMENT_NODE) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -530,7 +530,11 @@ class Popup {
     _getFrameParentElement() {
         const defaultParent = document.body;
         const fullscreenElement = DOM.getFullscreenElement();
-        if (fullscreenElement === null || fullscreenElement.shadowRoot) {
+        if (
+            fullscreenElement === null ||
+            fullscreenElement.shadowRoot ||
+            fullscreenElement.openOrClosedShadowRoot // Available to Firefox 63+ for WebExtensions
+        ) {
             return defaultParent;
         }
 


### PR DESCRIPTION
[`Element.openOrClosedShadowRoot`](https://developer.mozilla.org/en-US/docs/Web/API/Element/openOrClosedShadowRoot) is available to Firefox 63+ in the WebExtension context.

I think this should resolve https://github.com/FooSoft/yomichan/pull/529#issuecomment-626326989.

Note: it is possible to embed the Yomichan `<iframe>` inside of a fullscreen shadow DOM after we have a reference to it, since [`fullscreenElement`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/fullscreenElement) is available for the shadow root. However, the problem then becomes that the shadow DOM doesn't have client.css (or custom outer CSS), so the popup won't appear. This would have to be solved by putting the `<iframe>` into its own shadow DOM, and give that one the styles. This probably shouldn't be done unless/until we find a use case in the wild which necessitates it.