### PR TITLE
Ensure single popup factory

### DIFF
--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -24,6 +24,19 @@
  * api
  */
 
+async function createPopupFactory() {
+    const {frameId} = await api.frameInformationGet();
+    if (typeof frameId !== 'number') {
+        const error = new Error('Failed to get frameId');
+        yomichan.logError(error);
+        throw error;
+    }
+
+    const popupFactory = new PopupFactory(frameId);
+    await popupFactory.prepare();
+    return popupFactory;
+}
+
 async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
     const rootPopupInformationPromise = yomichan.getTemporaryListenerResult(
         chrome.runtime.onMessage,
@@ -45,15 +58,7 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
 }
 
 async function getOrCreatePopup(depth) {
-    const {frameId} = await api.frameInformationGet();
-    if (typeof frameId !== 'number') {
-        const error = new Error('Failed to get frameId');
-        yomichan.logError(error);
-        throw error;
-    }
-
-    const popupFactory = new PopupFactory(frameId);
-    await popupFactory.prepare();
+    const popupFactory = await createPopupFactory();
 
     const popup = popupFactory.getOrCreatePopup(null, null, depth);
 


### PR DESCRIPTION
Since the call is async, technically it's possible to have more than one `PopupFactory` instance created. This can cause an issue with #553, since `CrossFrameAPI` doesn't permit re-registering a handler with the same name.

There are potentially other issues with this system. Since the file needs to be refactored in general, I leave that as a task for another time.

This issue can be reproduced by doing the following:
* Merge #553 
* Add `await promiseTimeout(5000);` to `Backend.prepare()` below https://github.com/FooSoft/yomichan/blob/83a577fa569e5a6d468e3b304313106bba3e1e49/ext/bg/js/backend.js#L144
  (This simulates an abnormally long prepare time, which may occur during database upgrades)
* Reload the extension
* Open/reload a webpage during the 5000ms delay
* When the delay is complete, an error should be printed