### PR TITLE
Script ready state change

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -85,7 +85,7 @@ class Backend {
         this._logErrorLevel = null;
 
         this._messageHandlers = new Map([
-            ['yomichanCoreReady',            {async: false, contentScript: true,  handler: this._onApiYomichanCoreReady.bind(this)}],
+            ['requestBackendReadySignal',    {async: false, contentScript: true,  handler: this._onApiRequestBackendReadySignal.bind(this)}],
             ['optionsSchemaGet',             {async: false, contentScript: true,  handler: this._onApiOptionsSchemaGet.bind(this)}],
             ['optionsGet',                   {async: false, contentScript: true,  handler: this._onApiOptionsGet.bind(this)}],
             ['optionsGetFull',               {async: false, contentScript: true,  handler: this._onApiOptionsGetFull.bind(this)}],
@@ -212,9 +212,9 @@ class Backend {
 
             this._clipboardMonitor.on('change', this._onClipboardTextChange.bind(this));
 
-            this._sendMessageAllTabs('backendPrepared');
+            this._sendMessageAllTabs('backendReady');
             const callback = () => this._checkLastError(chrome.runtime.lastError);
-            chrome.runtime.sendMessage({action: 'backendPrepared'}, callback);
+            chrome.runtime.sendMessage({action: 'backendReady'}, callback);
         } catch (e) {
             yomichan.logError(e);
             throw e;
@@ -361,10 +361,10 @@ class Backend {
 
     // Message handlers
 
-    _onApiYomichanCoreReady(_params, sender) {
+    _onApiRequestBackendReadySignal(_params, sender) {
         // tab ID isn't set in background (e.g. browser_action)
         const callback = () => this._checkLastError(chrome.runtime.lastError);
-        const data = {action: 'backendPrepared'};
+        const data = {action: 'backendReady'};
         if (typeof sender.tab === 'undefined') {
             chrome.runtime.sendMessage(data, callback);
             return false;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1393,7 +1393,7 @@ class Backend {
                     sender.tab.id !== tabId ||
                     sender.frameId !== frameId ||
                     !isObject(message) ||
-                    message.action !== 'yomichanCoreReady'
+                    message.action !== 'yomichanReady'
                 ) {
                     return;
                 }

--- a/ext/bg/js/context-main.js
+++ b/ext/bg/js/context-main.js
@@ -76,7 +76,7 @@ async function setupOptions() {
 
 (async () => {
     api.forwardLogsToBackend();
-    await yomichan.ready();
+    await yomichan.backendReady();
 
     const manifest = chrome.runtime.getManifest();
 
@@ -87,4 +87,6 @@ async function setupOptions() {
     setupButtonEvents('.action-open-search', 'search', chrome.runtime.getURL('/bg/search.html'));
     setupButtonEvents('.action-open-options', 'options', chrome.runtime.getURL(manifest.options_ui.page));
     setupButtonEvents('.action-open-help', 'help', 'https://foosoft.net/projects/yomichan/');
+
+    yomichan.ready();
 })();

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -23,10 +23,12 @@
 (async () => {
     try {
         api.forwardLogsToBackend();
-        await yomichan.ready();
+        await yomichan.backendReady();
 
         const displaySearch = new DisplaySearch();
         await displaySearch.prepare();
+
+        yomichan.ready();
     } catch (e) {
         yomichan.logError(e);
     }

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -63,47 +63,51 @@ async function setupEnvironmentInfo() {
 
 
 (async () => {
-    api.forwardLogsToBackend();
-    await yomichan.backendReady();
+    try {
+        api.forwardLogsToBackend();
+        await yomichan.backendReady();
 
-    setupEnvironmentInfo();
-    showExtensionInformation();
-    settingsPopulateModifierKeys();
+        setupEnvironmentInfo();
+        showExtensionInformation();
+        settingsPopulateModifierKeys();
 
-    const optionsFull = await api.optionsGetFull();
+        const optionsFull = await api.optionsGetFull();
 
-    const settingsController = new SettingsController(optionsFull.profileCurrent);
-    settingsController.prepare();
+        const settingsController = new SettingsController(optionsFull.profileCurrent);
+        settingsController.prepare();
 
-    const storageController = new StorageController();
-    storageController.prepare();
+        const storageController = new StorageController();
+        storageController.prepare();
 
-    const genericSettingController = new GenericSettingController(settingsController);
-    genericSettingController.prepare();
+        const genericSettingController = new GenericSettingController(settingsController);
+        genericSettingController.prepare();
 
-    const clipboardPopupsController = new ClipboardPopupsController(settingsController);
-    clipboardPopupsController.prepare();
+        const clipboardPopupsController = new ClipboardPopupsController(settingsController);
+        clipboardPopupsController.prepare();
 
-    const popupPreviewController = new PopupPreviewController(settingsController);
-    popupPreviewController.prepare();
+        const popupPreviewController = new PopupPreviewController(settingsController);
+        popupPreviewController.prepare();
 
-    const audioController = new AudioController(settingsController);
-    audioController.prepare();
+        const audioController = new AudioController(settingsController);
+        audioController.prepare();
 
-    const profileController = new ProfileController(settingsController);
-    profileController.prepare();
+        const profileController = new ProfileController(settingsController);
+        profileController.prepare();
 
-    const dictionaryController = new DictionaryController(settingsController, storageController);
-    dictionaryController.prepare();
+        const dictionaryController = new DictionaryController(settingsController, storageController);
+        dictionaryController.prepare();
 
-    const ankiController = new AnkiController(settingsController);
-    ankiController.prepare();
+        const ankiController = new AnkiController(settingsController);
+        ankiController.prepare();
 
-    const ankiTemplatesController = new AnkiTemplatesController(settingsController, ankiController);
-    ankiTemplatesController.prepare();
+        const ankiTemplatesController = new AnkiTemplatesController(settingsController, ankiController);
+        ankiTemplatesController.prepare();
 
-    const settingsBackup = new SettingsBackup(settingsController);
-    settingsBackup.prepare();
+        const settingsBackup = new SettingsBackup(settingsController);
+        settingsBackup.prepare();
 
-    yomichan.ready();
+        yomichan.ready();
+    } catch (e) {
+        yomichan.logError(e);
+    }
 })();

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -64,7 +64,7 @@ async function setupEnvironmentInfo() {
 
 (async () => {
     api.forwardLogsToBackend();
-    await yomichan.ready();
+    await yomichan.backendReady();
 
     setupEnvironmentInfo();
     showExtensionInformation();
@@ -104,4 +104,6 @@ async function setupEnvironmentInfo() {
 
     const settingsBackup = new SettingsBackup(settingsController);
     settingsBackup.prepare();
+
+    yomichan.ready();
 })();

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -24,7 +24,7 @@
 (async () => {
     try {
         api.forwardLogsToBackend();
-        await yomichan.ready();
+        await yomichan.backendReady();
 
         const {frameId} = await api.frameInformationGet();
         if (typeof frameId !== 'number') {
@@ -40,6 +40,8 @@
             {}
         );
         await frontend.prepare();
+
+        yomichan.ready();
     } catch (e) {
         yomichan.logError(e);
     }

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -23,10 +23,12 @@
 (async () => {
     try {
         api.forwardLogsToBackend();
-        await yomichan.ready();
+        await yomichan.backendReady();
 
         const display = new DisplayFloat();
         await display.prepare();
+
+        yomichan.ready();
     } catch (e) {
         yomichan.logError(e);
     }

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -51,15 +51,15 @@ const yomichan = (() => {
             this._isReady = false;
 
             const {promise, resolve} = deferPromise();
-            this._isBackendPreparedPromise = promise;
-            this._isBackendPreparedPromiseResolve = resolve;
+            this._isBackendReadyPromise = promise;
+            this._isBackendReadyPromiseResolve = resolve;
 
             this._messageHandlers = new Map([
-                ['isReady',         {async: false, handler: this._onMessageIsReady.bind(this)}],
-                ['backendPrepared', {async: false, handler: this._onMessageBackendPrepared.bind(this)}],
-                ['getUrl',          {async: false, handler: this._onMessageGetUrl.bind(this)}],
-                ['optionsUpdated',  {async: false, handler: this._onMessageOptionsUpdated.bind(this)}],
-                ['zoomChanged',     {async: false, handler: this._onMessageZoomChanged.bind(this)}]
+                ['isReady',        {async: false, handler: this._onMessageIsReady.bind(this)}],
+                ['backendReady',   {async: false, handler: this._onMessageBackendReady.bind(this)}],
+                ['getUrl',         {async: false, handler: this._onMessageGetUrl.bind(this)}],
+                ['optionsUpdated', {async: false, handler: this._onMessageOptionsUpdated.bind(this)}],
+                ['zoomChanged',    {async: false, handler: this._onMessageZoomChanged.bind(this)}]
             ]);
         }
 
@@ -73,10 +73,14 @@ const yomichan = (() => {
             chrome.runtime.onMessage.addListener(this._onMessage.bind(this));
         }
 
+        backendReady() {
+            this.sendMessage({action: 'requestBackendReadySignal'});
+            return this._isBackendReadyPromise;
+        }
+
         ready() {
             this._isReady = true;
-            this.sendMessage({action: 'yomichanCoreReady'});
-            return this._isBackendPreparedPromise;
+            this.sendMessage({action: 'yomichanReady'});
         }
 
         generateId(length) {
@@ -275,10 +279,10 @@ const yomichan = (() => {
             return this._isReady;
         }
 
-        _onMessageBackendPrepared() {
-            if (this._isBackendPreparedPromiseResolve === null) { return; }
-            this._isBackendPreparedPromiseResolve();
-            this._isBackendPreparedPromiseResolve = null;
+        _onMessageBackendReady() {
+            if (this._isBackendReadyPromiseResolve === null) { return; }
+            this._isBackendReadyPromiseResolve();
+            this._isBackendReadyPromiseResolve = null;
         }
 
         _onMessageGetUrl() {


### PR DESCRIPTION
* `yomichan.ready` is now `yomichan.backendReady`, which now only waits for the backend to be ready, but does not signal that the frontend is ready.
* `yomichan.ready` is now used to signal that the frontend is ready, which should include web extension event listeners.