### PR TITLE
Detect language tags starting with "ja_"

### DIFF
--- a/ext/bg/js/settings/audio.js
+++ b/ext/bg/js/settings/audio.js
@@ -118,6 +118,7 @@ class AudioController {
 
     _languageTagIsJapanese(languageTag) {
         return (
+            languageTag.startsWith('ja_') ||
             languageTag.startsWith('ja-') ||
             languageTag.startsWith('jpn-')
         );


### PR DESCRIPTION
Noticed this while testing the Kiwi browser mentioned in #595. The full tag is "ja_JP".