### PR TITLE
Extension unload detection

### DIFF
--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -29,7 +29,7 @@
             </div>
         </div>
 
-        <div id="error-orphaned" hidden>
+        <div id="error-extension-unloaded" hidden>
             <div class="entry">
                 <h1>Yomichan Updated!</h1>
                 <p>

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -32,7 +32,6 @@ class Frontend {
         this._options = null;
         this._pageZoomFactor = 1.0;
         this._contentScale = 1.0;
-        this._orphaned = false;
         this._lastShowPromise = Promise.resolve();
         this._enabledEventListeners = new EventListenerCollection();
         this._activeModifiers = new Set();
@@ -110,7 +109,6 @@ class Frontend {
             visualViewport.addEventListener('resize', this._onVisualViewportResize.bind(this));
         }
 
-        yomichan.on('orphaned', this._onOrphaned.bind(this));
         yomichan.on('optionsUpdated', this.updateOptions.bind(this));
         yomichan.on('zoomChanged', this._onZoomChanged.bind(this));
         chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
@@ -228,10 +226,6 @@ class Frontend {
         const result = handler(params, sender);
         callback(result);
         return false;
-    }
-
-    _onOrphaned() {
-        this._orphaned = true;
     }
 
     _onZoomChanged({newZoomFactor}) {
@@ -370,7 +364,7 @@ class Frontend {
                 }
             }
         } catch (e) {
-            if (this._orphaned) {
+            if (yomichan.isExtensionUnloaded) {
                 if (textSource !== null && this._options.scanning.modifier !== 'none') {
                     this._showPopupContent(textSource, await this.getOptionsContext(), 'orphaned');
                 }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -366,7 +366,7 @@ class Frontend {
         } catch (e) {
             if (yomichan.isExtensionUnloaded) {
                 if (textSource !== null && this._options.scanning.modifier !== 'none') {
-                    this._showPopupContent(textSource, await this.getOptionsContext(), 'orphaned');
+                    this._showPopupContent(textSource, await this.getOptionsContext(), 'extensionUnloaded');
                 }
             } else {
                 yomichan.logError(e);

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -322,7 +322,7 @@ const api = (() => {
             const data = {action, params};
             return new Promise((resolve, reject) => {
                 try {
-                    chrome.runtime.sendMessage(data, (response) => {
+                    yomichan.sendMessage(data, (response) => {
                         this._checkLastError(chrome.runtime.lastError);
                         if (response !== null && typeof response === 'object') {
                             if (typeof response.error !== 'undefined') {
@@ -337,7 +337,6 @@ const api = (() => {
                     });
                 } catch (e) {
                     reject(e);
-                    yomichan.triggerOrphaned(e);
                 }
             });
         }

--- a/ext/mixed/js/comm.js
+++ b/ext/mixed/js/comm.js
@@ -268,7 +268,7 @@ class CrossFrameAPI {
     }
 
     _createCommPort(otherFrameId) {
-        const port = chrome.runtime.connect(null, {name: `background-cross-frame-communication-port-${otherFrameId}`});
+        const port = yomichan.connect(null, {name: `background-cross-frame-communication-port-${otherFrameId}`});
         return this._setupCommPort(otherFrameId, port);
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -172,7 +172,7 @@ class Display {
 
     onError(error) {
         if (yomichan.isExtensionUnloaded) {
-            this.setContent('orphaned');
+            this.setContent('extensionUnloaded');
         } else {
             yomichan.logError(error);
         }
@@ -488,8 +488,8 @@ class Display {
                 case 'kanji':
                     await this._setContentKanji(details.definitions, details.context, token);
                     break;
-                case 'orphaned':
-                    this._setContentOrphaned();
+                case 'extensionUnloaded':
+                    this._setContentExtensionUnloaded();
                     break;
             }
         } catch (e) {
@@ -608,15 +608,15 @@ class Display {
         this._updateAdderButtons(states);
     }
 
-    _setContentOrphaned() {
-        const errorOrphaned = document.querySelector('#error-orphaned');
+    _setContentExtensionUnloaded() {
+        const errorExtensionUnloaded = document.querySelector('#error-extension-unloaded');
 
         if (this._container !== null) {
             this._container.hidden = true;
         }
 
-        if (errorOrphaned !== null) {
-            errorOrphaned.hidden = false;
+        if (errorExtensionUnloaded !== null) {
+            errorExtensionUnloaded.hidden = false;
         }
 
         this._updateNavigation(null, null);

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -47,7 +47,6 @@ class Display {
             useCache: true
         });
         this._styleNode = null;
-        this._orphaned = false;
 
         this._eventListeners = new EventListenerCollection();
         this._persistentEventListeners = new EventListenerCollection();
@@ -169,15 +168,10 @@ class Display {
         this._setInteractive(true);
         await yomichan.ready();
         await this._displayGenerator.prepare();
-        yomichan.on('orphaned', this._onOrphaned.bind(this));
-    }
-
-    _onOrphaned() {
-        this._orphaned = true;
     }
 
     onError(error) {
-        if (this._orphaned) {
+        if (yomichan.isExtensionUnloaded) {
             this.setContent('orphaned');
         } else {
             yomichan.logError(error);

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -214,7 +214,7 @@ const yomichan = (() => {
 
         _onExtensionUnloaded(error) {
             this._isExtensionUnloaded = true;
-            this.trigger('orphaned', {error});
+            this.trigger('extensionUnloaded', {error});
         }
 
         _getUrl() {

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -47,6 +47,8 @@ const yomichan = (() => {
                 // NOP
             }
 
+            this._isExtensionUnloaded = false;
+
             const {promise, resolve} = deferPromise();
             this._isBackendPreparedPromise = promise;
             this._isBackendPreparedPromiseResolve = resolve;
@@ -61,12 +63,16 @@ const yomichan = (() => {
 
         // Public
 
+        get isExtensionUnloaded() {
+            return this._isExtensionUnloaded;
+        }
+
         prepare() {
             chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
         }
 
         ready() {
-            chrome.runtime.sendMessage({action: 'yomichanCoreReady'});
+            this.sendMessage({action: 'yomichanCoreReady'});
             return this._isBackendPreparedPromise;
         }
 
@@ -78,10 +84,6 @@ const yomichan = (() => {
                 id += value.toString(16).padStart(2, '0');
             }
             return id;
-        }
-
-        triggerOrphaned(error) {
-            this.trigger('orphaned', {error});
         }
 
         isExtensionUrl(url) {
@@ -190,7 +192,30 @@ const yomichan = (() => {
             this.trigger('log', {error, level, context});
         }
 
+        sendMessage(...args) {
+            try {
+                return chrome.runtime.sendMessage(...args);
+            } catch (e) {
+                this._onExtensionUnloaded(e);
+                throw e;
+            }
+        }
+
+        connect(...args) {
+            try {
+                return chrome.runtime.connect(...args);
+            } catch (e) {
+                this._onExtensionUnloaded(e);
+                throw e;
+            }
+        }
+
         // Private
+
+        _onExtensionUnloaded(error) {
+            this._isExtensionUnloaded = true;
+            this.trigger('orphaned', {error});
+        }
 
         _getUrl() {
             return (typeof window === 'object' && window !== null ? window.location.href : '');


### PR DESCRIPTION
First step towards fixing #642. There are additional places where extension unload can be detected/triggered, such as `chrome.runtime.connect`, which are causing unhandled errors. This change unifies the way that the extension unloaded state is stored and accessed.