### PR TITLE
Port name details

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -318,7 +318,7 @@ class Backend {
                 throw new Error('Port does not have an associated tab ID');
             }
             const senderFrameId = port.sender.frameId;
-            if (typeof tabId !== 'number') {
+            if (typeof senderFrameId !== 'number') {
                 throw new Error('Port does not have an associated frame ID');
             }
             const targetFrameId = details.targetFrameId;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -305,8 +305,13 @@ class Backend {
 
     _onConnect(port) {
         try {
-            const match = /^background-cross-frame-communication-port-(\d+)$/.exec(`${port.name}`);
-            if (match === null) { return; }
+            let details;
+            try {
+                details = JSON.parse(port.name);
+            } catch (e) {
+                return;
+            }
+            if (details.name !== 'background-cross-frame-communication-port') { return; }
 
             const tabId = (port.sender && port.sender.tab ? port.sender.tab.id : null);
             if (typeof tabId !== 'number') {
@@ -316,9 +321,13 @@ class Backend {
             if (typeof tabId !== 'number') {
                 throw new Error('Port does not have an associated frame ID');
             }
-            const targetFrameId = parseInt(match[1], 10);
+            const targetFrameId = details.targetFrameId;
 
-            let forwardPort = chrome.tabs.connect(tabId, {frameId: targetFrameId, name: `cross-frame-communication-port-${senderFrameId}`});
+            const details2 = {
+                name: 'cross-frame-communication-port',
+                sourceFrameId: senderFrameId
+            };
+            let forwardPort = chrome.tabs.connect(tabId, {frameId: targetFrameId, name: JSON.stringify(details2)});
 
             const cleanup = () => {
                 this._checkLastError(chrome.runtime.lastError);
@@ -720,9 +729,12 @@ class Backend {
 
         const frameId = sender.frameId;
         const id = yomichan.generateId(16);
-        const portName = `action-port-${id}`;
+        const details = {
+            name: 'action-port',
+            id
+        };
 
-        const port = chrome.tabs.connect(tabId, {name: portName, frameId});
+        const port = chrome.tabs.connect(tabId, {name: JSON.stringify(details), frameId});
         try {
             this._createActionListenerPort(port, sender, this._messageHandlersWithProgress);
         } catch (e) {
@@ -730,7 +742,7 @@ class Backend {
             throw e;
         }
 
-        return portName;
+        return details;
     }
 
     async _onApiImportDictionaryArchive({archiveContent, details}, sender, onProgress) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -321,13 +321,16 @@ class Backend {
             if (typeof senderFrameId !== 'number') {
                 throw new Error('Port does not have an associated frame ID');
             }
-            const targetFrameId = details.targetFrameId;
+            let {targetTabId, targetFrameId} = details;
+            if (typeof targetTabId !== 'number') {
+                targetTabId = tabId;
+            }
 
             const details2 = {
                 name: 'cross-frame-communication-port',
                 sourceFrameId: senderFrameId
             };
-            let forwardPort = chrome.tabs.connect(tabId, {frameId: targetFrameId, name: JSON.stringify(details2)});
+            let forwardPort = chrome.tabs.connect(targetTabId, {frameId: targetFrameId, name: JSON.stringify(details2)});
 
             const cleanup = () => {
                 this._checkLastError(chrome.runtime.lastError);

--- a/ext/mixed/js/comm.js
+++ b/ext/mixed/js/comm.js
@@ -216,8 +216,12 @@ class CrossFrameAPI {
         chrome.runtime.onConnect.addListener(this._onConnect.bind(this));
     }
 
-    async invoke(targetFrameId, action, params={}) {
-        const commPort = this._getOrCreateCommPort(null, targetFrameId);
+    invoke(targetFrameId, action, params={}) {
+        return this.invokeTab(null, targetFrameId, action, params);
+    }
+
+    async invokeTab(targetTabId, targetFrameId, action, params={}) {
+        const commPort = this._getOrCreateCommPort(targetTabId, targetFrameId);
         return await commPort.invoke(action, params, this._ackTimeout, this._responseTimeout);
     }
 


### PR DESCRIPTION
Use the port name as a JSON string to pass port usage details, rather than using a string that must be regex parsed. This is used to add support for cross-tab communication in content scripts by reusing the cross-frame communication system.