### PR TITLE
Refactor hotkey definitions to be more generic

### DIFF
--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -40,14 +40,11 @@ class DisplayFloat extends Display {
             ['setContentScale',    {handler: this._onMessageSetContentScale.bind(this)}]
         ]);
 
-        this.setOnKeyDownHandlers([
-            ['C', (e) => {
-                if (e.ctrlKey && !window.getSelection().toString()) {
-                    this._copySelection();
-                    return true;
-                }
-                return false;
-            }]
+        this.registerActions([
+            ['copy-host-selection', () => this._copySelection()]
+        ]);
+        this.registerHotkeys([
+            {key: 'C', modifiers: ['ctrl'], action: 'copy-host-selection'}
         ]);
     }
 
@@ -168,7 +165,9 @@ class DisplayFloat extends Display {
     // Private
 
     _copySelection() {
+        if (window.getSelection().toString()) { return false; }
         this._invoke('copySelection');
+        return true;
     }
 
     _clearAutoPlayTimer() {


### PR DESCRIPTION
This change converts the key handler map into two different maps.
* The first map is a mapping of `actionName: string => actionHandler: function`, which allows actions to be referenced using a string name.
* The second is a mapping of `key: string => {modifiers: Set, action: string}`, which maps the key/modifier combinations to the action it should perform when pressed.

This separation lays the groundwork for future support for customizable keyboard shortcuts, which will help to solve #653.