### PR TITLE
Ignore getZoom errors

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -65,8 +65,12 @@ class Frontend {
     async prepare() {
         try {
             await this.updateOptions();
-            const {zoomFactor} = await api.getZoom();
-            this._pageZoomFactor = zoomFactor;
+            try {
+                const {zoomFactor} = await api.getZoom();
+                this._pageZoomFactor = zoomFactor;
+            } catch (e) {
+                // Ignore exceptions which may occur due to being on an unsupported page (e.g. about:blank)
+            }
 
             window.addEventListener('resize', this._onResize.bind(this), false);
 


### PR DESCRIPTION
Unclear how this happened, but I saw the following error occur on Firefox:
```
Yomichan v20.5.22.1 has encountered a problem.
Originating URL: about:blank
Error: Invalid tab
_onApiGetZoom@moz-extension://.../bg/js/backend.js:687:35
onMessage@moz-extension://.../bg/js/backend.js:222:44
```

This change should fix it.