### PR TITLE
Content script ready checks

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1368,4 +1368,59 @@ class Backend {
             // Edge throws exception for no reason here.
         }
     }
+
+    _waitUntilTabFrameIsReady(tabId, frameId, timeout=null) {
+        return new Promise((resolve, reject) => {
+            let timer = null;
+            let onMessage = (message, sender) => {
+                if (
+                    !sender.tab ||
+                    sender.tab.id !== tabId ||
+                    sender.frameId !== frameId ||
+                    !isObject(message) ||
+                    message.action !== 'yomichanCoreReady'
+                ) {
+                    return;
+                }
+
+                cleanup();
+                resolve();
+            };
+            const cleanup = () => {
+                if (timer !== null) {
+                    clearTimeout(timer);
+                    timer = null;
+                }
+                if (onMessage !== null) {
+                    chrome.runtime.onMessage.removeListener(onMessage);
+                    onMessage = null;
+                }
+            };
+
+            chrome.runtime.onMessage.addListener(onMessage);
+
+            chrome.tabs.sendMessage(tabId, {action: 'isReady'}, {frameId}, (response) => {
+                const error = chrome.runtime.lastError;
+                if (error) { return; }
+
+                try {
+                    const value = yomichan.getMessageResponseResult(response);
+                    if (!value) { return; }
+
+                    cleanup();
+                    resolve();
+                } catch (e) {
+                    // NOP
+                }
+            });
+
+            if (timeout !== null) {
+                timer = setTimeout(() => {
+                    timer = null;
+                    cleanup();
+                    reject(new Error('Timeout'));
+                }, timeout);
+            }
+        });
+    }
 }

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -23,6 +23,7 @@
 (async () => {
     try {
         api.forwardLogsToBackend();
+        await yomichan.ready();
 
         const display = new DisplayFloat();
         await display.prepare();

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -95,7 +95,6 @@ class Display {
 
     async prepare() {
         this._setInteractive(true);
-        await yomichan.ready();
         await this._displayGenerator.prepare();
     }
 

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -48,12 +48,14 @@ const yomichan = (() => {
             }
 
             this._isExtensionUnloaded = false;
+            this._isReady = false;
 
             const {promise, resolve} = deferPromise();
             this._isBackendPreparedPromise = promise;
             this._isBackendPreparedPromiseResolve = resolve;
 
             this._messageHandlers = new Map([
+                ['isReady',         {async: false, handler: this._onMessageIsReady.bind(this)}],
                 ['backendPrepared', {async: false, handler: this._onMessageBackendPrepared.bind(this)}],
                 ['getUrl',          {async: false, handler: this._onMessageGetUrl.bind(this)}],
                 ['optionsUpdated',  {async: false, handler: this._onMessageOptionsUpdated.bind(this)}],
@@ -72,6 +74,7 @@ const yomichan = (() => {
         }
 
         ready() {
+            this._isReady = true;
             this.sendMessage({action: 'yomichanCoreReady'});
             return this._isBackendPreparedPromise;
         }
@@ -266,6 +269,10 @@ const yomichan = (() => {
             const messageHandler = this._messageHandlers.get(action);
             if (typeof messageHandler === 'undefined') { return false; }
             return this.invokeMessageHandler(messageHandler, params, callback, sender);
+        }
+
+        _onMessageIsReady() {
+            return this._isReady;
         }
 
         _onMessageBackendPrepared() {


### PR DESCRIPTION
* Moves `yomichan.ready()` check out of `Display` and into the entry point IIFE.
* Adds `_waitUntilTabFrameIsReady` to the backend.