### PR TITLE
Simplify Popup.showContent API to use only two details arguments

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -432,13 +432,17 @@ class Frontend {
     }
 
     _showPopupContent(textSource, optionsContext, type=null, details=null) {
-        const context = {optionsContext, source: this._id};
         this._lastShowPromise = this._popup.showContent(
-            textSource.getRect(),
-            textSource.getWritingMode(),
-            type,
-            details,
-            context
+            {
+                source: this._id,
+                optionsContext,
+                elementRect: textSource.getRect(),
+                writingMode: textSource.getWritingMode()
+            },
+            {
+                type,
+                details
+            }
         );
         this._lastShowPromise.catch((error) => {
             if (yomichan.isExtensionUnloaded) { return; }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -124,11 +124,16 @@ class PopupFactory {
         return await popup.containsPoint(x, y);
     }
 
-    async _onApiShowContent({id, elementRect, writingMode, type, details, context}) {
+    async _onApiShowContent({id, details, displayDetails}) {
         const popup = this._getPopup(id);
-        elementRect = this._convertJsonRectToDOMRect(popup, elementRect);
         if (!this._popupCanShow(popup)) { return; }
-        return await popup.showContent(elementRect, writingMode, type, details, context);
+
+        const {elementRect} = details;
+        if (typeof elementRect !== 'undefined') {
+            details.elementRect = this._convertJsonRectToDOMRect(popup, elementRect);
+        }
+
+        return await popup.showContent(details, displayDetails);
     }
 
     _onApiSetCustomCss({id, css}) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -88,14 +88,17 @@ class PopupProxy extends EventDispatcher {
         return await this._invoke('containsPoint', {id: this._id, x, y});
     }
 
-    async showContent(elementRect, writingMode, type, details, context) {
-        let {x, y, width, height} = elementRect;
-        if (this._frameOffsetForwarder !== null) {
-            await this._updateFrameOffset();
-            [x, y] = this._applyFrameOffset(x, y);
+    async showContent(details, displayDetails) {
+        const {elementRect} = details;
+        if (typeof elementRect !== 'undefined') {
+            let {x, y, width, height} = elementRect;
+            if (this._frameOffsetForwarder !== null) {
+                await this._updateFrameOffset();
+                [x, y] = this._applyFrameOffset(x, y);
+            }
+            details.elementRect = {x, y, width, height};
         }
-        elementRect = {x, y, width, height};
-        return await this._invoke('showContent', {id: this._id, elementRect, writingMode, type, details, context});
+        return await this._invoke('showContent', {id: this._id, details, displayDetails});
     }
 
     setCustomCss(css) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -133,17 +133,21 @@ class Popup {
         return false;
     }
 
-    async showContent(elementRect, writingMode, type, details, context) {
+    async showContent(details, displayDetails) {
         if (this._options === null) { throw new Error('Options not assigned'); }
 
-        const {optionsContext, source} = context;
-        if (source !== this._previousOptionsContextSource) {
+        const {source, optionsContext, elementRect, writingMode} = details;
+        if (typeof source !== 'undefined' && source !== this._previousOptionsContextSource) {
             await this.setOptionsContext(optionsContext, source);
         }
 
-        await this._show(elementRect, writingMode);
-        if (type === null) { return; }
-        this._invokeApi('setContent', {type, details});
+        if (typeof elementRect !== 'undefined' && typeof writingMode !== 'undefined') {
+            await this._show(elementRect, writingMode);
+        }
+
+        if (displayDetails !== null) {
+            this._invokeApi('setContent', {type: displayDetails.type, details: displayDetails.details});
+        }
     }
 
     setCustomCss(css) {


### PR DESCRIPTION
`Popup*.showContent` API is refactored to only take two arguments: one which is only `Popup` uses (for external layout and styling), and one which only `Display` uses (for content assignment). This is part of a goal to simplify and standardize the data structure passed to `showContent` and `setContent` functions.