### PR TITLE
Various updates to FrameOffsetForwarder

### DIFF
--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -25,13 +25,6 @@ class FrameOffsetForwarder {
         this._cacheMaxSize = 1000;
         this._frameCache = new Set();
         this._unreachableContentWindowCache = new Set();
-
-        this._forwardFrameOffset = (
-            window !== window.parent ?
-            this._forwardFrameOffsetParent.bind(this) :
-            this._forwardFrameOffsetOrigin.bind(this)
-        );
-
         this._windowMessageHandlers = new Map([
             ['getFrameOffset', ({offset, uniqueId}, e) => this._onGetFrameOffset(offset, uniqueId, e)]
         ]);
@@ -100,7 +93,11 @@ class FrameOffsetForwarder {
         const {x, y} = sourceFrame.getBoundingClientRect();
         offset = [forwardedX + x, forwardedY + y];
 
-        this._forwardFrameOffset(offset, uniqueId);
+        if (window === window.parent) {
+            this._forwardFrameOffsetOrigin(offset, uniqueId);
+        } else {
+            this._forwardFrameOffsetParent(offset, uniqueId);
+        }
     }
 
     _findFrameWithContentWindow(contentWindow) {

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -37,6 +37,10 @@ class FrameOffsetForwarder {
     }
 
     async getOffset() {
+        if (window === window.parent) {
+            return [0, 0];
+        }
+
         const uniqueId = yomichan.generateId(16);
 
         const frameOffsetPromise = yomichan.getTemporaryListenerResult(

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -26,7 +26,7 @@ class FrameOffsetForwarder {
         this._frameCache = new Set();
         this._unreachableContentWindowCache = new Set();
         this._windowMessageHandlers = new Map([
-            ['getFrameOffset', ({offset, uniqueId}, e) => this._onGetFrameOffset(offset, uniqueId, e)]
+            ['getFrameOffset', this._onMessageGetFrameOffset.bind(this)]
         ]);
     }
 
@@ -75,7 +75,7 @@ class FrameOffsetForwarder {
         }
     }
 
-    _onGetFrameOffset(offset, uniqueId, e) {
+    _onMessageGetFrameOffset({offset, uniqueId}, e) {
         let sourceFrame = null;
         if (!this._unreachableContentWindowCache.has(e.source)) {
             sourceFrame = this._findFrameWithContentWindow(e.source);

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -149,7 +149,7 @@ class FrameOffsetForwarder {
         }
         yield frameCache;
         // will contain duplicates, but frame elements are cheap to handle
-        yield [...document.querySelectorAll('frame, iframe:not(.yomichan-float)')];
+        yield [...document.querySelectorAll('frame,iframe')];
         yield [document.documentElement];
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -56,7 +56,7 @@ class Frontend {
         this._isSearchPage = isSearchPage;
         this._depth = depth;
         this._frameId = frameId;
-        this._frameOffsetForwarder = new FrameOffsetForwarder();
+        this._frameOffsetForwarder = new FrameOffsetForwarder(frameId);
         this._popupFactory = popupFactory;
         this._allowRootFramePopupProxy = allowRootFramePopupProxy;
         this._popupCache = new Map();


### PR DESCRIPTION
* Faster exit if used on the root window.
* Updated iframe selector since the default Yomichan iframe is now embedded in a shadow DOM.
* Function reuse for a `postMessage` call.
* Reply message is only sent to a single frame instead of broadcast to every frame in the tab.