### PR TITLE
Backup update

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -122,7 +122,8 @@ class Backend {
             ['logIndicatorClear',            {async: false, contentScript: true,  handler: this._onApiLogIndicatorClear.bind(this)}],
             ['createActionPort',             {async: false, contentScript: true,  handler: this._onApiCreateActionPort.bind(this)}],
             ['modifySettings',               {async: true,  contentScript: true,  handler: this._onApiModifySettings.bind(this)}],
-            ['getSettings',                  {async: false, contentScript: true,  handler: this._onApiGetSettings.bind(this)}]
+            ['getSettings',                  {async: false, contentScript: true,  handler: this._onApiGetSettings.bind(this)}],
+            ['setAllSettings',               {async: true,  contentScript: false, handler: this._onApiSetAllSettings.bind(this)}]
         ]);
         this._messageHandlersWithProgress = new Map([
             ['importDictionaryArchive', {async: true,  contentScript: false, handler: this._onApiImportDictionaryArchive.bind(this)}],
@@ -858,6 +859,11 @@ class Backend {
             }
         }
         return results;
+    }
+
+    async _onApiSetAllSettings({value, source}) {
+        this.options = JsonSchema.getValidValueOrDefault(this.optionsSchema, value);
+        await this._onApiOptionsSave({source});
     }
 
     // Command handlers

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -318,15 +318,6 @@ class Backend {
         return useSchema ? JsonSchema.createProxy(options, this.optionsSchema) : options;
     }
 
-    setFullOptions(options) {
-        try {
-            this.options = JsonSchema.getValidValueOrDefault(this.optionsSchema, utilIsolate(options));
-        } catch (e) {
-            // This shouldn't happen, but catch errors just in case of bugs
-            yomichan.logError(e);
-        }
-    }
-
     getOptions(optionsContext, useSchema=false) {
         return this.getProfile(optionsContext, useSchema).options;
     }

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -141,7 +141,7 @@ class SettingsBackup {
     // Importing
 
     async _settingsImportSetOptionsFull(optionsFull) {
-        await this._settingsController.setOptionsFull(optionsFull);
+        await this._settingsController.setAllSettings(optionsFull);
     }
 
     _showSettingsImportError(error) {

--- a/ext/bg/js/settings/backup.js
+++ b/ext/bg/js/settings/backup.js
@@ -340,9 +340,6 @@ class SettingsBackup {
 
         // Assign options
         await this._settingsImportSetOptionsFull(optionsFull);
-
-        // Reload settings page
-        window.location.reload();
     }
 
     _onSettingsImportClick() {
@@ -376,8 +373,5 @@ class SettingsBackup {
 
         // Assign options
         await this._settingsImportSetOptionsFull(optionsFull);
-
-        // Reload settings page
-        window.location.reload();
     }
 }

--- a/ext/bg/js/settings/settings-controller.js
+++ b/ext/bg/js/settings/settings-controller.js
@@ -65,9 +65,9 @@ class SettingsController extends EventDispatcher {
         return utilBackend().getFullOptions();
     }
 
-    async setOptionsFull(optionsFull) {
-        utilBackend().setFullOptions(utilBackgroundIsolate(optionsFull));
-        await this.save();
+    async setAllSettings(value) {
+        await api.setAllSettings(value, this._source);
+        this._onOptionsUpdatedInternal();
     }
 
     async getGlobalSettings(targets) {

--- a/ext/bg/js/settings/settings-controller.js
+++ b/ext/bg/js/settings/settings-controller.js
@@ -34,9 +34,7 @@ class SettingsController extends EventDispatcher {
 
     set profileIndex(value) {
         if (this._profileIndex === value) { return; }
-        this._profileIndex = value;
-        this.trigger('optionsContextChanged');
-        this._onOptionsUpdatedInternal();
+        this._setProfileIndex(value);
     }
 
     prepare() {
@@ -66,8 +64,9 @@ class SettingsController extends EventDispatcher {
     }
 
     async setAllSettings(value) {
+        const profileIndex = value.profileCurrent;
         await api.setAllSettings(value, this._source);
-        this._onOptionsUpdatedInternal();
+        this._setProfileIndex(profileIndex);
     }
 
     async getGlobalSettings(targets) {
@@ -99,6 +98,12 @@ class SettingsController extends EventDispatcher {
     }
 
     // Private
+
+    _setProfileIndex(value) {
+        this._profileIndex = value;
+        this.trigger('optionsContextChanged');
+        this._onOptionsUpdatedInternal();
+    }
 
     _onOptionsUpdated({source}) {
         if (source === this._source) { return; }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -176,6 +176,10 @@ const api = (() => {
             return this._invoke('getSettings', {targets});
         }
 
+        setAllSettings(value, source) {
+            return this._invoke('setAllSettings', {value, source});
+        }
+
         // Invoke functions with progress
 
         importDictionaryArchive(archiveContent, details, onProgress) {


### PR DESCRIPTION
* Changes how options are overwritten in order to not use `utilBackend`/`utilBackground*` functions.
* Page reload is no longer necessary after settings import.