### PR TITLE
PopupProxy refactor

### DIFF
--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -49,9 +49,7 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
     api.broadcastTab('rootPopupRequestInformationBroadcast');
     const {popupId, frameId: parentFrameId} = await rootPopupInformationPromise;
 
-    const getFrameOffset = frameOffsetForwarder.getOffset.bind(frameOffsetForwarder);
-
-    const popup = new PopupProxy(popupId, 0, null, parentFrameId, getFrameOffset);
+    const popup = new PopupProxy(popupId, 0, null, parentFrameId, frameOffsetForwarder);
     popup.on('offsetNotFound', setDisabled);
     await popup.prepare();
 

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -114,7 +114,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
 
         if (!proxy && frameOffsetForwarder === null) {
             frameOffsetForwarder = new FrameOffsetForwarder();
-            frameOffsetForwarder.start();
+            frameOffsetForwarder.prepare();
         }
 
         let popup;

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -51,7 +51,8 @@ async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
 
     const getFrameOffset = frameOffsetForwarder.getOffset.bind(frameOffsetForwarder);
 
-    const popup = new PopupProxy(popupId, 0, null, parentFrameId, getFrameOffset, setDisabled);
+    const popup = new PopupProxy(popupId, 0, null, parentFrameId, getFrameOffset);
+    popup.on('offsetNotFound', setDisabled);
     await popup.prepare();
 
     return popup;

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -21,8 +21,7 @@
 
 class FrameOffsetForwarder {
     constructor() {
-        this._started = false;
-
+        this._isPrepared = false;
         this._cacheMaxSize = 1000;
         this._frameCache = new Set();
         this._unreachableContentWindowCache = new Set();
@@ -38,10 +37,10 @@ class FrameOffsetForwarder {
         ]);
     }
 
-    start() {
-        if (this._started) { return; }
+    prepare() {
+        if (this._isPrepared) { return; }
         window.addEventListener('message', this.onMessage.bind(this), false);
-        this._started = true;
+        this._isPrepared = true;
     }
 
     async getOffset() {

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -39,7 +39,7 @@ class FrameOffsetForwarder {
 
     prepare() {
         if (this._isPrepared) { return; }
-        window.addEventListener('message', this.onMessage.bind(this), false);
+        window.addEventListener('message', this._onMessage.bind(this), false);
         this._isPrepared = true;
     }
 
@@ -68,7 +68,9 @@ class FrameOffsetForwarder {
         return offset;
     }
 
-    onMessage(e) {
+    // Private
+
+    _onMessage(e) {
         const {action, params} = e.data;
         const handler = this._windowMessageHandlers.get(action);
         if (typeof handler !== 'function') { return; }

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -70,11 +70,18 @@ class FrameOffsetForwarder {
 
     // Private
 
-    _onMessage(e) {
-        const {action, params} = e.data;
-        const handler = this._windowMessageHandlers.get(action);
-        if (typeof handler !== 'function') { return; }
-        handler(params, e);
+    _onMessage(event) {
+        const data = event.data;
+        if (data === null || typeof data !== 'object') { return; }
+
+        try {
+            const {action, params} = event.data;
+            const handler = this._windowMessageHandlers.get(action);
+            if (typeof handler !== 'function') { return; }
+            handler(params, event);
+        } catch (e) {
+            // NOP
+        }
     }
 
     _onGetFrameOffset(offset, uniqueId, e) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -19,14 +19,14 @@
  * api
  */
 
-class PopupProxy {
-    constructor(id, depth, parentPopupId, parentFrameId, getFrameOffset=null, setDisabled=null) {
+class PopupProxy extends EventDispatcher {
+    constructor(id, depth, parentPopupId, parentFrameId, getFrameOffset=null) {
+        super();
         this._id = id;
         this._depth = depth;
         this._parentPopupId = parentPopupId;
         this._parentFrameId = parentFrameId;
         this._getFrameOffset = getFrameOffset;
-        this._setDisabled = setDisabled;
 
         this._frameOffset = null;
         this._frameOffsetPromise = null;
@@ -138,8 +138,8 @@ class PopupProxy {
         try {
             const offset = await this._frameOffsetPromise;
             this._frameOffset = offset !== null ? offset : [0, 0];
-            if (offset === null && this._setDisabled !== null) {
-                this._setDisabled();
+            if (offset === null) {
+                this.trigger('offsetNotFound');
                 return;
             }
             this._frameOffsetUpdatedAt = now;

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -20,13 +20,13 @@
  */
 
 class PopupProxy extends EventDispatcher {
-    constructor(id, depth, parentPopupId, parentFrameId, getFrameOffset=null) {
+    constructor(id, depth, parentPopupId, parentFrameId, frameOffsetForwarder=null) {
         super();
         this._id = id;
         this._depth = depth;
         this._parentPopupId = parentPopupId;
         this._parentFrameId = parentFrameId;
-        this._getFrameOffset = getFrameOffset;
+        this._frameOffsetForwarder = frameOffsetForwarder;
 
         this._frameOffset = null;
         this._frameOffsetPromise = null;
@@ -75,7 +75,7 @@ class PopupProxy extends EventDispatcher {
     }
 
     async containsPoint(x, y) {
-        if (this._getFrameOffset !== null) {
+        if (this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
             [x, y] = this._applyFrameOffset(x, y);
         }
@@ -84,7 +84,7 @@ class PopupProxy extends EventDispatcher {
 
     async showContent(elementRect, writingMode, type, details, context) {
         let {x, y, width, height} = elementRect;
-        if (this._getFrameOffset !== null) {
+        if (this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
             [x, y] = this._applyFrameOffset(x, y);
         }
@@ -134,7 +134,7 @@ class PopupProxy extends EventDispatcher {
     }
 
     async _updateFrameOffsetInner(now) {
-        this._frameOffsetPromise = this._getFrameOffset();
+        this._frameOffsetPromise = this._frameOffsetForwarder.getOffset();
         try {
             const offset = await this._frameOffsetPromise;
             this._frameOffset = offset !== null ? offset : [0, 0];


### PR DESCRIPTION
* `PopupProxy.setDisabled` is replaced with an event listener.
* The `FrameOffsetForwarder` instance is passed directly to `PopupProxy`'s constructor, rather than a binding to `getOffset`.
* `FrameOffsetForwarder.start` is now `FrameOffsetForwarder.prepare`.
* `FrameOffsetForwarder.onMessage` is now private.
* `FrameOffsetForwarder`'s `window.onmessage` handler no longer throws errors on unexpected values. This happens if the root page uses `window.postMessage` at all, which is the case on Google Docs. (See: https://github.com/FooSoft/yomichan/issues/608#issuecomment-643789813)