### PR TITLE
Limit action port message size

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -893,19 +893,19 @@ class Backend {
                 const result = async ? await promiseOrResult : promiseOrResult;
                 port.postMessage({type: 'complete', data: result});
             } catch (e) {
-                if (port !== null) {
-                    port.postMessage({type: 'error', data: errorToJson(e)});
-                }
-                cleanup();
+                cleanup(e);
             }
         };
 
         const onDisconnect = () => {
-            cleanup();
+            cleanup(null);
         };
 
-        const cleanup = () => {
+        const cleanup = (error) => {
             if (port === null) { return; }
+            if (error !== null) {
+                port.postMessage({type: 'error', data: errorToJson(error)});
+            }
             if (!hasStarted) {
                 port.onMessage.removeListener(onMessage);
             }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -900,18 +900,22 @@ class Backend {
             }
         };
 
+        const onDisconnect = () => {
+            cleanup();
+        };
+
         const cleanup = () => {
             if (port === null) { return; }
             if (!hasStarted) {
                 port.onMessage.removeListener(onMessage);
             }
-            port.onDisconnect.removeListener(cleanup);
+            port.onDisconnect.removeListener(onDisconnect);
             port = null;
             handlers = null;
         };
 
         port.onMessage.addListener(onMessage);
-        port.onDisconnect.addListener(cleanup);
+        port.onDisconnect.addListener(onDisconnect);
     }
 
     _getErrorLevelValue(errorLevel) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -872,10 +872,11 @@ class Backend {
             }
         };
 
-        const onMessage = ({action, data}) => {
+        const onMessage = (message) => {
             if (hasStarted) { return; }
 
             try {
+                const {action, data} = message;
                 switch (action) {
                     case 'fragment':
                         messageString += data;
@@ -896,8 +897,9 @@ class Backend {
             }
         };
 
-        const onMessageComplete = async ({action, params}) => {
+        const onMessageComplete = async (message) => {
             try {
+                const {action, params} = message;
                 port.postMessage({type: 'ack'});
 
                 const messageHandler = handlers.get(action);

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -236,7 +236,6 @@ const api = (() => {
 
         _invokeWithProgress(action, params, onProgress, timeout=5000) {
             return new Promise((resolve, reject) => {
-                let timer = null;
                 let port = null;
 
                 if (typeof onProgress !== 'function') {
@@ -245,12 +244,6 @@ const api = (() => {
 
                 const onMessage = (message) => {
                     switch (message.type) {
-                        case 'ack':
-                            if (timer !== null) {
-                                clearTimeout(timer);
-                                timer = null;
-                            }
-                            break;
                         case 'progress':
                             try {
                                 onProgress(...message.data);
@@ -275,10 +268,6 @@ const api = (() => {
                 };
 
                 const cleanup = () => {
-                    if (timer !== null) {
-                        clearTimeout(timer);
-                        timer = null;
-                    }
                     if (port !== null) {
                         port.onMessage.removeListener(onMessage);
                         port.onDisconnect.removeListener(onDisconnect);
@@ -287,11 +276,6 @@ const api = (() => {
                     }
                     onProgress = null;
                 };
-
-                timer = setTimeout(() => {
-                    cleanup();
-                    reject(new Error('Timeout'));
-                }, timeout);
 
                 (async () => {
                     try {


### PR DESCRIPTION
This change splits up messages sent over the action ports into fragments in order to prevent exceeding the maximum message length.

Fixes #586.