### PR TITLE
Popup crossFrame communication

### DIFF
--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -32,12 +32,12 @@ class DisplayFloat extends Display {
         this._ownerFrameId = null;
         this._frameEndpoint = new FrameEndpoint();
         this._windowMessageHandlers = new Map([
-            ['configure',          {handler: this._onMessageConfigure.bind(this)}],
-            ['setOptionsContext',  {handler: this._onMessageSetOptionsContext.bind(this)}],
-            ['setContent',         {handler: this._onMessageSetContent.bind(this)}],
-            ['clearAutoPlayTimer', {handler: this._onMessageClearAutoPlayTimer.bind(this)}],
-            ['setCustomCss',       {handler: this._onMessageSetCustomCss.bind(this)}],
-            ['setContentScale',    {handler: this._onMessageSetContentScale.bind(this)}]
+            ['configure',          {async: true,  handler: this._onMessageConfigure.bind(this)}],
+            ['setOptionsContext',  {async: false, handler: this._onMessageSetOptionsContext.bind(this)}],
+            ['setContent',         {async: false, handler: this._onMessageSetContent.bind(this)}],
+            ['clearAutoPlayTimer', {async: false, handler: this._onMessageClearAutoPlayTimer.bind(this)}],
+            ['setCustomCss',       {async: false, handler: this._onMessageSetCustomCss.bind(this)}],
+            ['setContentScale',    {async: false, handler: this._onMessageSetContentScale.bind(this)}]
         ]);
 
         this.registerActions([
@@ -112,9 +112,9 @@ class DisplayFloat extends Display {
             throw new Error(`Invalid action: ${action}`);
         }
 
-        const handler = handlerInfo.handler;
+        const {async, handler} = handlerInfo;
         const result = handler(params);
-        return {async: false, result};
+        return {async, result};
     }
 
     async _onMessageConfigure({messageId, frameId, ownerFrameId, popupId, optionsContext, childrenSupported, scale}) {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -117,7 +117,7 @@ class DisplayFloat extends Display {
         return {async, result};
     }
 
-    async _onMessageConfigure({messageId, frameId, ownerFrameId, popupId, optionsContext, childrenSupported, scale}) {
+    async _onMessageConfigure({frameId, ownerFrameId, popupId, optionsContext, childrenSupported, scale}) {
         this._ownerFrameId = ownerFrameId;
         this.setOptionsContext(optionsContext);
 
@@ -130,8 +130,6 @@ class DisplayFloat extends Display {
         }
 
         this._setContentScale(scale);
-
-        api.sendMessageToFrame(frameId, 'popupConfigured', {messageId});
     }
 
     _onMessageSetOptionsContext({optionsContext}) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -456,12 +456,12 @@ class Popup {
         return dark ? 'dark' : 'light';
     }
 
-    _invokeApi(action, params={}) {
+    async _invokeApi(action, params={}) {
         const contentWindow = this._frame.contentWindow;
         if (this._frameClient === null || !this._frameClient.isConnected() || contentWindow === null) { return; }
 
         const message = this._frameClient.createMessage({action, params});
-        api.crossFrame.invoke(this._frameClient.frameId, 'popupMessage', message);
+        return await api.crossFrame.invoke(this._frameClient.frameId, 'popupMessage', message);
     }
 
     _getFrameParentElement() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -257,22 +257,7 @@ class Popup {
         await frameClient.connect(this._frame, this._targetOrigin, this._frameId, setupFrame);
 
         // Configure
-        const messageId = yomichan.generateId(16);
-        const popupPreparedPromise = yomichan.getTemporaryListenerResult(
-            chrome.runtime.onMessage,
-            (message, {resolve}) => {
-                if (
-                    isObject(message) &&
-                    message.action === 'popupConfigured' &&
-                    isObject(message.params) &&
-                    message.params.messageId === messageId
-                ) {
-                    resolve();
-                }
-            }
-        );
-        this._invokeApi('configure', {
-            messageId,
+        await this._invokeApi('configure', {
             frameId: this._frameId,
             ownerFrameId: this._ownerFrameId,
             popupId: this._id,
@@ -280,8 +265,6 @@ class Popup {
             childrenSupported: this._childrenSupported,
             scale: this._contentScale
         });
-
-        return popupPreparedPromise;
     }
 
     _onFrameLoad() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -461,7 +461,7 @@ class Popup {
         if (this._frameClient === null || !this._frameClient.isConnected() || contentWindow === null) { return; }
 
         const message = this._frameClient.createMessage({action, params});
-        contentWindow.postMessage(message, this._targetOrigin);
+        api.crossFrame.invoke(this._frameClient.frameId, 'popupMessage', message);
     }
 
     _getFrameParentElement() {


### PR DESCRIPTION
This change updates the `Popup` => `DisplayFloat` communication use the `api.crossFrame` mechanism instead. This provides an easier callback/return value mechanism for API calls. This results in `DisplayFloat` not listening to window messages, so third-party content won't be able to send messages that interfere.