### PR TITLE
Rename Database to DictionaryDatabase

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -32,7 +32,7 @@
         <script src="/bg/js/clipboard-monitor.js"></script>
         <script src="/bg/js/conditions.js"></script>
         <script src="/bg/js/generic-database.js"></script>
-        <script src="/bg/js/database.js"></script>
+        <script src="/bg/js/dictionary-database.js"></script>
         <script src="/bg/js/dictionary-importer.js"></script>
         <script src="/bg/js/deinflector.js"></script>
         <script src="/bg/js/dictionary.js"></script>

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -21,7 +21,7 @@
  * AudioSystem
  * AudioUriBuilder
  * ClipboardMonitor
- * Database
+ * DictionaryDatabase
  * DictionaryImporter
  * Environment
  * JsonSchema
@@ -43,9 +43,9 @@
 class Backend {
     constructor() {
         this._environment = new Environment();
-        this._database = new Database();
+        this._dictionaryDatabase = new DictionaryDatabase();
         this._dictionaryImporter = new DictionaryImporter();
-        this._translator = new Translator(this._database);
+        this._translator = new Translator(this._dictionaryDatabase);
         this._anki = new AnkiConnect();
         this._mecab = new Mecab();
         this._clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
@@ -173,7 +173,7 @@ class Backend {
 
             await this._environment.prepare();
             try {
-                await this._database.prepare();
+                await this._dictionaryDatabase.prepare();
             } catch (e) {
                 yomichan.logError(e);
             }
@@ -681,11 +681,11 @@ class Backend {
 
     async _onApiPurgeDatabase() {
         this._translator.clearDatabaseCaches();
-        await this._database.purge();
+        await this._dictionaryDatabase.purge();
     }
 
     async _onApiGetMedia({targets}) {
-        return await this._database.getMedia(targets);
+        return await this._dictionaryDatabase.getMedia(targets);
     }
 
     _onApiLog({error, level, context}) {
@@ -719,12 +719,12 @@ class Backend {
     }
 
     async _onApiImportDictionaryArchive({archiveContent, details}, sender, onProgress) {
-        return await this._dictionaryImporter.import(this._database, archiveContent, details, onProgress);
+        return await this._dictionaryImporter.import(this._dictionaryDatabase, archiveContent, details, onProgress);
     }
 
     async _onApiDeleteDictionary({dictionaryName}, sender, onProgress) {
         this._translator.clearDatabaseCaches();
-        await this._database.deleteDictionary(dictionaryName, {rate: 1000}, onProgress);
+        await this._dictionaryDatabase.deleteDictionary(dictionaryName, {rate: 1000}, onProgress);
     }
 
     async _onApiModifySettings({targets, source}) {
@@ -938,7 +938,7 @@ class Backend {
     }
 
     async _importDictionary(archiveSource, onProgress, details) {
-        return await this._dictionaryImporter.import(this._database, archiveSource, onProgress, details);
+        return await this._dictionaryImporter.import(this._dictionaryDatabase, archiveSource, onProgress, details);
     }
 
     async _textParseScanning(text, options) {

--- a/ext/bg/js/dictionary-database.js
+++ b/ext/bg/js/dictionary-database.js
@@ -20,7 +20,7 @@
  * dictFieldSplit
  */
 
-class Database {
+class DictionaryDatabase {
     constructor() {
         this._db = new GenericDatabase();
         this._dbName = 'dict';

--- a/ext/bg/js/dictionary-importer.js
+++ b/ext/bg/js/dictionary-importer.js
@@ -27,11 +27,11 @@ class DictionaryImporter {
         this._schemas = new Map();
     }
 
-    async import(database, archiveSource, details, onProgress) {
-        if (!database) {
+    async import(dictionaryDatabase, archiveSource, details, onProgress) {
+        if (!dictionaryDatabase) {
             throw new Error('Invalid database');
         }
-        if (!database.isPrepared()) {
+        if (!dictionaryDatabase.isPrepared()) {
             throw new Error('Database is not ready');
         }
 
@@ -60,7 +60,7 @@ class DictionaryImporter {
         }
 
         // Verify database is not already imported
-        if (await database.dictionaryExists(dictionaryTitle)) {
+        if (await dictionaryDatabase.dictionaryExists(dictionaryTitle)) {
             throw new Error('Dictionary is already imported');
         }
 
@@ -168,7 +168,7 @@ class DictionaryImporter {
         // Add dictionary
         const summary = this._createSummary(dictionaryTitle, version, index, {prefixWildcardsSupported});
 
-        database.bulkAdd('dictionaries', [summary], 0, 1);
+        dictionaryDatabase.bulkAdd('dictionaries', [summary], 0, 1);
 
         // Add data
         const errors = [];
@@ -188,7 +188,7 @@ class DictionaryImporter {
                 const count = Math.min(maxTransactionLength, ii - i);
 
                 try {
-                    await database.bulkAdd(objectStoreName, entries, i, count);
+                    await dictionaryDatabase.bulkAdd(objectStoreName, entries, i, count);
                 } catch (e) {
                     errors.push(errorToJson(e));
                 }

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -116,10 +116,10 @@ vm.execute([
     'bg/js/request.js',
     'bg/js/dictionary-importer.js',
     'bg/js/generic-database.js',
-    'bg/js/database.js'
+    'bg/js/dictionary-database.js'
 ]);
 const DictionaryImporter = vm.get('DictionaryImporter');
-const Database = vm.get('Database');
+const DictionaryDatabase = vm.get('DictionaryDatabase');
 
 
 function countTermsWithExpression(terms, expression) {
@@ -180,15 +180,15 @@ async function testDatabase1() {
         {
             cleanup: async () => {
                 // Test purge
-                await database.purge();
-                await testDatabaseEmpty1(database);
+                await dictionaryDatabase.purge();
+                await testDatabaseEmpty1(dictionaryDatabase);
             }
         },
         {
             cleanup: async () => {
                 // Test deleteDictionary
                 let progressEvent = false;
-                await database.deleteDictionary(
+                await dictionaryDatabase.deleteDictionary(
                     title,
                     {rate: 1000},
                     () => {
@@ -197,7 +197,7 @@ async function testDatabase1() {
                 );
                 assert.ok(progressEvent);
 
-                await testDatabaseEmpty1(database);
+                await testDatabaseEmpty1(dictionaryDatabase);
             }
         },
         {
@@ -207,8 +207,8 @@ async function testDatabase1() {
 
     // Setup database
     const dictionaryImporter = new DictionaryImporter();
-    const database = new Database();
-    await database.prepare();
+    const dictionaryDatabase = new DictionaryDatabase();
+    await dictionaryDatabase.prepare();
 
     for (const {cleanup} of iterations) {
         const expectedSummary = {
@@ -222,7 +222,7 @@ async function testDatabase1() {
         // Import data
         let progressEvent = false;
         const {result, errors} = await dictionaryImporter.import(
-            database,
+            dictionaryDatabase,
             testDictionarySource,
             {prefixWildcardsSupported: true},
             () => {
@@ -234,11 +234,11 @@ async function testDatabase1() {
         assert.ok(progressEvent);
 
         // Get info summary
-        const info = await database.getDictionaryInfo();
+        const info = await dictionaryDatabase.getDictionaryInfo();
         vm.assert.deepStrictEqual(info, [expectedSummary]);
 
         // Get counts
-        const counts = await database.getDictionaryCounts(
+        const counts = await dictionaryDatabase.getDictionaryCounts(
             info.map((v) => v.title),
             true
         );
@@ -248,19 +248,19 @@ async function testDatabase1() {
         });
 
         // Test find* functions
-        await testFindTermsBulkTest1(database, titles);
-        await testTindTermsExactBulk1(database, titles);
-        await testFindTermsBySequenceBulk1(database, title);
-        await testFindTermMetaBulk1(database, titles);
-        await testFindKanjiBulk1(database, titles);
-        await testFindKanjiMetaBulk1(database, titles);
-        await testFindTagForTitle1(database, title);
+        await testFindTermsBulkTest1(dictionaryDatabase, titles);
+        await testTindTermsExactBulk1(dictionaryDatabase, titles);
+        await testFindTermsBySequenceBulk1(dictionaryDatabase, title);
+        await testFindTermMetaBulk1(dictionaryDatabase, titles);
+        await testFindKanjiBulk1(dictionaryDatabase, titles);
+        await testFindKanjiMetaBulk1(dictionaryDatabase, titles);
+        await testFindTagForTitle1(dictionaryDatabase, title);
 
         // Cleanup
         await cleanup();
     }
 
-    await database.close();
+    await dictionaryDatabase.close();
 }
 
 async function testDatabaseEmpty1(database) {
@@ -861,33 +861,33 @@ async function testDatabase2() {
 
     // Setup database
     const dictionaryImporter = new DictionaryImporter();
-    const database = new Database();
+    const dictionaryDatabase = new DictionaryDatabase();
 
     // Error: not prepared
-    await assert.rejects(async () => await database.deleteDictionary(title, {rate: 1000}, () => {}));
-    await assert.rejects(async () => await database.findTermsBulk(['?'], titles, null));
-    await assert.rejects(async () => await database.findTermsExactBulk(['?'], ['?'], titles));
-    await assert.rejects(async () => await database.findTermsBySequenceBulk([1], title));
-    await assert.rejects(async () => await database.findTermMetaBulk(['?'], titles));
-    await assert.rejects(async () => await database.findTermMetaBulk(['?'], titles));
-    await assert.rejects(async () => await database.findKanjiBulk(['?'], titles));
-    await assert.rejects(async () => await database.findKanjiMetaBulk(['?'], titles));
-    await assert.rejects(async () => await database.findTagForTitle('tag', title));
-    await assert.rejects(async () => await database.getDictionaryInfo());
-    await assert.rejects(async () => await database.getDictionaryCounts(titles, true));
-    await assert.rejects(async () => await dictionaryImporter.import(database, testDictionarySource, {}, () => {}));
+    await assert.rejects(async () => await dictionaryDatabase.deleteDictionary(title, {rate: 1000}, () => {}));
+    await assert.rejects(async () => await dictionaryDatabase.findTermsBulk(['?'], titles, null));
+    await assert.rejects(async () => await dictionaryDatabase.findTermsExactBulk(['?'], ['?'], titles));
+    await assert.rejects(async () => await dictionaryDatabase.findTermsBySequenceBulk([1], title));
+    await assert.rejects(async () => await dictionaryDatabase.findTermMetaBulk(['?'], titles));
+    await assert.rejects(async () => await dictionaryDatabase.findTermMetaBulk(['?'], titles));
+    await assert.rejects(async () => await dictionaryDatabase.findKanjiBulk(['?'], titles));
+    await assert.rejects(async () => await dictionaryDatabase.findKanjiMetaBulk(['?'], titles));
+    await assert.rejects(async () => await dictionaryDatabase.findTagForTitle('tag', title));
+    await assert.rejects(async () => await dictionaryDatabase.getDictionaryInfo());
+    await assert.rejects(async () => await dictionaryDatabase.getDictionaryCounts(titles, true));
+    await assert.rejects(async () => await dictionaryImporter.import(dictionaryDatabase, testDictionarySource, {}, () => {}));
 
-    await database.prepare();
+    await dictionaryDatabase.prepare();
 
     // Error: already prepared
-    await assert.rejects(async () => await database.prepare());
+    await assert.rejects(async () => await dictionaryDatabase.prepare());
 
-    await dictionaryImporter.import(database, testDictionarySource, {}, () => {});
+    await dictionaryImporter.import(dictionaryDatabase, testDictionarySource, {}, () => {});
 
     // Error: dictionary already imported
-    await assert.rejects(async () => await dictionaryImporter.import(database, testDictionarySource, {}, () => {}));
+    await assert.rejects(async () => await dictionaryImporter.import(dictionaryDatabase, testDictionarySource, {}, () => {}));
 
-    await database.close();
+    await dictionaryDatabase.close();
 }
 
 
@@ -903,8 +903,8 @@ async function testDatabase3() {
 
     // Setup database
     const dictionaryImporter = new DictionaryImporter();
-    const database = new Database();
-    await database.prepare();
+    const dictionaryDatabase = new DictionaryDatabase();
+    await dictionaryDatabase.prepare();
 
     for (const invalidDictionary of invalidDictionaries) {
         const testDictionary = yomichanTest.createTestDictionaryArchive(invalidDictionary);
@@ -912,7 +912,7 @@ async function testDatabase3() {
 
         let error = null;
         try {
-            await dictionaryImporter.import(database, testDictionarySource, {}, () => {});
+            await dictionaryImporter.import(dictionaryDatabase, testDictionarySource, {}, () => {});
         } catch (e) {
             error = e;
         }
@@ -927,7 +927,7 @@ async function testDatabase3() {
         }
     }
 
-    await database.close();
+    await dictionaryDatabase.close();
 }
 
 


### PR DESCRIPTION
This change renames `Database` to `DictionaryDatabase` in order to give it better semantics. In the future, the `GenericDatabase` class may be used for more features besides storing dictionary information, such as storing logs.

Originally mentioned in https://github.com/FooSoft/yomichan/pull/600#issue-433907630.