### PR TITLE
Consistent fields for return value of promiseTimeout

### DIFF
--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -164,7 +164,10 @@ function getSetDifference(set1, set2) {
 
 function promiseTimeout(delay, resolveValue) {
     if (delay <= 0) {
-        return Promise.resolve(resolveValue);
+        const promise = Promise.resolve(resolveValue);
+        promise.resolve = () => {}; // NOP
+        promise.reject = () => {}; // NOP
+        return promise;
     }
 
     let timer = null;


### PR DESCRIPTION
Missing `.resolve` and `.reject` when `delay <= 0`.