### PR TITLE
Clone function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,6 +99,7 @@
                 "getSetDifference": "readonly",
                 "escapeRegExp": "readonly",
                 "deferPromise": "readonly",
+                "clone": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly",
                 "EXTENSION_IS_BROWSER_EDGE": "readonly"

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -38,7 +38,6 @@
  * profileConditionsDescriptorPromise
  * requestJson
  * requestText
- * utilIsolate
  */
 
 class Backend {
@@ -875,7 +874,7 @@ class Backend {
         for (const target of targets) {
             try {
                 const result = this._modifySetting(target);
-                results.push({result: utilIsolate(result)});
+                results.push({result: clone(result)});
             } catch (e) {
                 results.push({error: errorToJson(e)});
             }
@@ -889,7 +888,7 @@ class Backend {
         for (const target of targets) {
             try {
                 const result = this._getSetting(target);
-                results.push({result: utilIsolate(result)});
+                results.push({result: clone(result)});
             } catch (e) {
                 results.push({error: errorToJson(e)});
             }

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -90,7 +90,7 @@ class JsonSchemaProxyHandler {
             throw new Error(`Property ${property} not supported`);
         }
 
-        value = JsonSchema.isolate(value);
+        value = JsonSchema.clone(value);
 
         JsonSchemaProxyHandler.validate(value, propertySchema, new JsonSchemaTraversalInfo(value, propertySchema));
 
@@ -515,7 +515,7 @@ class JsonSchemaProxyHandler {
 
             const schemaDefault = schema.default;
             if (typeof schemaDefault !== 'undefined') {
-                value = JsonSchema.isolate(schemaDefault);
+                value = JsonSchema.clone(schemaDefault);
                 type = JsonSchemaProxyHandler.getValueType(value);
                 assignDefault = !JsonSchemaProxyHandler.isValueTypeAny(value, type, schemaType);
             }
@@ -628,19 +628,7 @@ class JsonSchema {
         return JsonSchemaProxyHandler.getValidValueOrDefault(schema, value);
     }
 
-    static isolate(value) {
-        if (value === null) { return null; }
-
-        switch (typeof value) {
-            case 'boolean':
-            case 'number':
-            case 'string':
-            case 'bigint':
-            case 'symbol':
-                return value;
-        }
-
-        const stringValue = JSON.stringify(value);
-        return typeof stringValue === 'string' ? JSON.parse(stringValue) : null;
+    static clone(value) {
+        return clone(value);
     }
 }

--- a/ext/bg/js/util.js
+++ b/ext/bg/js/util.js
@@ -15,26 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-function utilIsolate(value) {
-    if (value === null) { return null; }
-
-    switch (typeof value) {
-        case 'boolean':
-        case 'number':
-        case 'string':
-        case 'bigint':
-        case 'symbol':
-            return value;
-    }
-
-    const stringValue = JSON.stringify(value);
-    return typeof stringValue === 'string' ? JSON.parse(stringValue) : null;
-}
-
 function utilFunctionIsolate(func) {
     return function isolatedFunction(...args) {
         try {
-            args = args.map((v) => utilIsolate(v));
+            args = args.map((v) => clone(v));
             return func.call(this, ...args);
         } catch (e) {
             try {
@@ -50,7 +34,7 @@ function utilFunctionIsolate(func) {
 
 function utilBackgroundIsolate(data) {
     const backgroundPage = chrome.extension.getBackgroundPage();
-    return backgroundPage.utilIsolate(data);
+    return backgroundPage.clone(data);
 }
 
 function utilBackgroundFunctionIsolate(func) {

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -193,22 +193,32 @@ const clone = (() => {
 
     function cloneArray(value, visited) {
         if (visited.has(value)) { throw new Error('Circular'); }
-        const result = [];
-        for (const item of value) {
-            result.push(cloneInternal(item, visited));
+        try {
+            visited.add(value);
+            const result = [];
+            for (const item of value) {
+                result.push(cloneInternal(item, visited));
+            }
+            return result;
+        } finally {
+            visited.delete(value);
         }
-        return result;
     }
 
     function cloneObject(value, visited) {
         if (visited.has(value)) { throw new Error('Circular'); }
-        const result = {};
-        for (const key in value) {
-            if (Object.prototype.hasOwnProperty.call(value, key)) {
-                result[key] = cloneInternal(value[key], visited);
+        try {
+            visited.add(value);
+            const result = {};
+            for (const key in value) {
+                if (Object.prototype.hasOwnProperty.call(value, key)) {
+                    result[key] = cloneInternal(value[key], visited);
+                }
             }
+            return result;
+        } finally {
+            visited.delete(value);
         }
-        return result;
     }
 
     return clone;

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -157,6 +157,63 @@ function getSetDifference(set1, set2) {
     );
 }
 
+const clone = (() => {
+    // eslint-disable-next-line no-shadow
+    function clone(value) {
+        if (value === null) { return null; }
+        switch (typeof value) {
+            case 'boolean':
+            case 'number':
+            case 'string':
+            case 'bigint':
+            case 'symbol':
+            case 'undefined':
+                return value;
+            default:
+                return cloneInternal(value, new Set());
+        }
+    }
+
+    function cloneInternal(value, visited) {
+        if (value === null) { return null; }
+        switch (typeof value) {
+            case 'boolean':
+            case 'number':
+            case 'string':
+            case 'bigint':
+            case 'symbol':
+            case 'undefined':
+                return value;
+            case 'function':
+                return cloneObject(value, visited);
+            case 'object':
+                return Array.isArray(value) ? cloneArray(value, visited) : cloneObject(value, visited);
+        }
+    }
+
+    function cloneArray(value, visited) {
+        if (visited.has(value)) { throw new Error('Circular'); }
+        const result = [];
+        for (const item of value) {
+            result.push(cloneInternal(item, visited));
+        }
+        return result;
+    }
+
+    function cloneObject(value, visited) {
+        if (visited.has(value)) { throw new Error('Circular'); }
+        const result = {};
+        for (const key in value) {
+            if (Object.prototype.hasOwnProperty.call(value, key)) {
+                result[key] = cloneInternal(value[key], visited);
+            }
+        }
+        return result;
+    }
+
+    return clone;
+})();
+
 
 /*
  * Async utilities

--- a/test/dictionary-validate.js
+++ b/test/dictionary-validate.js
@@ -21,7 +21,10 @@ const {JSZip} = require('./yomichan-test');
 const {VM} = require('./yomichan-vm');
 
 const vm = new VM();
-vm.execute('bg/js/json-schema.js');
+vm.execute([
+    'mixed/js/core.js',
+    'bg/js/json-schema.js'
+]);
 const JsonSchema = vm.get('JsonSchema');
 
 

--- a/test/schema-validate.js
+++ b/test/schema-validate.js
@@ -19,7 +19,10 @@ const fs = require('fs');
 const {VM} = require('./yomichan-vm');
 
 const vm = new VM();
-vm.execute('bg/js/json-schema.js');
+vm.execute([
+    'mixed/js/core.js',
+    'bg/js/json-schema.js'
+]);
 const JsonSchema = vm.get('JsonSchema');
 
 

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -19,7 +19,10 @@ const assert = require('assert');
 const {VM} = require('./yomichan-vm');
 
 const vm = new VM();
-vm.execute('bg/js/json-schema.js');
+vm.execute([
+    'mixed/js/core.js',
+    'bg/js/json-schema.js'
+]);
 const JsonSchema = vm.get('JsonSchema');
 
 


### PR DESCRIPTION
Add a `clone` function to replace various `isolate` functions. This function skips the JSON stringification/parsing, so it should theoretically be more efficient. The name should also be more clear as to what it is actually doing. "isolation" makes sense when sending values across `window` boundaries, but this functionality is being removed in favor of message passing.