### PR TITLE
Strip request origin

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -40,6 +40,7 @@
         <script src="/bg/js/media-utility.js"></script>
         <script src="/bg/js/options.js"></script>
         <script src="/bg/js/profile-conditions.js"></script>
+        <script src="/bg/js/request-builder.js"></script>
         <script src="/bg/js/template-renderer.js"></script>
         <script src="/bg/js/text-source-map.js"></script>
         <script src="/bg/js/translator.js"></script>

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -28,6 +28,7 @@
  * Mecab
  * ObjectPropertyAccessor
  * OptionsUtil
+ * RequestBuilder
  * TemplateRenderer
  * Translator
  * conditionsTestValue
@@ -49,9 +50,13 @@ class Backend {
         this._options = null;
         this._optionsSchema = null;
         this._defaultAnkiFieldTemplates = null;
-        this._audioUriBuilder = new AudioUriBuilder();
+        this._requestBuilder = new RequestBuilder();
+        this._audioUriBuilder = new AudioUriBuilder({
+            requestBuilder: this._requestBuilder
+        });
         this._audioSystem = new AudioSystem({
             audioUriBuilder: this._audioUriBuilder,
+            requestBuilder: this._requestBuilder,
             useCache: false
         });
         this._ankiNoteBuilder = new AnkiNoteBuilder({

--- a/ext/bg/js/request-builder.js
+++ b/ext/bg/js/request-builder.js
@@ -1,0 +1,108 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+class RequestBuilder {
+    constructor() {
+    }
+
+    async fetchAnonymous(url, init) {
+        const originURL = this._getOriginURL(url);
+        const modifications = [
+            ['cookie', null],
+            ['origin', {name: 'Origin', value: originURL}]
+        ];
+        return this.fetchModifyHeaders(url, init, modifications);
+    }
+
+    async fetchModifyHeaders(url, init, modifications) {
+        const matchURL = this._getMatchURL(url);
+
+        let done = false;
+        const callback = (details) => {
+            if (done || details.url !== url) { return {}; }
+            done = true;
+
+            const requestHeaders = details.requestHeaders;
+            this._modifyHeaders(requestHeaders, modifications);
+            return {requestHeaders};
+        };
+        const filter = {
+            urls: [matchURL],
+            types: ['xmlhttprequest']
+        };
+        const extraInfoSpec = ['blocking', 'requestHeaders', 'extraHeaders'];
+
+        let needsCleanup = false;
+        try {
+            chrome.webRequest.onBeforeSendHeaders.addListener(callback, filter, extraInfoSpec);
+            needsCleanup = true;
+        } catch (e) {
+            // NOP
+        }
+
+        try {
+            return await fetch(url, init);
+        } finally {
+            if (needsCleanup) {
+                try {
+                    chrome.webRequest.onBeforeSendHeaders.removeListener(callback);
+                } catch (e) {
+                    // NOP
+                }
+            }
+        }
+    }
+
+    // Private
+
+    _getMatchURL(url) {
+        const url2 = new URL(url);
+        return `${url2.protocol}//${url2.host}${url2.pathname}`;
+    }
+
+    _getOriginURL(url) {
+        const url2 = new URL(url);
+        return `${url2.protocol}//${url2.host}`;
+    }
+
+    _modifyHeaders(headers, modifications) {
+        modifications = new Map(modifications);
+
+        for (let i = 0, ii = headers.length; i < ii; ++i) {
+            const header = headers[i];
+            const name = header.name.toLowerCase();
+            const modification = modifications.get(name);
+            if (typeof modification === 'undefined') { continue; }
+
+            modifications.delete(name);
+
+            if (modification === null) {
+                headers.splice(i, 1);
+                --i;
+                --ii;
+            } else {
+                headers[i] = modification;
+            }
+        }
+
+        for (const header of modifications.values()) {
+            if (header !== null) {
+                headers.push(header);
+            }
+        }
+    }
+}

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -67,7 +67,9 @@
         "storage",
         "clipboardWrite",
         "unlimitedStorage",
-        "nativeMessaging"
+        "nativeMessaging",
+        "webRequest",
+        "webRequestBlocking"
     ],
     "optional_permissions": [
         "clipboardRead"


### PR DESCRIPTION
Fixes #706.

This change adds the `webRequest` and `webRequestBlocking` permissions, as they are needed to modify the headers. However, according to some docs, these additional permissions should not trigger an additional permissions warning, since I believe they fall under the same category as `<all_urls>`.

The new function `fetchAnonymous` is added in this change, which strips the `Cookie` header and modifies the `Origin` header to match the origin of the URL that is being requested. `AudioUriBuilder` and `AudioSystem` currently use this. The `XMLHttpRequest` changes made in #708 have been reverted to `fetch`.

(Note that there is an extremely unlikely chance for the header modification to affect an external request, but this would require an incredibly unlikely timing exploit that also requires user input, and would ultimately not really be harmful.)