### PR TITLE
Refactor DisplayFloat=>Frontend message passing

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -255,7 +255,7 @@ class DisplaySearch extends Display {
                 this.clearContent();
             }
             this._setTitleText(query);
-            window.parent.postMessage('popupClose', '*');
+            yomichan.trigger('closePopups');
         } catch (e) {
             this.onError(e);
         }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -61,7 +61,7 @@ class DisplayFloat extends Display {
     }
 
     onEscape() {
-        this._invoke('popupClose');
+        this._invoke('closePopup');
     }
 
     async setOptionsContext(optionsContext) {
@@ -175,7 +175,7 @@ class DisplayFloat extends Display {
     // Private
 
     _copySelection() {
-        this._invoke('selectionCopy');
+        this._invoke('copySelection');
     }
 
     _clearAutoPlayTimer() {
@@ -270,6 +270,6 @@ class DisplayFloat extends Display {
     }
 
     _invoke(action, params={}) {
-        window.parent.postMessage({action, params}, '*');
+        return api.crossFrame.invoke(this._ownerFrameId, action, params);
     }
 }

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -30,6 +30,7 @@ class DisplayFloat extends Display {
         this._secret = yomichan.generateId(16);
         this._token = null;
         this._nestedPopupsPrepared = false;
+        this._ownerFrameId = null;
         this._windowMessageHandlers = new Map([
             ['initialize',         {handler: this._onMessageInitialize.bind(this), authenticate: false}],
             ['configure',          {handler: this._onMessageConfigure.bind(this)}],
@@ -134,7 +135,8 @@ class DisplayFloat extends Display {
         this._initialize(params);
     }
 
-    async _onMessageConfigure({messageId, frameId, popupId, optionsContext, childrenSupported, scale}) {
+    async _onMessageConfigure({messageId, frameId, ownerFrameId, popupId, optionsContext, childrenSupported, scale}) {
+        this._ownerFrameId = ownerFrameId;
         this.setOptionsContext(optionsContext);
 
         await this.updateOptions();

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -61,7 +61,7 @@ class DisplayFloat extends Display {
     }
 
     onEscape() {
-        window.parent.postMessage('popupClose', '*');
+        this._invoke('popupClose');
     }
 
     async setOptionsContext(optionsContext) {
@@ -175,7 +175,7 @@ class DisplayFloat extends Display {
     // Private
 
     _copySelection() {
-        window.parent.postMessage('selectionCopy', '*');
+        this._invoke('selectionCopy');
     }
 
     _clearAutoPlayTimer() {
@@ -267,5 +267,9 @@ class DisplayFloat extends Display {
             }
         );
         await frontend.prepare();
+    }
+
+    _invoke(action, params={}) {
+        window.parent.postMessage({action, params}, '*');
     }
 }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -307,7 +307,7 @@ class Frontend {
     }
 
     async _getDefaultPopup() {
-        return this._popupFactory.getOrCreatePopup(null, null, this._depth);
+        return this._popupFactory.getOrCreatePopup({depth: this._depth});
     }
 
     async _getProxyPopup() {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -212,11 +212,14 @@ class Frontend {
     }
 
     _onWindowMessage(e) {
-        const action = e.data;
+        const data = e.data;
+        if (!isObject(data)) { return; }
+
+        const {action, params} = data;
         const handler = this._windowMessageHandlers.get(action);
         if (typeof handler !== 'function') { return false; }
 
-        handler();
+        handler(params);
     }
 
     _onRuntimeMessage({action, params}, sender, callback) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -105,6 +105,7 @@ class Frontend {
 
         yomichan.on('optionsUpdated', this.updateOptions.bind(this));
         yomichan.on('zoomChanged', this._onZoomChanged.bind(this));
+        yomichan.on('closePopups', this._onApiClosePopup.bind(this));
         chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
 
         this._textScanner.on('clearSelection', this._onClearSelection.bind(this));

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -307,11 +307,11 @@ class Frontend {
     }
 
     async _getDefaultPopup() {
-        return this._popupFactory.getOrCreatePopup({depth: this._depth});
+        return this._popupFactory.getOrCreatePopup({depth: this._depth, ownerFrameId: this._frameId});
     }
 
     async _getProxyPopup() {
-        const popup = new PopupProxy(null, this._depth + 1, this._proxyPopupId, this._parentFrameId);
+        const popup = new PopupProxy(null, this._depth + 1, this._proxyPopupId, this._parentFrameId, this._frameId);
         await popup.prepare();
         return popup;
     }
@@ -328,7 +328,7 @@ class Frontend {
         api.broadcastTab('rootPopupRequestInformationBroadcast');
         const {popupId, frameId: parentFrameId} = await rootPopupInformationPromise;
 
-        const popup = new PopupProxy(popupId, 0, null, parentFrameId, this._frameOffsetForwarder);
+        const popup = new PopupProxy(popupId, 0, null, parentFrameId, this._frameId, this._frameOffsetForwarder);
         popup.on('offsetNotFound', () => {
             this._allowRootFramePopupProxy = false;
             this._updatePopup();

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -43,7 +43,7 @@ class PopupFactory {
         ]);
     }
 
-    getOrCreatePopup({id=null, parentId=null, depth=null}) {
+    getOrCreatePopup({id=null, parentId=null, ownerFrameId=null, depth=null}) {
         // Find by existing id
         if (id !== null) {
             const popup = this._popups.get(id);
@@ -80,7 +80,7 @@ class PopupFactory {
         } else if (depth === null) {
             depth = 0;
         }
-        const popup = new Popup(id, depth, this._frameId);
+        const popup = new Popup(id, depth, this._frameId, ownerFrameId);
         if (parent !== null) {
             popup.setParent(parent);
         }
@@ -91,8 +91,8 @@ class PopupFactory {
 
     // API message handlers
 
-    _onApiGetOrCreatePopup({id, parentId}) {
-        const popup = this.getOrCreatePopup({id, parentId});
+    _onApiGetOrCreatePopup({id, parentId, ownerFrameId}) {
+        const popup = this.getOrCreatePopup({id, parentId, ownerFrameId});
         return {
             id: popup.id
         };

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -43,7 +43,7 @@ class PopupFactory {
         ]);
     }
 
-    getOrCreatePopup(id=null, parentId=null, depth=null) {
+    getOrCreatePopup({id=null, parentId=null, depth=null}) {
         // Find by existing id
         if (id !== null) {
             const popup = this._popups.get(id);
@@ -92,7 +92,7 @@ class PopupFactory {
     // API message handlers
 
     _onApiGetOrCreatePopup({id, parentId}) {
-        const popup = this.getOrCreatePopup(id, parentId);
+        const popup = this.getOrCreatePopup({id, parentId});
         return {
             id: popup.id
         };

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -20,12 +20,13 @@
  */
 
 class PopupProxy extends EventDispatcher {
-    constructor(id, depth, parentPopupId, parentFrameId, frameOffsetForwarder=null) {
+    constructor(id, depth, parentPopupId, parentFrameId, ownerFrameId, frameOffsetForwarder=null) {
         super();
         this._id = id;
         this._depth = depth;
         this._parentPopupId = parentPopupId;
         this._parentFrameId = parentFrameId;
+        this._ownerFrameId = ownerFrameId;
         this._frameOffsetForwarder = frameOffsetForwarder;
 
         this._frameOffset = null;
@@ -51,7 +52,7 @@ class PopupProxy extends EventDispatcher {
     // Public functions
 
     async prepare() {
-        const {id} = await this._invoke('getOrCreatePopup', {id: this._id, parentId: this._parentPopupId});
+        const {id} = await this._invoke('getOrCreatePopup', {id: this._id, parentId: this._parentPopupId, ownerFrameId: this._ownerFrameId});
         this._id = id;
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -22,10 +22,11 @@
  */
 
 class Popup {
-    constructor(id, depth, frameId) {
+    constructor(id, depth, frameId, ownerFrameId) {
         this._id = id;
         this._depth = depth;
         this._frameId = frameId;
+        this._ownerFrameId = ownerFrameId;
         this._parent = null;
         this._child = null;
         this._childrenSupported = true;
@@ -382,6 +383,7 @@ class Popup {
         this._invokeApi('configure', {
             messageId,
             frameId: this._frameId,
+            ownerFrameId: this._ownerFrameId,
             popupId: this._id,
             optionsContext: this._optionsContext,
             childrenSupported: this._childrenSupported,


### PR DESCRIPTION
* Added "owner" frame ID to `Popup`/`PopupProxy`/`DisplayFloat`.
* Updated `DisplayFloat`'s host frame action invocation to use `CrossFrameAPI`.

This fixes an issue where a few messages sent by Yomichan (`'popupClose'`, `'selectionCopy'`) would be visible to the underlying page (originally mentioned in https://github.com/FooSoft/yomichan/issues/353#issuecomment-587065276). This also fixes an issue where pressing the ESC button will close all popups instead of only the most recent, and the same issue for CTRL+C.