### PR TITLE
Secure popup frame url changes

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -110,7 +110,7 @@
                                     "showPitchAccentPositionNotation",
                                     "showPitchAccentGraph",
                                     "showIframePopupsInRootFrame",
-                                    "unsecurePopupFrameUrl"
+                                    "useSecurePopupFrameUrl"
                                 ],
                                 "properties": {
                                     "enable": {
@@ -249,9 +249,9 @@
                                         "type": "boolean",
                                         "default": false
                                     },
-                                    "unsecurePopupFrameUrl": {
+                                    "useSecurePopupFrameUrl": {
                                         "type": "boolean",
-                                        "default": false
+                                        "default": true
                                     }
                                 }
                             },

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -177,7 +177,7 @@ function profileOptionsCreateDefaults() {
             showPitchAccentPositionNotation: true,
             showPitchAccentGraph: false,
             showIframePopupsInRootFrame: false,
-            unsecurePopupFrameUrl: false
+            useSecurePopupFrameUrl: true
         },
 
         audio: {

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -183,7 +183,7 @@
                 </div>
 
                 <div class="checkbox options-advanced">
-                    <label><input type="checkbox" id="show-iframe-popups-in-root-frame" data-setting="general.unsecurePopupFrameUrl"> Use unsecure popup frame URL</label>
+                    <label><input type="checkbox" data-setting="general.unsecurePopupFrameUrl"> Use unsecure popup frame URL</label>
                 </div>
 
                 <div class="checkbox options-advanced">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -183,7 +183,7 @@
                 </div>
 
                 <div class="checkbox options-advanced">
-                    <label><input type="checkbox" data-setting="general.unsecurePopupFrameUrl"> Use unsecure popup frame URL</label>
+                    <label><input type="checkbox" data-setting="general.useSecurePopupFrameUrl"> Use secure popup frame URL</label>
                 </div>
 
                 <div class="checkbox options-advanced">

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -326,6 +326,10 @@ class Popup {
     }
 
     async _createInjectPromise() {
+        if (this._options === null) {
+            throw new Error('Options not initialized');
+        }
+
         this._injectStyles();
 
         const unsecurePopupFrameUrl = (this._options !== null && this._options.general.unsecurePopupFrameUrl);

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -330,19 +330,20 @@ class Popup {
             throw new Error('Options not initialized');
         }
 
+        const {useSecurePopupFrameUrl} = this._options.general;
+
         this._injectStyles();
 
-        const unsecurePopupFrameUrl = (this._options !== null && this._options.general.unsecurePopupFrameUrl);
         const {secret, token} = await this._initializeFrame(this._frame, this._targetOrigin, this._frameId, (frame) => {
             frame.removeAttribute('src');
             frame.removeAttribute('srcdoc');
             this._observeFullscreen(true);
             this._onFullscreenChanged();
             const url = chrome.runtime.getURL('/fg/float.html');
-            if (unsecurePopupFrameUrl) {
-                frame.setAttribute('src', url);
-            } else {
+            if (useSecurePopupFrameUrl) {
                 frame.contentDocument.location.href = url;
+            } else {
+                frame.setAttribute('src', url);
             }
         });
         this._frameSecret = secret;


### PR DESCRIPTION
Follow-up of #618.
* Throw an error if `this._options` is not ready. If this error occurs, it indicates developer error. This allows the null check to be removed.
* Remove incorrect id from copy-pasted HTML.
* Renamed `unsecurePopupFrameUrl` to `useSecurePopupFrameUrl`, as this naming convention better matches the convention of variables named "enabled" instead of variables named "disabled".