### PR TITLE
More display refactoring

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -184,7 +184,6 @@ class DisplaySearch extends Display {
 
         if (typeof source !== 'string') { source = ''; }
 
-        this._closePopups();
         this._query.value = source;
         this._setIntroVisible(!valid, animate);
         this._updateSearchButton();
@@ -381,9 +380,5 @@ class DisplaySearch extends Display {
         yomichan.on('optionsUpdated', onOptionsUpdated);
 
         await onOptionsUpdated();
-    }
-
-    _closePopups() {
-        yomichan.trigger('closePopups');
     }
 }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -152,6 +152,17 @@ class DisplaySearch extends Display {
         }
     }
 
+    postProcessQuery(query) {
+        if (this._isWanakanaEnabled()) {
+            try {
+                query = wanakana.toKana(query);
+            } catch (e) {
+                // NOP
+            }
+        }
+        return query;
+    }
+
     // Private
 
     _onContentUpdating({type, source, content, urlSearchParams}) {
@@ -177,7 +188,7 @@ class DisplaySearch extends Display {
         if (full === null) { full = source; }
 
         this._closePopups();
-        this._setQuery(full);
+        this._query.value = source;
         this._setIntroVisible(!valid, animate);
         this._setTitleText(source);
         this._updateSearchButton();
@@ -287,19 +298,6 @@ class DisplaySearch extends Display {
 
     _isWanakanaEnabled() {
         return this._wanakanaEnable !== null && this._wanakanaEnable.checked;
-    }
-
-    _setQuery(query) {
-        let interpretedQuery = query;
-        if (this._isWanakanaEnabled()) {
-            try {
-                interpretedQuery = wanakana.toKana(query);
-            } catch (e) {
-                // NOP
-            }
-        }
-        this._query.value = interpretedQuery;
-        this.setQueryParserText(interpretedQuery);
     }
 
     _setIntroVisible(visible, animate) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -165,7 +165,7 @@ class DisplaySearch extends Display {
 
     // Private
 
-    _onContentUpdating({type, source, content, urlSearchParams}) {
+    _onContentUpdating({type, content, source}) {
         let animate = false;
         let valid = false;
         switch (type) {
@@ -184,13 +184,9 @@ class DisplaySearch extends Display {
 
         if (typeof source !== 'string') { source = ''; }
 
-        let full = urlSearchParams.get('full');
-        if (full === null) { full = source; }
-
         this._closePopups();
         this._query.value = source;
         this._setIntroVisible(!valid, animate);
-        this._setTitleText(source);
         this._updateSearchButton();
     }
 
@@ -358,19 +354,6 @@ class DisplaySearch extends Display {
 
     _updateSearchButton() {
         this._search.disabled = this._introVisible && (this._query === null || this._query.value.length === 0);
-    }
-
-    _setTitleText(text) {
-        // Chrome limits title to 1024 characters
-        if (text.length > 1000) {
-            text = text.substring(0, 1000) + '...';
-        }
-
-        if (text.length === 0) {
-            document.title = 'Yomichan Search';
-        } else {
-            document.title = `${text} - Yomichan Search`;
-        }
     }
 
     async _prepareNestedPopups() {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -67,7 +67,9 @@ class DisplaySearch extends Display {
 
         const options = this.getOptions();
 
-        const {queryParams: {query='', mode=''}} = parseUrl(window.location.href);
+        const urlSearchParams = new URLSearchParams(location.search);
+        let mode = urlSearchParams.get('mode');
+        if (mode === null) { mode = ''; }
 
         document.documentElement.dataset.searchMode = mode;
 
@@ -77,8 +79,6 @@ class DisplaySearch extends Display {
         } else {
             this._wanakanaEnable.checked = false;
         }
-
-        this._setQuery(query);
 
         if (mode !== 'popup') {
             if (options.general.enableClipboardMonitor === true) {
@@ -147,7 +147,6 @@ class DisplaySearch extends Display {
         if (!this._isPrepared) { return; }
         const query = this._query.value;
         if (query) {
-            this._setQuery(query);
             this._onSearchQueryUpdated(query, false);
         }
     }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -63,6 +63,7 @@ class DisplaySearch extends Display {
 
         this.on('contentUpdating', this._onContentUpdating.bind(this));
 
+        this.queryParserVisible = true;
         this.setHistorySettings({useBrowserHistory: true});
 
         const options = this.getOptions();

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -46,7 +46,7 @@
 
             <div id="spinner" hidden><img src="/mixed/img/spinner.gif"></div>
 
-            <div class="scan-disable">
+            <div class="scan-disable" id="query-parser-container">
                 <div id="query-parser-select-container" class="input-group"></div>
                 <div id="query-parser-content"></div>
             </div>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -3,7 +3,7 @@
     <head>
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width,initial-scale=1" />
-        <title></title>
+        <title>Yomichan Search</title>
         <link rel="icon" type="image/png" href="/mixed/img/icon16.png" sizes="16x16">
         <link rel="icon" type="image/png" href="/mixed/img/icon19.png" sizes="19x19">
         <link rel="icon" type="image/png" href="/mixed/img/icon32.png" sizes="32x32">

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -21,7 +21,7 @@
             <button class="action-button action-next" data-icon="source-term" title="Next term (Alt + F)"></button>
         </div></div><div class="navigation-header-spacer"></div>
 
-        <div class="scan-disable" hidden>
+        <div class="scan-disable" id="query-parser-container" hidden>
             <div id="query-parser-select-container" class="input-group"></div>
             <div id="query-parser-content"></div>
         </div>

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -305,6 +305,7 @@ button.action-button {
     border-bottom: 0.03571428em dashed var(--dark-border-color); /* 28px => 1px */
     color: var(--default-text-color);
     text-decoration: none;
+    cursor: pointer;
 }
 
 .term-expression[data-frequency=popular]>.term-expression-text,

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -280,7 +280,6 @@ class DisplayGenerator {
 
     _createKanjiLink(character) {
         const node = document.createElement('a');
-        node.href = '#';
         node.className = 'kanji-link';
         node.textContent = character;
         return node;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -387,6 +387,8 @@ class Display extends EventDispatcher {
             this._queryParserVisibleOverride = (fullVisible === null ? null : (fullVisible !== 'false'));
             this._updateQueryParserVisibility();
 
+            this._setEventListenersActive(false);
+
             let asigned = false;
             const eventArgs = {type, urlSearchParams, token};
             this._historyHasChanged = true;
@@ -446,6 +448,8 @@ class Display extends EventDispatcher {
                 this.trigger('contentUpdating', eventArgs);
                 this._clearContent();
             }
+
+            this._setEventListenersActive(true);
 
             eventArgs.stale = (this._setContentToken !== token);
             this.trigger('contentUpdated', eventArgs);
@@ -759,8 +763,6 @@ class Display extends EventDispatcher {
         if (typeof url !== 'string') { url = window.location.href; }
         sentence = this._getValidSentenceData(sentence);
 
-        this._setEventListenersActive(false);
-
         this._definitions = definitions;
 
         for (const definition of definitions) {
@@ -807,8 +809,6 @@ class Display extends EventDispatcher {
             this.autoPlayAudio();
         }
 
-        this._setEventListenersActive(true);
-
         const modes = isTerms ? ['term-kanji', 'term-kana'] : ['kanji'];
         const states = await this._getDefinitionsAddable(definitions, modes);
         if (this._setContentToken !== token) { return; }
@@ -832,7 +832,6 @@ class Display extends EventDispatcher {
     }
 
     _clearContent() {
-        this._setEventListenersActive(false);
         this._container.textContent = '';
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -387,6 +387,7 @@ class Display extends EventDispatcher {
             this._queryParserVisibleOverride = (fullVisible === null ? null : (fullVisible !== 'false'));
             this._updateQueryParserVisibility();
 
+            this._closePopups();
             this._setEventListenersActive(false);
 
             let asigned = false;
@@ -1249,5 +1250,9 @@ class Display extends EventDispatcher {
 
     _updateQueryParserVisibility() {
         this._queryParserContainer.hidden = !this._isQueryParserVisible();
+    }
+
+    _closePopups() {
+        yomichan.trigger('closePopups');
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -69,6 +69,8 @@ class Display extends EventDispatcher {
         this._historyChangeIgnore = false;
         this._historyHasChanged = false;
         this._navigationHeader = document.querySelector('#navigation-header');
+        this._defaultTitle = 'Yomichan Search';
+        this._defaultTitleMaxLength = 1000;
         this._fullQuery = '';
         this._queryParserVisible = false;
         this._queryParserVisibleOverride = null;
@@ -750,6 +752,7 @@ class Display extends EventDispatcher {
         let full = urlSearchParams.get('full');
         full = (full === null ? source : this.postProcessQuery(full));
         this._setQueryParserText(full);
+        this._setTitleText(source);
 
         let {definitions} = content;
         if (!Array.isArray(definitions)) {
@@ -843,10 +846,12 @@ class Display extends EventDispatcher {
 
         this._updateNavigation(null, null);
         this._setNoContentVisible(false);
+        this._setTitleText('');
     }
 
     _clearContent() {
         this._container.textContent = '';
+        this._setTitleText('');
     }
 
     _setNoContentVisible(visible) {
@@ -862,6 +867,21 @@ class Display extends EventDispatcher {
         this._fullQuery = text;
         if (!this._isQueryParserVisible()) { return; }
         this._queryParser.setText(text);
+    }
+
+    _setTitleText(text) {
+        // Chrome limits title to 1024 characters
+        const ellipsis = '...';
+        const maxLength = this._defaultTitleMaxLength - this._defaultTitle.length;
+        if (text.length > maxLength) {
+            text = `${text.substring(0, Math.max(0, maxLength - maxLength))}${ellipsis}`;
+        }
+
+        document.title = (
+            text.length === 0 ?
+            this._defaultTitle :
+            `${text} - ${this._defaultTitle}`
+        );
     }
 
     _updateNavigation(previous, next) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -70,6 +70,9 @@ class Display extends EventDispatcher {
         this._historyHasChanged = false;
         this._navigationHeader = document.querySelector('#navigation-header');
         this._fullQuery = '';
+        this._queryParserVisible = false;
+        this._queryParserVisibleOverride = null;
+        this._queryParserContainer = document.querySelector('#query-parser-container');
         this._queryParser = new QueryParser({
             getOptionsContext: this.getOptionsContext.bind(this),
             setSpinnerVisible: this.setSpinnerVisible.bind(this)
@@ -121,6 +124,15 @@ class Display extends EventDispatcher {
 
     set autoPlayAudioDelay(value) {
         this._autoPlayAudioDelay = value;
+    }
+
+    get queryParserVisible() {
+        return this._queryParserVisible;
+    }
+
+    set queryParserVisible(value) {
+        this._queryParserVisible = value;
+        this._updateQueryParserVisibility();
     }
 
     async prepare() {
@@ -370,6 +382,10 @@ class Display extends EventDispatcher {
             const urlSearchParams = new URLSearchParams(location.search);
             let type = urlSearchParams.get('type');
             if (type === null) { type = 'terms'; }
+
+            const fullVisible = urlSearchParams.get('full-visible');
+            this._queryParserVisibleOverride = (fullVisible === null ? null : (fullVisible !== 'false'));
+            this._updateQueryParserVisibility();
 
             let asigned = false;
             const eventArgs = {type, urlSearchParams, token};
@@ -1177,6 +1193,21 @@ class Display extends EventDispatcher {
         if (!wildcards) {
             params.wildcards = 'off';
         }
+        if (this._queryParserVisibleOverride !== null) {
+            params['full-visible'] = `${this._queryParserVisibleOverride}`;
+        }
         return params;
+    }
+
+    _isQueryParserVisible() {
+        return (
+            this._queryParserVisibleOverride !== null ?
+            this._queryParserVisibleOverride :
+            this._queryParserVisible
+        );
+    }
+
+    _updateQueryParserVisibility() {
+        this._queryParserContainer.hidden = !this._isQueryParserVisible();
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -334,10 +334,8 @@ class Display extends EventDispatcher {
         return data;
     }
 
-    setQueryParserText(text) {
-        if (this._fullQuery === text) { return; }
-        this._fullQuery = text;
-        this._queryParser.setText(text);
+    postProcessQuery(query) {
+        return query;
     }
 
     // Message handlers
@@ -734,7 +732,7 @@ class Display extends EventDispatcher {
     }
 
     async _setContentTermsOrKanji(token, isTerms, urlSearchParams, eventArgs) {
-        const source = urlSearchParams.get('query');
+        let source = urlSearchParams.get('query');
         if (!source) { return false; }
 
         let {state, content} = this._history;
@@ -747,6 +745,11 @@ class Display extends EventDispatcher {
             state = {};
             changeHistory = true;
         }
+
+        source = this.postProcessQuery(source);
+        let full = urlSearchParams.get('full');
+        full = (full === null ? source : this.postProcessQuery(full));
+        this._setQueryParserText(full);
 
         let {definitions} = content;
         if (!Array.isArray(definitions)) {
@@ -852,6 +855,13 @@ class Display extends EventDispatcher {
         if (noResults !== null) {
             noResults.hidden = !visible;
         }
+    }
+
+    _setQueryParserText(text) {
+        if (this._fullQuery === text) { return; }
+        this._fullQuery = text;
+        if (!this._isQueryParserVisible()) { return; }
+        this._queryParser.setText(text);
     }
 
     _updateNavigation(previous, next) {

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -48,6 +48,7 @@ const yomichan = (() => {
             }
 
             this._isExtensionUnloaded = false;
+            this._isTriggeringExtensionUnloaded = false;
             this._isReady = false;
 
             const {promise, resolve} = deferPromise();
@@ -256,7 +257,13 @@ const yomichan = (() => {
 
         triggerExtensionUnloaded() {
             this._isExtensionUnloaded = true;
-            this.trigger('extensionUnloaded');
+            if (this._isTriggeringExtensionUnloaded) { return; }
+            try {
+                this._isTriggeringExtensionUnloaded = true;
+                this.trigger('extensionUnloaded');
+            } finally {
+                this._isTriggeringExtensionUnloaded = false;
+            }
         }
 
         // Private


### PR DESCRIPTION
* Query parser text assignment moved into core `Display` class.
* Title text assignment moved into `Display` class.
* Adds support for forcing the query parser to be visible or hidden using a URL search parameter.
* Removes the "#" link for kanji search results, as it conflicts with navigation.
* Popup closing moved into `Display`.
