### PR TITLE
Frontend initialization refactor

### DIFF
--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -18,19 +18,7 @@
 /* global
  * DisplaySearch
  * api
- * dynamicLoader
  */
-
-async function injectSearchFrontend() {
-    await dynamicLoader.loadScripts([
-        '/mixed/js/text-scanner.js',
-        '/fg/js/frame-offset-forwarder.js',
-        '/fg/js/popup.js',
-        '/fg/js/popup-factory.js',
-        '/fg/js/frontend.js',
-        '/fg/js/content-script-main.js'
-    ]);
-}
 
 (async () => {
     api.forwardLogsToBackend();
@@ -38,22 +26,4 @@ async function injectSearchFrontend() {
 
     const displaySearch = new DisplaySearch();
     await displaySearch.prepare();
-
-    let optionsApplied = false;
-
-    const applyOptions = async () => {
-        const optionsContext = {depth: 0, url: window.location.href};
-        const options = await api.optionsGet(optionsContext);
-        if (!options.scanning.enableOnSearchPage || optionsApplied) { return; }
-
-        optionsApplied = true;
-        yomichan.off('optionsUpdated', applyOptions);
-
-        window.frontendInitializationData = {depth: 1, proxy: false, isSearchPage: true};
-        await injectSearchFrontend();
-    };
-
-    yomichan.on('optionsUpdated', applyOptions);
-
-    await applyOptions();
 })();

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -21,9 +21,13 @@
  */
 
 (async () => {
-    api.forwardLogsToBackend();
-    await yomichan.prepare();
+    try {
+        api.forwardLogsToBackend();
+        await yomichan.prepare();
 
-    const displaySearch = new DisplaySearch();
-    await displaySearch.prepare();
+        const displaySearch = new DisplaySearch();
+        await displaySearch.prepare();
+    } catch (e) {
+        yomichan.logError(e);
+    }
 })();

--- a/ext/bg/js/search-query-parser.js
+++ b/ext/bg/js/search-query-parser.js
@@ -42,6 +42,7 @@ class QueryParser {
 
     async prepare() {
         await this._queryParserGenerator.prepare();
+        this._textScanner.prepare();
         this._queryParser.addEventListener('click', this._onClick.bind(this));
     }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -407,7 +407,11 @@ class DisplaySearch extends Display {
             complete = true;
             yomichan.off('optionsUpdated', onOptionsUpdated);
 
-            await this._setupNestedPopups();
+            try {
+                await this._setupNestedPopups();
+            } catch (e) {
+                yomichan.logError(e);
+            }
         };
 
         yomichan.on('optionsUpdated', onOptionsUpdated);

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -74,53 +74,49 @@ class DisplaySearch extends Display {
     }
 
     async prepare() {
-        try {
-            await super.prepare();
-            await this.updateOptions();
-            yomichan.on('optionsUpdated', () => this.updateOptions());
-            await this.queryParser.prepare();
+        await super.prepare();
+        await this.updateOptions();
+        yomichan.on('optionsUpdated', () => this.updateOptions());
+        await this.queryParser.prepare();
 
-            const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
+        const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
 
-            document.documentElement.dataset.searchMode = mode;
+        document.documentElement.dataset.searchMode = mode;
 
-            if (this.options.general.enableWanakana === true) {
-                this.wanakanaEnable.checked = true;
-                wanakana.bind(this.query);
-            } else {
-                this.wanakanaEnable.checked = false;
-            }
-
-            this.setQuery(query);
-            this.onSearchQueryUpdated(this.query.value, false);
-
-            if (mode !== 'popup') {
-                if (this.options.general.enableClipboardMonitor === true) {
-                    this.clipboardMonitorEnable.checked = true;
-                    this.clipboardMonitor.start();
-                } else {
-                    this.clipboardMonitorEnable.checked = false;
-                }
-                this.clipboardMonitorEnable.addEventListener('change', this.onClipboardMonitorEnableChange.bind(this));
-            }
-
-            chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
-
-            this.search.addEventListener('click', this.onSearch.bind(this), false);
-            this.query.addEventListener('input', this.onSearchInput.bind(this), false);
-            this.wanakanaEnable.addEventListener('change', this.onWanakanaEnableChange.bind(this));
-            window.addEventListener('popstate', this.onPopState.bind(this));
-            window.addEventListener('copy', this.onCopy.bind(this));
-            this.clipboardMonitor.on('change', this.onExternalSearchUpdate.bind(this));
-
-            this.updateSearchButton();
-
-            await this._prepareNestedPopups();
-
-            this._isPrepared = true;
-        } catch (e) {
-            this.onError(e);
+        if (this.options.general.enableWanakana === true) {
+            this.wanakanaEnable.checked = true;
+            wanakana.bind(this.query);
+        } else {
+            this.wanakanaEnable.checked = false;
         }
+
+        this.setQuery(query);
+        this.onSearchQueryUpdated(this.query.value, false);
+
+        if (mode !== 'popup') {
+            if (this.options.general.enableClipboardMonitor === true) {
+                this.clipboardMonitorEnable.checked = true;
+                this.clipboardMonitor.start();
+            } else {
+                this.clipboardMonitorEnable.checked = false;
+            }
+            this.clipboardMonitorEnable.addEventListener('change', this.onClipboardMonitorEnableChange.bind(this));
+        }
+
+        chrome.runtime.onMessage.addListener(this.onRuntimeMessage.bind(this));
+
+        this.search.addEventListener('click', this.onSearch.bind(this), false);
+        this.query.addEventListener('input', this.onSearchInput.bind(this), false);
+        this.wanakanaEnable.addEventListener('change', this.onWanakanaEnableChange.bind(this));
+        window.addEventListener('popstate', this.onPopState.bind(this));
+        window.addEventListener('copy', this.onCopy.bind(this));
+        this.clipboardMonitor.on('change', this.onExternalSearchUpdate.bind(this));
+
+        this.updateSearchButton();
+
+        await this._prepareNestedPopups();
+
+        this._isPrepared = true;
     }
 
     onError(error) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -19,6 +19,8 @@
  * ClipboardMonitor
  * DOM
  * Display
+ * Frontend
+ * PopupFactory
  * QueryParser
  * api
  * dynamicLoader
@@ -414,14 +416,28 @@ class DisplaySearch extends Display {
     }
 
     async _setupNestedPopups() {
-        window.frontendInitializationData = {depth: 1, proxy: false, isSearchPage: true};
         await dynamicLoader.loadScripts([
             '/mixed/js/text-scanner.js',
             '/fg/js/frame-offset-forwarder.js',
             '/fg/js/popup.js',
             '/fg/js/popup-factory.js',
-            '/fg/js/frontend.js',
-            '/fg/js/content-script-main.js'
+            '/fg/js/frontend.js'
         ]);
+
+        const {frameId} = await api.frameInformationGet();
+
+        const popupFactory = new PopupFactory(frameId);
+        await popupFactory.prepare();
+
+        const frontend = new Frontend(
+            frameId,
+            popupFactory,
+            {
+                depth: 1,
+                proxy: false,
+                isSearchPage: true
+            }
+        );
+        await frontend.prepare();
     }
 }

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -21,7 +21,11 @@
  */
 
 (async () => {
-    api.forwardLogsToBackend();
-    const preview = new PopupPreviewFrame();
-    await preview.prepare();
+    try {
+        api.forwardLogsToBackend();
+        const preview = new PopupPreviewFrame();
+        await preview.prepare();
+    } catch (e) {
+        yomichan.logError(e);
+    }
 })();

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * PopupFactory
  * PopupPreviewFrame
  * api
  */
@@ -23,7 +24,13 @@
 (async () => {
     try {
         api.forwardLogsToBackend();
-        const preview = new PopupPreviewFrame();
+
+        const {frameId} = await api.frameInformationGet();
+
+        const popupFactory = new PopupFactory(frameId);
+        await popupFactory.prepare();
+
+        const preview = new PopupPreviewFrame(frameId, popupFactory);
         await preview.prepare();
     } catch (e) {
         yomichan.logError(e);

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -62,7 +62,13 @@ class PopupPreviewFrame {
         this._popupSetCustomOuterCssOld = this._popup.setCustomOuterCss.bind(this._popup);
         this._popup.setCustomOuterCss = this._popupSetCustomOuterCss.bind(this);
 
-        this._frontend = new Frontend(this._frameId, this._popupFactory);
+        this._frontend = new Frontend(
+            this._frameId,
+            this._popupFactory,
+            {
+                allowRootFramePopupProxy: false
+            }
+        );
         this._frontendGetOptionsContextOld = this._frontend.getOptionsContext.bind(this._frontend);
         this._frontend.getOptionsContext = this._getOptionsContext.bind(this);
         await this._frontend.prepare();

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -29,7 +29,6 @@ class PopupPreviewFrame {
         this._frontend = null;
         this._frontendGetOptionsContextOld = null;
         this._apiOptionsGetOld = null;
-        this._popup = null;
         this._popupSetCustomOuterCssOld = null;
         this._popupShown = false;
         this._themeChangeTimeout = null;
@@ -56,12 +55,6 @@ class PopupPreviewFrame {
         api.optionsGet = this._apiOptionsGet.bind(this);
 
         // Overwrite frontend
-        this._popup = this._popupFactory.getOrCreatePopup();
-        this._popup.setChildrenSupported(false);
-
-        this._popupSetCustomOuterCssOld = this._popup.setCustomOuterCss.bind(this._popup);
-        this._popup.setCustomOuterCss = this._popupSetCustomOuterCss.bind(this);
-
         this._frontend = new Frontend(
             this._frameId,
             this._popupFactory,
@@ -74,6 +67,12 @@ class PopupPreviewFrame {
         await this._frontend.prepare();
         this._frontend.setDisabledOverride(true);
         this._frontend.canClearSelection = false;
+
+        const popup = this._frontend.popup;
+        popup.setChildrenSupported(false);
+
+        this._popupSetCustomOuterCssOld = popup.setCustomOuterCss.bind(popup);
+        popup.setCustomOuterCss = this._popupSetCustomOuterCss.bind(this);
 
         // Update search
         this._updateSearch();
@@ -134,7 +133,9 @@ class PopupPreviewFrame {
         }
         this._themeChangeTimeout = setTimeout(() => {
             this._themeChangeTimeout = null;
-            this._popup.updateTheme();
+            const popup = this._frontend.popup;
+            if (popup === null) { return; }
+            popup.updateTheme();
         }, 300);
     }
 
@@ -156,12 +157,16 @@ class PopupPreviewFrame {
 
     _setCustomCss({css}) {
         if (this._frontend === null) { return; }
-        this._popup.setCustomCss(css);
+        const popup = this._frontend.popup;
+        if (popup === null) { return; }
+        popup.setCustomCss(css);
     }
 
     _setCustomOuterCss({css}) {
         if (this._frontend === null) { return; }
-        this._popup.setCustomOuterCss(css, false);
+        const popup = this._frontend.popup;
+        if (popup === null) { return; }
+        popup.setCustomOuterCss(css, false);
     }
 
     async _updateOptionsContext({optionsContext}) {
@@ -190,7 +195,8 @@ class PopupPreviewFrame {
         this._textSource = source;
         await this._frontend.showContentCompleted();
 
-        if (this._popup.isVisibleSync()) {
+        const popup = this._frontend.popup;
+        if (popup !== null && popup.isVisibleSync()) {
             this._popupShown = true;
         }
 

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -18,13 +18,14 @@
 /* global
  * Frontend
  * Popup
- * PopupFactory
  * TextSourceRange
  * api
  */
 
 class PopupPreviewFrame {
-    constructor() {
+    constructor(frameId, popupFactory) {
+        this._frameId = frameId;
+        this._popupFactory = popupFactory;
         this._frontend = null;
         this._frontendGetOptionsContextOld = null;
         this._apiOptionsGetOld = null;
@@ -55,18 +56,13 @@ class PopupPreviewFrame {
         api.optionsGet = this._apiOptionsGet.bind(this);
 
         // Overwrite frontend
-        const {frameId} = await api.frameInformationGet();
-
-        const popupFactory = new PopupFactory(frameId);
-        await popupFactory.prepare();
-
-        this._popup = popupFactory.getOrCreatePopup();
+        this._popup = this._popupFactory.getOrCreatePopup();
         this._popup.setChildrenSupported(false);
 
         this._popupSetCustomOuterCssOld = this._popup.setCustomOuterCss.bind(this._popup);
         this._popup.setCustomOuterCss = this._popupSetCustomOuterCss.bind(this);
 
-        this._frontend = new Frontend(this._popup);
+        this._frontend = new Frontend(this._frameId, this._popupFactory);
         this._frontendGetOptionsContextOld = this._frontend.getOptionsContext.bind(this._frontend);
         this._frontend.getOptionsContext = this._getOptionsContext.bind(this);
         await this._frontend.prepare();

--- a/ext/bg/settings-popup-preview.html
+++ b/ext/bg/settings-popup-preview.html
@@ -130,6 +130,7 @@
         <script src="/fg/js/source.js"></script>
         <script src="/fg/js/popup-factory.js"></script>
         <script src="/fg/js/frontend.js"></script>
+        <script src="/fg/js/frame-offset-forwarder.js"></script>
         <script src="/bg/js/settings/popup-preview-frame.js"></script>
 
         <script src="/bg/js/settings/popup-preview-frame-main.js"></script>

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -34,7 +34,11 @@
         const popupFactory = new PopupFactory(frameId);
         await popupFactory.prepare();
 
-        const frontend = new Frontend(frameId, popupFactory, window.frontendInitializationData || {});
+        const frontend = new Frontend(
+            frameId,
+            popupFactory,
+            {}
+        );
         await frontend.prepare();
     } catch (e) {
         yomichan.logError(e);

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -17,6 +17,7 @@
 
 /* global
  * Frontend
+ * PopupFactory
  * api
  */
 
@@ -25,7 +26,15 @@
         api.forwardLogsToBackend();
         await yomichan.prepare();
 
-        const frontend = new Frontend(window.frontendInitializationData || {});
+        const {frameId} = await api.frameInformationGet();
+        if (typeof frameId !== 'number') {
+            throw new Error('Failed to get frameId');
+        }
+
+        const popupFactory = new PopupFactory(frameId);
+        await popupFactory.prepare();
+
+        const frontend = new Frontend(frameId, popupFactory, window.frontendInitializationData || {});
         await frontend.prepare();
     } catch (e) {
         yomichan.logError(e);

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -156,7 +156,7 @@ async function createPopupProxy(depth, id, parentFrameId) {
     };
 
     yomichan.on('optionsUpdated', applyOptions);
-    window.addEventListener('fullscreenchange', applyOptions, false);
+    DOM.addFullscreenChangeEventListener(applyOptions);
 
     await applyOptions();
 })();

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -16,156 +16,18 @@
  */
 
 /* global
- * DOM
- * FrameOffsetForwarder
  * Frontend
- * PopupFactory
- * PopupProxy
  * api
  */
 
-async function createPopupFactory() {
-    const {frameId} = await api.frameInformationGet();
-    if (typeof frameId !== 'number') {
-        const error = new Error('Failed to get frameId');
-        yomichan.logError(error);
-        throw error;
-    }
-
-    const popupFactory = new PopupFactory(frameId);
-    await popupFactory.prepare();
-    return popupFactory;
-}
-
-async function createIframePopupProxy(frameOffsetForwarder, setDisabled) {
-    const rootPopupInformationPromise = yomichan.getTemporaryListenerResult(
-        chrome.runtime.onMessage,
-        ({action, params}, {resolve}) => {
-            if (action === 'rootPopupInformation') {
-                resolve(params);
-            }
-        }
-    );
-    api.broadcastTab('rootPopupRequestInformationBroadcast');
-    const {popupId, frameId: parentFrameId} = await rootPopupInformationPromise;
-
-    const popup = new PopupProxy(popupId, 0, null, parentFrameId, frameOffsetForwarder);
-    popup.on('offsetNotFound', setDisabled);
-    await popup.prepare();
-
-    return popup;
-}
-
-async function getOrCreatePopup(depth, popupFactory) {
-    return popupFactory.getOrCreatePopup(null, null, depth);
-}
-
-async function createPopupProxy(depth, id, parentFrameId) {
-    const popup = new PopupProxy(null, depth + 1, id, parentFrameId);
-    await popup.prepare();
-
-    return popup;
-}
-
 (async () => {
-    api.forwardLogsToBackend();
-    await yomichan.prepare();
-
     try {
+        api.forwardLogsToBackend();
+        await yomichan.prepare();
+
         const frontend = new Frontend(window.frontendInitializationData || {});
         await frontend.prepare();
     } catch (e) {
         yomichan.logError(e);
-        return;
     }
-    if (true) { return; } // TODO
-
-    const data = window.frontendInitializationData || {};
-    const {id, depth=0, parentFrameId, url=window.location.href, proxy=false, isSearchPage=false} = data;
-
-    const isIframe = !proxy && (window !== window.parent);
-
-    const popups = {
-        iframe: null,
-        proxy: null,
-        normal: null
-    };
-
-    let frontend = null;
-    let frontendPreparePromise = null;
-    let frameOffsetForwarder = null;
-    let popupFactoryPromise = null;
-
-    let iframePopupsInRootFrameAvailable = true;
-
-    const disableIframePopupsInRootFrame = () => {
-        iframePopupsInRootFrameAvailable = false;
-        applyOptions();
-    };
-
-    let urlUpdatedAt = 0;
-    let popupProxyUrlCached = url;
-    const getPopupProxyUrl = async () => {
-        const now = Date.now();
-        if (popups.proxy !== null && now - urlUpdatedAt > 500) {
-            popupProxyUrlCached = await popups.proxy.getUrl();
-            urlUpdatedAt = now;
-        }
-        return popupProxyUrlCached;
-    };
-
-    const applyOptions = async () => {
-        const optionsContext = {
-            depth: isSearchPage ? 0 : depth,
-            url: proxy ? await getPopupProxyUrl() : window.location.href
-        };
-        const options = await api.optionsGet(optionsContext);
-
-        if (!proxy && frameOffsetForwarder === null) {
-            frameOffsetForwarder = new FrameOffsetForwarder();
-            frameOffsetForwarder.prepare();
-        }
-
-        let popup;
-        if (isIframe && options.general.showIframePopupsInRootFrame && DOM.getFullscreenElement() === null && iframePopupsInRootFrameAvailable) {
-            popup = popups.iframe || await createIframePopupProxy(frameOffsetForwarder, disableIframePopupsInRootFrame);
-            popups.iframe = popup;
-        } else if (proxy) {
-            popup = popups.proxy || await createPopupProxy(depth, id, parentFrameId);
-            popups.proxy = popup;
-        } else {
-            popup = popups.normal;
-            if (!popup) {
-                if (popupFactoryPromise === null) {
-                    popupFactoryPromise = createPopupFactory();
-                }
-                const popupFactory = await popupFactoryPromise;
-                const popupNormal = await getOrCreatePopup(depth, popupFactory);
-                popups.normal = popupNormal;
-                popup = popupNormal;
-            }
-        }
-
-        if (frontend === null) {
-            const getUrl = proxy ? getPopupProxyUrl : null;
-            frontend = new Frontend(popup, getUrl);
-            frontendPreparePromise = frontend.prepare();
-            await frontendPreparePromise;
-        } else {
-            await frontendPreparePromise;
-            if (isSearchPage) {
-                const disabled = !options.scanning.enableOnSearchPage;
-                frontend.setDisabledOverride(disabled);
-            }
-
-            if (isIframe) {
-                await frontend.setPopup(popup);
-            }
-        }
-    };
-
-    yomichan.on('optionsUpdated', applyOptions);
-    DOM.addFullscreenChangeEventListener(applyOptions);
-
-    await applyOptions();
 })();

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -71,6 +71,15 @@ async function createPopupProxy(depth, id, parentFrameId) {
     api.forwardLogsToBackend();
     await yomichan.prepare();
 
+    try {
+        const frontend = new Frontend(window.frontendInitializationData || {});
+        await frontend.prepare();
+    } catch (e) {
+        yomichan.logError(e);
+        return;
+    }
+    if (true) { return; } // TODO
+
     const data = window.frontendInitializationData || {};
     const {id, depth=0, parentFrameId, url=window.location.href, proxy=false, isSearchPage=false} = data;
 

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -18,41 +18,7 @@
 /* global
  * DisplayFloat
  * api
- * dynamicLoader
  */
-
-async function injectPopupNested() {
-    await dynamicLoader.loadScripts([
-        '/mixed/js/text-scanner.js',
-        '/fg/js/popup.js',
-        '/fg/js/popup-proxy.js',
-        '/fg/js/popup-factory.js',
-        '/fg/js/frame-offset-forwarder.js',
-        '/fg/js/frontend.js',
-        '/fg/js/content-script-main.js'
-    ]);
-}
-
-async function popupNestedInitialize(id, depth, parentFrameId, url) {
-    let optionsApplied = false;
-
-    const applyOptions = async () => {
-        const optionsContext = {depth, url};
-        const options = await api.optionsGet(optionsContext);
-        const maxPopupDepthExceeded = !(typeof depth === 'number' && depth < options.scanning.popupNestingMaxDepth);
-        if (maxPopupDepthExceeded || optionsApplied) { return; }
-
-        optionsApplied = true;
-        yomichan.off('optionsUpdated', applyOptions);
-
-        window.frontendInitializationData = {id, depth, parentFrameId, url, proxy: true};
-        await injectPopupNested();
-    };
-
-    yomichan.on('optionsUpdated', applyOptions);
-
-    await applyOptions();
-}
 
 (async () => {
     api.forwardLogsToBackend();

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -21,7 +21,12 @@
  */
 
 (async () => {
-    api.forwardLogsToBackend();
-    const display = new DisplayFloat();
-    await display.prepare();
+    try {
+        api.forwardLogsToBackend();
+
+        const display = new DisplayFloat();
+        await display.prepare();
+    } catch (e) {
+        yomichan.logError(e);
+    }
 })();

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -26,6 +26,8 @@ async function injectPopupNested() {
         '/mixed/js/text-scanner.js',
         '/fg/js/popup.js',
         '/fg/js/popup-proxy.js',
+        '/fg/js/popup-factory.js',
+        '/fg/js/frame-offset-forwarder.js',
         '/fg/js/frontend.js',
         '/fg/js/content-script-main.js'
     ]);

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -202,7 +202,7 @@ class DisplayFloat extends Display {
         );
     }
 
-    _prepareNestedPopups(id, depth, parentFrameId, url) {
+    async _prepareNestedPopups(id, depth, parentFrameId, url) {
         let complete = false;
 
         const onOptionsUpdated = async () => {
@@ -219,7 +219,7 @@ class DisplayFloat extends Display {
 
         yomichan.on('optionsUpdated', onOptionsUpdated);
 
-        onOptionsUpdated();
+        await onOptionsUpdated();
     }
 
     async _setupNestedPopups(id, depth, parentFrameId, url) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -17,6 +17,8 @@
 
 /* global
  * Display
+ * Frontend
+ * PopupFactory
  * api
  * dynamicLoader
  */
@@ -223,15 +225,31 @@ class DisplayFloat extends Display {
     }
 
     async _setupNestedPopups(id, depth, parentFrameId, url) {
-        window.frontendInitializationData = {id, depth, parentFrameId, url, proxy: true};
         await dynamicLoader.loadScripts([
             '/mixed/js/text-scanner.js',
             '/fg/js/popup.js',
             '/fg/js/popup-proxy.js',
             '/fg/js/popup-factory.js',
             '/fg/js/frame-offset-forwarder.js',
-            '/fg/js/frontend.js',
-            '/fg/js/content-script-main.js'
+            '/fg/js/frontend.js'
         ]);
+
+        const {frameId} = await api.frameInformationGet();
+
+        const popupFactory = new PopupFactory(frameId);
+        await popupFactory.prepare();
+
+        const frontend = new Frontend(
+            frameId,
+            popupFactory,
+            {
+                id,
+                depth,
+                parentFrameId,
+                url,
+                proxy: true
+            }
+        );
+        await frontend.prepare();
     }
 }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -216,7 +216,11 @@ class DisplayFloat extends Display {
             complete = true;
             yomichan.off('optionsUpdated', onOptionsUpdated);
 
-            await this._setupNestedPopups(id, depth, parentFrameId, url);
+            try {
+                await this._setupNestedPopups(id, depth, parentFrameId, url);
+            } catch (e) {
+                yomichan.logError(e);
+            }
         };
 
         yomichan.on('optionsUpdated', onOptionsUpdated);

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -18,7 +18,6 @@
 /* global
  * DOM
  * FrameOffsetForwarder
- * PopupFactory
  * PopupProxy
  * TextScanner
  * api
@@ -26,7 +25,7 @@
  */
 
 class Frontend {
-    constructor(frontendInitializationData) {
+    constructor(frameId, popupFactory, frontendInitializationData) {
         this._id = yomichan.generateId(16);
         this._popup = null;
         this._disabledOverride = false;
@@ -51,9 +50,9 @@ class Frontend {
         this._useProxyPopup = useProxyPopup;
         this._isSearchPage = isSearchPage;
         this._depth = depth;
-        this._frameId = null;
+        this._frameId = frameId;
         this._frameOffsetForwarder = new FrameOffsetForwarder();
-        this._popupFactory = null;
+        this._popupFactory = popupFactory;
         this._iframePopupsInRootFrameAvailable = true;
         this._popupCache = new Map();
         this._updatePopupToken = null;
@@ -79,16 +78,6 @@ class Frontend {
     }
 
     async prepare() {
-        const {frameId} = await api.frameInformationGet();
-        if (typeof frameId !== 'number') {
-            throw new Error('Failed to get frameId');
-        }
-        this._frameId = frameId;
-
-        this._frameOffsetForwarder.prepare();
-        this._popupFactory = new PopupFactory(frameId);
-        await this._popupFactory.prepare();
-
         await this.updateOptions();
         try {
             const {zoomFactor} = await api.getZoom();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -97,6 +97,8 @@ class Frontend {
             // Ignore exceptions which may occur due to being on an unsupported page (e.g. about:blank)
         }
 
+        this._textScanner.prepare();
+
         window.addEventListener('resize', this._onResize.bind(this), false);
         DOM.addFullscreenChangeEventListener(this._updatePopup.bind(this));
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -44,7 +44,14 @@ class Frontend {
             search: this._search.bind(this)
         });
 
-        const {depth=0, id: proxyPopupId, parentFrameId, proxy: useProxyPopup=false, isSearchPage=false} = frontendInitializationData;
+        const {
+            depth=0,
+            id: proxyPopupId,
+            parentFrameId,
+            proxy: useProxyPopup=false,
+            isSearchPage=false,
+            allowRootFramePopupProxy=true
+        } = frontendInitializationData;
         this._proxyPopupId = proxyPopupId;
         this._parentFrameId = parentFrameId;
         this._useProxyPopup = useProxyPopup;
@@ -53,7 +60,7 @@ class Frontend {
         this._frameId = frameId;
         this._frameOffsetForwarder = new FrameOffsetForwarder();
         this._popupFactory = popupFactory;
-        this._iframePopupsInRootFrameAvailable = true;
+        this._allowRootFramePopupProxy = allowRootFramePopupProxy;
         this._popupCache = new Map();
         this._updatePopupToken = null;
 
@@ -259,7 +266,7 @@ class Frontend {
             isIframe &&
             showIframePopupsInRootFrame &&
             DOM.getFullscreenElement() === null &&
-            this._iframePopupsInRootFrameAvailable
+            this._allowRootFramePopupProxy
         ) {
             popupPromise = this._popupCache.get('iframe');
             if (typeof popupPromise === 'undefined') {
@@ -323,7 +330,7 @@ class Frontend {
 
         const popup = new PopupProxy(popupId, 0, null, parentFrameId, this._frameOffsetForwarder);
         popup.on('offsetNotFound', () => {
-            this._iframePopupsInRootFrameAvailable = false;
+            this._allowRootFramePopupProxy = false;
             this._updatePopup();
         });
         await popup.prepare();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -84,6 +84,10 @@ class Frontend {
         this._textScanner.canClearSelection = value;
     }
 
+    get popup() {
+        return this._popup;
+    }
+
     async prepare() {
         await this.updateOptions();
         try {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -307,6 +307,7 @@ class Frontend {
 
         this._textScanner.clearSelection(true);
         this._popup = popup;
+        this._depth = popup.depth;
     }
 
     async _getDefaultPopup() {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -89,6 +89,8 @@ class Frontend {
     }
 
     async prepare() {
+        this._frameOffsetForwarder.prepare();
+
         await this.updateOptions();
         try {
             const {zoomFactor} = await api.getZoom();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -79,51 +79,47 @@ class Frontend {
     }
 
     async prepare() {
-        try {
-            const {frameId} = await api.frameInformationGet();
-            if (typeof frameId !== 'number') {
-                throw new Error('Failed to get frameId');
-            }
-            this._frameId = frameId;
-
-            this._frameOffsetForwarder.prepare();
-            this._popupFactory = new PopupFactory(frameId);
-            await this._popupFactory.prepare();
-
-            await this.updateOptions();
-            try {
-                const {zoomFactor} = await api.getZoom();
-                this._pageZoomFactor = zoomFactor;
-            } catch (e) {
-                // Ignore exceptions which may occur due to being on an unsupported page (e.g. about:blank)
-            }
-
-            window.addEventListener('resize', this._onResize.bind(this), false);
-            DOM.addFullscreenChangeEventListener(this._updatePopup.bind(this));
-
-            const visualViewport = window.visualViewport;
-            if (visualViewport !== null && typeof visualViewport === 'object') {
-                window.visualViewport.addEventListener('scroll', this._onVisualViewportScroll.bind(this));
-                window.visualViewport.addEventListener('resize', this._onVisualViewportResize.bind(this));
-            }
-
-            yomichan.on('orphaned', this._onOrphaned.bind(this));
-            yomichan.on('optionsUpdated', this.updateOptions.bind(this));
-            yomichan.on('zoomChanged', this._onZoomChanged.bind(this));
-            chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
-
-            this._textScanner.on('clearSelection', this._onClearSelection.bind(this));
-            this._textScanner.on('activeModifiersChanged', this._onActiveModifiersChanged.bind(this));
-
-            api.crossFrame.registerHandlers([
-                ['getUrl', {async: false, handler: this._onApiGetUrl.bind(this)}]
-            ]);
-
-            this._updateContentScale();
-            this._broadcastRootPopupInformation();
-        } catch (e) {
-            yomichan.logError(e);
+        const {frameId} = await api.frameInformationGet();
+        if (typeof frameId !== 'number') {
+            throw new Error('Failed to get frameId');
         }
+        this._frameId = frameId;
+
+        this._frameOffsetForwarder.prepare();
+        this._popupFactory = new PopupFactory(frameId);
+        await this._popupFactory.prepare();
+
+        await this.updateOptions();
+        try {
+            const {zoomFactor} = await api.getZoom();
+            this._pageZoomFactor = zoomFactor;
+        } catch (e) {
+            // Ignore exceptions which may occur due to being on an unsupported page (e.g. about:blank)
+        }
+
+        window.addEventListener('resize', this._onResize.bind(this), false);
+        DOM.addFullscreenChangeEventListener(this._updatePopup.bind(this));
+
+        const visualViewport = window.visualViewport;
+        if (visualViewport !== null && typeof visualViewport === 'object') {
+            window.visualViewport.addEventListener('scroll', this._onVisualViewportScroll.bind(this));
+            window.visualViewport.addEventListener('resize', this._onVisualViewportResize.bind(this));
+        }
+
+        yomichan.on('orphaned', this._onOrphaned.bind(this));
+        yomichan.on('optionsUpdated', this.updateOptions.bind(this));
+        yomichan.on('zoomChanged', this._onZoomChanged.bind(this));
+        chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
+
+        this._textScanner.on('clearSelection', this._onClearSelection.bind(this));
+        this._textScanner.on('activeModifiersChanged', this._onActiveModifiersChanged.bind(this));
+
+        api.crossFrame.registerHandlers([
+            ['getUrl', {async: false, handler: this._onApiGetUrl.bind(this)}]
+        ]);
+
+        this._updateContentScale();
+        this._broadcastRootPopupInformation();
     }
 
     setDisabledOverride(disabled) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -37,8 +37,8 @@ class Frontend {
         this._optionsUpdatePending = false;
         this._textScanner = new TextScanner({
             node: window,
-            ignoreElements: () => this._popup.isProxy() ? [] : [this._popup.getFrame()],
-            ignorePoint: (x, y) => this._popup.containsPoint(x, y),
+            ignoreElements: this._ignoreElements.bind(this),
+            ignorePoint: this._ignorePoint.bind(this),
             search: this._search.bind(this)
         });
 
@@ -221,6 +221,14 @@ class Frontend {
             return;
         }
         await this.updateOptions();
+    }
+
+    _ignoreElements() {
+        return this._popup.isProxy() ? [] : [this._popup.getFrame()];
+    }
+
+    _ignorePoint(x, y) {
+        return this._popup.containsPoint(x, y);
     }
 
     async _search(textSource, cause) {

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -39,8 +39,7 @@ class PopupFactory {
             ['showContent',        {async: true,  handler: this._onApiShowContent.bind(this)}],
             ['setCustomCss',       {async: false, handler: this._onApiSetCustomCss.bind(this)}],
             ['clearAutoPlayTimer', {async: false, handler: this._onApiClearAutoPlayTimer.bind(this)}],
-            ['setContentScale',    {async: false, handler: this._onApiSetContentScale.bind(this)}],
-            ['getUrl',             {async: false, handler: this._onApiGetUrl.bind(this)}]
+            ['setContentScale',    {async: false, handler: this._onApiSetContentScale.bind(this)}]
         ]);
     }
 
@@ -145,10 +144,6 @@ class PopupFactory {
     _onApiSetContentScale({id, scale}) {
         const popup = this._getPopup(id);
         return popup.setContentScale(scale);
-    }
-
-    _onApiGetUrl() {
-        return window.location.href;
     }
 
     // Private functions

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -104,10 +104,6 @@ class PopupProxy extends EventDispatcher {
         this._invoke('setContentScale', {id: this._id, scale});
     }
 
-    async getUrl() {
-        return await this._invoke('getUrl', {});
-    }
-
     // Private
 
     _invoke(action, params={}) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -409,16 +409,7 @@ class Popup {
             return;
         }
 
-        const fullscreenEvents = [
-            'fullscreenchange',
-            'MSFullscreenChange',
-            'mozfullscreenchange',
-            'webkitfullscreenchange'
-        ];
-        const onFullscreenChanged = this._onFullscreenChanged.bind(this);
-        for (const eventName of fullscreenEvents) {
-            this._fullscreenEventListeners.addEventListener(document, eventName, onFullscreenChanged, false);
-        }
+        DOM.addFullscreenChangeEventListener(this._onFullscreenChanged.bind(this), this._fullscreenEventListeners);
     }
 
     _onFullscreenChanged() {

--- a/ext/mixed/js/dom.js
+++ b/ext/mixed/js/dom.js
@@ -77,6 +77,24 @@ class DOM {
         return (typeof key === 'string' ? (key.length === 1 ? key.toUpperCase() : key) : '');
     }
 
+    static addFullscreenChangeEventListener(onFullscreenChanged, eventListenerCollection=null) {
+        const target = document;
+        const options = false;
+        const fullscreenEventNames = [
+            'fullscreenchange',
+            'MSFullscreenChange',
+            'mozfullscreenchange',
+            'webkitfullscreenchange'
+        ];
+        for (const eventName of fullscreenEventNames) {
+            if (eventListenerCollection === null) {
+                target.addEventListener(eventName, onFullscreenChanged, options);
+            } else {
+                eventListenerCollection.addEventListener(target, eventName, onFullscreenChanged, options);
+            }
+        }
+    }
+
     static getFullscreenElement() {
         return (
             document.fullscreenElement ||

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -29,6 +29,7 @@ class TextScanner extends EventDispatcher {
         this._ignorePoint = ignorePoint;
         this._search = search;
 
+        this._isPrepared = false;
         this._ignoreNodes = null;
 
         this._causeCurrent = null;
@@ -70,10 +71,15 @@ class TextScanner extends EventDispatcher {
         return this._causeCurrent;
     }
 
+    prepare() {
+        this._isPrepared = true;
+        this.setEnabled(this._enabled);
+    }
+
     setEnabled(enabled) {
         this._eventListeners.removeAllEventListeners();
         this._enabled = enabled;
-        if (this._enabled) {
+        if (this._enabled && this._isPrepared) {
             this._hookEvents();
         } else {
             this.clearSelection(true);


### PR DESCRIPTION
This PR changes how the frontend and its popups are initialized. All management of popup creation and changing is now controlled by the frontend instance.

* Error wrapping of `prepare` functions is moved into the entry point functions instead.
* `frontendInitializationData` is no longer used for nested popup initialization. `new Frontend(...)` is directly used instead. (Originally set up in #467, #481)
* `getUrl` is no longer part of `PopupProxy`. Instead, it is part of `Frontend`. (https://github.com/FooSoft/yomichan/pull/516#discussion_r421844037)
* Created utility for listening to fullscreen changes, since it is now used in two places.
* `TextScanner` now has a `prepare` function to prevent inadvertent event hooking before the using class is ready. This basically means that `setEnabled` won't do anything unless the instance is `prepare`'d.

Addresses https://github.com/FooSoft/yomichan/pull/464#issuecomment-618715392.
This will be used as the foundation to investigate/implement some changes to address #608. This mainly entails some changes to popup frame message passing.