### PR TITLE
Force targetTabId to be null if not a number

### DIFF
--- a/ext/mixed/js/comm.js
+++ b/ext/mixed/js/comm.js
@@ -221,6 +221,7 @@ class CrossFrameAPI {
     }
 
     async invokeTab(targetTabId, targetFrameId, action, params={}) {
+        if (typeof targetTabId !== 'number') { targetTabId = null; }
         const commPort = this._getOrCreateCommPort(targetTabId, targetFrameId);
         return await commPort.invoke(action, params, this._ackTimeout, this._responseTimeout);
     }


### PR DESCRIPTION
Prevents a developer issue where if `undefined` is passed, it will forward to the current tab.