### PR TITLE
Add deferPromise function

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -99,6 +99,7 @@
                 "getSetIntersection": "readonly",
                 "getSetDifference": "readonly",
                 "escapeRegExp": "readonly",
+                "deferPromise": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly",
                 "EXTENSION_IS_BROWSER_EDGE": "readonly"

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -203,6 +203,16 @@ function promiseTimeout(delay, resolveValue) {
     return promise;
 }
 
+function deferPromise() {
+    let resolve;
+    let reject;
+    const promise = new Promise((resolve2, reject2) => {
+        resolve = resolve2;
+        reject = reject2;
+    });
+    return {promise, resolve, reject};
+}
+
 
 /*
  * Common events


### PR DESCRIPTION
This function is intended to simplify the pattern of starting a promise and then using the `reject`/`resolve` callbacks later, outside of the promise executor.