### PR TITLE
Fix search popup mode

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -932,7 +932,7 @@ class Backend {
         const popupWindow = await new Promise((resolve, reject) => {
             chrome.windows.create(
                 {
-                    url: baseUrl,
+                    url: `${baseUrl}?mode=popup`,
                     width: popupWidth,
                     height: popupHeight,
                     type: 'popup'

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -213,8 +213,7 @@ class DisplaySearch extends Display {
     }
 
     _onPopState() {
-        const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
-        document.documentElement.dataset.searchMode = mode;
+        const {queryParams: {query=''}} = parseUrl(window.location.href);
         this._setQuery(query);
         this._onSearchQueryUpdated(this._query.value, false);
     }


### PR DESCRIPTION
`mode` search parameter was removed in a previous commit, slightly changing behaviour.