### PR TITLE
Query parser fix

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -189,12 +189,13 @@ class DisplaySearch extends Display {
     }
 
     _onQueryParserSearch({type, definitions, sentence, cause, textSource}) {
-        this.setContent({
+        const query = textSource.text();
+        const details = {
             focus: false,
             history: cause !== 'mouse',
             params: {
                 type,
-                query: textSource.text(),
+                query,
                 wildcards: 'off'
             },
             state: {
@@ -204,7 +205,8 @@ class DisplaySearch extends Display {
             content: {
                 definitions
             }
-        });
+        };
+        this.setContent(details);
     }
 
     _onSearchInput() {
@@ -243,7 +245,7 @@ class DisplaySearch extends Display {
     }
 
     _onSearchQueryUpdated(query, animate) {
-        this.setContent({
+        const details = {
             focus: false,
             history: false,
             params: {
@@ -258,7 +260,8 @@ class DisplaySearch extends Display {
                 definitions: null,
                 animate
             }
-        });
+        };
+        this.setContent(details);
     }
 
     _onWanakanaEnableChange(e) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -19,7 +19,6 @@
  * ClipboardMonitor
  * DOM
  * Display
- * QueryParser
  * api
  * wanakana
  */
@@ -33,15 +32,10 @@ class DisplaySearch extends Display {
         this._intro = document.querySelector('#intro');
         this._clipboardMonitorEnable = document.querySelector('#clipboard-monitor-enable');
         this._wanakanaEnable = document.querySelector('#wanakana-enable');
-        this._fullQuery = '';
         this._introVisible = true;
         this._introAnimationTimer = null;
         this._clipboardMonitor = new ClipboardMonitor({
             getClipboard: api.clipboardGet.bind(api)
-        });
-        this._queryParser = new QueryParser({
-            getOptionsContext: this.getOptionsContext.bind(this),
-            setSpinnerVisible: this.setSpinnerVisible.bind(this)
         });
         this._onKeyDownIgnoreKeys = new Map([
             ['ANY_MOD', new Set([
@@ -66,9 +60,7 @@ class DisplaySearch extends Display {
         await super.prepare();
         await this.updateOptions();
         yomichan.on('optionsUpdated', () => this.updateOptions());
-        await this._queryParser.prepare();
 
-        this._queryParser.on('searched', this._onQueryParserSearch.bind(this));
         this.on('contentUpdating', this._onContentUpdating.bind(this));
 
         this.setHistorySettings({useBrowserHistory: true});
@@ -152,8 +144,6 @@ class DisplaySearch extends Display {
 
     async updateOptions() {
         await super.updateOptions();
-        const options = this.getOptions();
-        this._queryParser.setOptions(options);
         if (!this._isPrepared) { return; }
         const query = this._query.value;
         if (query) {
@@ -186,27 +176,6 @@ class DisplaySearch extends Display {
         this._setIntroVisible(!valid, animate);
         this._setTitleText(source);
         this._updateSearchButton();
-    }
-
-    _onQueryParserSearch({type, definitions, sentence, cause, textSource}) {
-        const query = textSource.text();
-        const details = {
-            focus: false,
-            history: cause !== 'mouse',
-            params: {
-                type,
-                query,
-                wildcards: 'off'
-            },
-            state: {
-                sentence,
-                url: window.location.href
-            },
-            content: {
-                definitions
-            }
-        };
-        this.setContent(details);
     }
 
     _onSearchInput() {
@@ -324,10 +293,8 @@ class DisplaySearch extends Display {
                 // NOP
             }
         }
-        if (this._fullQuery === interpretedQuery) { return; }
-        this._fullQuery = interpretedQuery;
         this._query.value = interpretedQuery;
-        this._queryParser.setText(interpretedQuery);
+        this.setQueryParserText(interpretedQuery);
     }
 
     _setIntroVisible(visible, animate) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -154,7 +154,7 @@ class DisplaySearch extends Display {
 
     // Private
 
-    _onContentUpdating({type, source, content}) {
+    _onContentUpdating({type, source, content, urlSearchParams}) {
         let animate = false;
         let valid = false;
         switch (type) {
@@ -170,9 +170,14 @@ class DisplaySearch extends Display {
                 source = '';
                 break;
         }
+
         if (typeof source !== 'string') { source = ''; }
+
+        let full = urlSearchParams.get('full');
+        if (full === null) { full = source; }
+
         this._closePopups();
-        this._setQuery(source);
+        this._setQuery(full);
         this._setIntroVisible(!valid, animate);
         this._setTitleText(source);
         this._updateSearchButton();

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -33,7 +33,7 @@ class DisplaySearch extends Display {
         this._intro = document.querySelector('#intro');
         this._clipboardMonitorEnable = document.querySelector('#clipboard-monitor-enable');
         this._wanakanaEnable = document.querySelector('#wanakana-enable');
-        this._queryText = '';
+        this._fullQuery = '';
         this._introVisible = true;
         this._introAnimationTimer = null;
         this._clipboardMonitor = new ClipboardMonitor({
@@ -324,8 +324,8 @@ class DisplaySearch extends Display {
                 // NOP
             }
         }
-        if (this._queryText === interpretedQuery) { return; }
-        this._queryText = interpretedQuery;
+        if (this._fullQuery === interpretedQuery) { return; }
+        this._fullQuery = interpretedQuery;
         this._query.value = interpretedQuery;
         this._queryParser.setText(interpretedQuery);
     }

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -21,6 +21,11 @@
             <button class="action-button action-next" data-icon="source-term" title="Next term (Alt + F)"></button>
         </div></div><div class="navigation-header-spacer"></div>
 
+        <div class="scan-disable" hidden>
+            <div id="query-parser-select-container" class="input-group"></div>
+            <div id="query-parser-content"></div>
+        </div>
+
         <div id="definitions"></div>
 
         <div id="no-results" hidden>
@@ -57,8 +62,11 @@
         <script src="/mixed/js/frame-endpoint.js"></script>
         <script src="/mixed/js/media-loader.js"></script>
         <script src="/mixed/js/scroll.js"></script>
+        <script src="/mixed/js/text-scanner.js"></script>
         <script src="/mixed/js/template-handler.js"></script>
 
+        <script src="/bg/js/query-parser-generator.js"></script>
+        <script src="/bg/js/query-parser.js"></script>
         <script src="/fg/js/float.js"></script>
 
         <script src="/fg/js/float-main.js"></script>

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1166,7 +1166,11 @@ class Display extends EventDispatcher {
     }
 
     _createSearchParams(type, query, wildcards) {
-        const params = {query};
+        const params = {};
+        if (query.length < this._fullQuery.length) {
+            params.full = this._fullQuery;
+        }
+        params.query = query;
         if (typeof type === 'string') {
             params.type = type;
         }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -428,13 +428,14 @@ class Display extends EventDispatcher {
     }
 
     _onExtensionUnloaded() {
-        this.setContent({
+        const details = {
             focus: false,
             history: false,
             params: {type: 'unloaded'},
             state: {},
             content: {}
-        });
+        };
+        this.setContent(details);
     }
 
     _onSourceTermView(e) {
@@ -462,7 +463,7 @@ class Display extends EventDispatcher {
 
             const query = link.textContent;
             const definitions = await api.kanjiFind(query, this.getOptionsContext());
-            this.setContent({
+            const details = {
                 focus: false,
                 history: true,
                 params: {
@@ -478,7 +479,8 @@ class Display extends EventDispatcher {
                 content: {
                     definitions
                 }
-            });
+            };
+            this.setContent(details);
         } catch (error) {
             this.onError(error);
         }
@@ -520,12 +522,13 @@ class Display extends EventDispatcher {
             state.scrollY = this._windowScroll.y;
             this._historyStateUpdate(state);
 
-            this.setContent({
+            const query = textSource.text();
+            const details = {
                 focus: false,
                 history: true,
                 params: {
                     type: 'terms',
-                    query: textSource.text(),
+                    query,
                     wildcards: 'off'
                 },
                 state: {
@@ -536,7 +539,8 @@ class Display extends EventDispatcher {
                 content: {
                     definitions
                 }
-            });
+            };
+            this.setContent(details);
         } catch (error) {
             this.onError(error);
         }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -23,6 +23,7 @@
  * Frontend
  * MediaLoader
  * PopupFactory
+ * QueryParser
  * WindowScroll
  * api
  * docRangeFromPoint
@@ -68,6 +69,11 @@ class Display extends EventDispatcher {
         this._historyChangeIgnore = false;
         this._historyHasChanged = false;
         this._navigationHeader = document.querySelector('#navigation-header');
+        this._fullQuery = '';
+        this._queryParser = new QueryParser({
+            getOptionsContext: this.getOptionsContext.bind(this),
+            setSpinnerVisible: this.setSpinnerVisible.bind(this)
+        });
 
         this.registerActions([
             ['close',               () => { this.onEscape(); }],
@@ -120,8 +126,10 @@ class Display extends EventDispatcher {
     async prepare() {
         this._setInteractive(true);
         await this._displayGenerator.prepare();
+        await this._queryParser.prepare();
         this._history.prepare();
         this._history.on('stateChanged', this._onStateChanged.bind(this));
+        this._queryParser.on('searched', this._onQueryParserSearch.bind(this));
         yomichan.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
         api.crossFrame.registerHandlers([
             ['popupMessage', {async: 'dynamic', handler: this._onMessage.bind(this)}]
@@ -188,6 +196,7 @@ class Display extends EventDispatcher {
         this._updateDocumentOptions(this._options);
         this._updateTheme(this._options.general.popupTheme);
         this.setCustomCss(this._options.general.customPopupCss);
+        this._queryParser.setOptions(this._options);
     }
 
     addMultipleEventListeners(selector, type, listener, options) {
@@ -313,6 +322,12 @@ class Display extends EventDispatcher {
         return data;
     }
 
+    setQueryParserText(text) {
+        if (this._fullQuery === text) { return; }
+        this._fullQuery = text;
+        this._queryParser.setText(text);
+    }
+
     // Message handlers
 
     _onMessage(data) {
@@ -425,6 +440,27 @@ class Display extends EventDispatcher {
                 this._setContentToken = null;
             }
         }
+    }
+
+    _onQueryParserSearch({type, definitions, sentence, cause, textSource}) {
+        const query = textSource.text();
+        const details = {
+            focus: false,
+            history: cause !== 'mouse',
+            params: {
+                type,
+                query,
+                wildcards: 'off'
+            },
+            state: {
+                sentence,
+                url: window.location.href
+            },
+            content: {
+                definitions
+            }
+        };
+        this.setContent(details);
     }
 
     _onExtensionUnloaded() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -447,11 +447,7 @@ class Display extends EventDispatcher {
         const details = {
             focus: false,
             history: cause !== 'mouse',
-            params: {
-                type,
-                query,
-                wildcards: 'off'
-            },
+            params: this._createSearchParams(type, query, false),
             state: {
                 sentence,
                 url: window.location.href
@@ -502,11 +498,7 @@ class Display extends EventDispatcher {
             const details = {
                 focus: false,
                 history: true,
-                params: {
-                    type: 'kanji',
-                    query,
-                    wildcards: 'off'
-                },
+                params: this._createSearchParams('kanji', query, false),
                 state: {
                     focusEntry: 0,
                     sentence: state.sentence,
@@ -562,11 +554,7 @@ class Display extends EventDispatcher {
             const details = {
                 focus: false,
                 history: true,
-                params: {
-                    type: 'terms',
-                    query,
-                    wildcards: 'off'
-                },
+                params: this._createSearchParams('terms', query, false),
                 state: {
                     focusEntry: 0,
                     sentence,
@@ -1175,5 +1163,16 @@ class Display extends EventDispatcher {
         } finally {
             this._historyChangeIgnore = historyChangeIgnorePre;
         }
+    }
+
+    _createSearchParams(type, query, wildcards) {
+        const params = {query};
+        if (typeof type === 'string') {
+            params.type = type;
+        }
+        if (!wildcards) {
+            params.wildcards = 'off';
+        }
+        return params;
     }
 }


### PR DESCRIPTION
This change fixes the query parser being reset after scanning it, due to the previous changes to history-driven content updates. This change also makes the query parser part of the core `Display` class, so it can eventually be used on the display page. For now, it is only visible and used on the search page.