### PR TITLE
Rename GenericDatabase to Database

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -31,7 +31,7 @@
         <script src="/bg/js/audio-uri-builder.js"></script>
         <script src="/bg/js/clipboard-monitor.js"></script>
         <script src="/bg/js/conditions.js"></script>
-        <script src="/bg/js/generic-database.js"></script>
+        <script src="/bg/js/database.js"></script>
         <script src="/bg/js/dictionary-database.js"></script>
         <script src="/bg/js/dictionary-importer.js"></script>
         <script src="/bg/js/deinflector.js"></script>

--- a/ext/bg/js/database.js
+++ b/ext/bg/js/database.js
@@ -15,7 +15,7 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-class GenericDatabase {
+class Database {
     constructor() {
         this._db = null;
         this._isOpening = false;

--- a/ext/bg/js/dictionary-database.js
+++ b/ext/bg/js/dictionary-database.js
@@ -16,13 +16,13 @@
  */
 
 /* global
- * GenericDatabase
+ * Database
  * dictFieldSplit
  */
 
 class DictionaryDatabase {
     constructor() {
-        this._db = new GenericDatabase();
+        this._db = new Database();
         this._dbName = 'dict';
         this._schemas = new Map();
     }
@@ -118,7 +118,7 @@ class DictionaryDatabase {
         if (this._db.isOpen()) {
             this._db.close();
         }
-        await GenericDatabase.deleteDatabase(this._dbName);
+        await Database.deleteDatabase(this._dbName);
         await this.prepare();
     }
 

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -115,7 +115,7 @@ vm.execute([
     'bg/js/media-utility.js',
     'bg/js/request.js',
     'bg/js/dictionary-importer.js',
-    'bg/js/generic-database.js',
+    'bg/js/database.js',
     'bg/js/dictionary-database.js'
 ]);
 const DictionaryImporter = vm.get('DictionaryImporter');


### PR DESCRIPTION
This change renames `GenericDatabase` to `Database`.

Originally mentioned in https://github.com/FooSoft/yomichan/pull/600#issue-433907630.