### PR TITLE
Fix _setContentTermsOrKanjiUpdateAdderButtons not working

### DIFF
--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -430,10 +430,6 @@ class Display extends EventDispatcher {
             this.trigger('contentUpdated', eventArgs);
         } catch (e) {
             this.onError(e);
-        } finally {
-            if (this._setContentToken === token) {
-                this._setContentToken = null;
-            }
         }
     }
 


### PR DESCRIPTION
`this._setContentToken` was cleared, so comparison exited. There is not really a good reason to clear this object anymore.