### PR TITLE
Persistent display mode

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -943,6 +943,12 @@ class Backend {
         const tab = tabs[0];
         await this._waitUntilTabFrameIsReady(tab.id, 0, 2000);
 
+        await this._sendMessageTab(
+            tab.id,
+            {action: 'setMode', params: {mode: 'popup'}},
+            {frameId: 0}
+        );
+
         this._searchPopupTabId = tab.id;
         return {tab, created: true};
     }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -919,7 +919,7 @@ class Backend {
         const popupWindow = await new Promise((resolve, reject) => {
             chrome.windows.create(
                 {
-                    url: `${baseUrl}?mode=popup`,
+                    url: baseUrl,
                     width: popupWidth,
                     height: popupHeight,
                     type: 'popup'

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -37,6 +37,7 @@ class DisplaySearch extends Display {
         this._clipboardMonitor = new ClipboardMonitor({
             getClipboard: api.clipboardGet.bind(api)
         });
+        this._clipboardMonitorEnabled = false;
         this._onKeyDownIgnoreKeys = new Map([
             ['ANY_MOD', new Set([
                 'Tab', 'ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight', 'PageDown', 'PageUp', 'Home', 'End',
@@ -59,6 +60,7 @@ class DisplaySearch extends Display {
         yomichan.on('optionsUpdated', () => this.updateOptions());
 
         this.on('contentUpdating', this._onContentUpdating.bind(this));
+        this.on('modeChange', this._onModeChange.bind(this));
 
         this.registerMessageHandlers([
             ['updateSearchQuery', {async: false, handler: this._onExternalSearchUpdate.bind(this)}]
@@ -68,13 +70,6 @@ class DisplaySearch extends Display {
         this.setHistorySettings({useBrowserHistory: true});
 
         const options = this.getOptions();
-
-        const urlSearchParams = new URLSearchParams(location.search);
-        let mode = urlSearchParams.get('mode');
-        if (mode === null) { mode = ''; }
-
-        document.documentElement.dataset.searchMode = mode;
-
         if (options.general.enableWanakana === true) {
             this._wanakanaEnable.checked = true;
             wanakana.bind(this._query);
@@ -82,23 +77,15 @@ class DisplaySearch extends Display {
             this._wanakanaEnable.checked = false;
         }
 
-        if (mode !== 'popup') {
-            if (options.general.enableClipboardMonitor === true) {
-                this._clipboardMonitorEnable.checked = true;
-                this._clipboardMonitor.start();
-            } else {
-                this._clipboardMonitorEnable.checked = false;
-            }
-            this._clipboardMonitorEnable.addEventListener('change', this._onClipboardMonitorEnableChange.bind(this));
-        }
-
         this._search.addEventListener('click', this._onSearch.bind(this), false);
         this._query.addEventListener('input', this._onSearchInput.bind(this), false);
         this._wanakanaEnable.addEventListener('change', this._onWanakanaEnableChange.bind(this));
         window.addEventListener('copy', this._onCopy.bind(this));
         this._clipboardMonitor.on('change', this._onExternalSearchUpdate.bind(this));
+        this._clipboardMonitorEnable.addEventListener('change', this._onClipboardMonitorEnableChange.bind(this));
 
         this._updateSearchButton();
+        this._onModeChange();
 
         await this._prepareNestedPopups();
 
@@ -254,34 +241,15 @@ class DisplaySearch extends Display {
     }
 
     _onClipboardMonitorEnableChange(e) {
-        if (e.target.checked) {
-            chrome.permissions.request(
-                {permissions: ['clipboardRead']},
-                (granted) => {
-                    if (granted) {
-                        this._clipboardMonitor.start();
-                        api.modifySettings([{
-                            action: 'set',
-                            path: 'general.enableClipboardMonitor',
-                            value: true,
-                            scope: 'profile',
-                            optionsContext: this.getOptionsContext()
-                        }], 'search');
-                    } else {
-                        e.target.checked = false;
-                    }
-                }
-            );
-        } else {
-            this._clipboardMonitor.stop();
-            api.modifySettings([{
-                action: 'set',
-                path: 'general.enableClipboardMonitor',
-                value: false,
-                scope: 'profile',
-                optionsContext: this.getOptionsContext()
-            }], 'search');
-        }
+        const enabled = e.target.checked;
+        this._setClipboardMonitorEnabled(enabled);
+    }
+
+    _onModeChange() {
+        let mode = this.mode;
+        if (mode === null) { mode = ''; }
+        document.documentElement.dataset.searchMode = mode;
+        this._updateClipboardMonitorEnabled();
     }
 
     _isWanakanaEnabled() {
@@ -373,5 +341,49 @@ class DisplaySearch extends Display {
         yomichan.on('optionsUpdated', onOptionsUpdated);
 
         await onOptionsUpdated();
+    }
+
+    async _setClipboardMonitorEnabled(value) {
+        let modify = true;
+        if (value) {
+            value = await this._requestPermissions(['clipboardRead']);
+            modify = value;
+        }
+
+        this._clipboardMonitorEnabled = value;
+        this._updateClipboardMonitorEnabled();
+
+        if (!modify) { return; }
+
+        await api.modifySettings([{
+            action: 'set',
+            path: 'general.enableClipboardMonitor',
+            value,
+            scope: 'profile',
+            optionsContext: this.getOptionsContext()
+        }], 'search');
+    }
+
+    _updateClipboardMonitorEnabled() {
+        const mode = this.mode;
+        const enabled = this._clipboardMonitorEnabled;
+        this._clipboardMonitorEnable.checked = enabled;
+        if (enabled && mode !== 'popup') {
+            this._clipboardMonitor.start();
+        } else {
+            this._clipboardMonitor.stop();
+        }
+    }
+
+    _requestPermissions(permissions) {
+        return new Promise((resolve) => {
+            chrome.permissions.request(
+                {permissions},
+                (granted) => {
+                    const e = chrome.runtime.lastError;
+                    resolve(!e && granted);
+                }
+            );
+        });
     }
 }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -51,9 +51,6 @@ class DisplaySearch extends Display {
             ['AltGraph', new Set()],
             ['Shift', new Set()]
         ]);
-        this._runtimeMessageHandlers = new Map([
-            ['updateSearchQuery', {async: false, handler: this._onExternalSearchUpdate.bind(this)}]
-        ]);
     }
 
     async prepare() {
@@ -62,6 +59,10 @@ class DisplaySearch extends Display {
         yomichan.on('optionsUpdated', () => this.updateOptions());
 
         this.on('contentUpdating', this._onContentUpdating.bind(this));
+
+        this.registerMessageHandlers([
+            ['updateSearchQuery', {async: false, handler: this._onExternalSearchUpdate.bind(this)}]
+        ]);
 
         this.queryParserVisible = true;
         this.setHistorySettings({useBrowserHistory: true});
@@ -90,8 +91,6 @@ class DisplaySearch extends Display {
             }
             this._clipboardMonitorEnable.addEventListener('change', this._onClipboardMonitorEnableChange.bind(this));
         }
-
-        chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
 
         this._search.addEventListener('click', this._onSearch.bind(this), false);
         this._query.addEventListener('input', this._onSearchInput.bind(this), false);
@@ -207,12 +206,6 @@ class DisplaySearch extends Display {
 
         const query = this._query.value;
         this._onSearchQueryUpdated(query, true);
-    }
-
-    _onRuntimeMessage({action, params}, sender, callback) {
-        const messageHandler = this._runtimeMessageHandlers.get(action);
-        if (typeof messageHandler === 'undefined') { return false; }
-        return yomichan.invokeMessageHandler(messageHandler, params, callback, sender);
     }
 
     _onCopy() {

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -44,7 +44,7 @@ class DisplayFloat extends Display {
     async prepare() {
         await super.prepare();
 
-        this.registerMessageHandlers([
+        this.registerDirectMessageHandlers([
             ['configure',       {async: true,  handler: this._onMessageConfigure.bind(this)}],
             ['setContentScale', {async: false, handler: this._onMessageSetContentScale.bind(this)}]
         ]);

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -64,7 +64,7 @@ class Display extends EventDispatcher {
         this._windowScroll = new WindowScroll();
         this._hotkeys = new Map();
         this._actions = new Map();
-        this._messageHandlers = new Map();
+        this._directMessageHandlers = new Map();
         this._history = new DisplayHistory({clearable: true, useBrowserHistory: false});
         this._historyChangeIgnore = false;
         this._historyHasChanged = false;
@@ -113,7 +113,7 @@ class Display extends EventDispatcher {
             {key: 'P',         modifiers: ['alt'], action: 'playAudio'},
             {key: 'V',         modifiers: ['alt'], action: 'viewNote'}
         ]);
-        this.registerMessageHandlers([
+        this.registerDirectMessageHandlers([
             ['setOptionsContext',  {async: false, handler: this._onMessageSetOptionsContext.bind(this)}],
             ['setContent',         {async: false, handler: this._onMessageSetContent.bind(this)}],
             ['clearAutoPlayTimer', {async: false, handler: this._onMessageClearAutoPlayTimer.bind(this)}],
@@ -147,7 +147,7 @@ class Display extends EventDispatcher {
         this._queryParser.on('searched', this._onQueryParserSearch.bind(this));
         yomichan.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
         api.crossFrame.registerHandlers([
-            ['popupMessage', {async: 'dynamic', handler: this._onMessage.bind(this)}]
+            ['popupMessage', {async: 'dynamic', handler: this._onDirectMessage.bind(this)}]
         ]);
     }
 
@@ -307,9 +307,9 @@ class Display extends EventDispatcher {
         }
     }
 
-    registerMessageHandlers(handlers) {
+    registerDirectMessageHandlers(handlers) {
         for (const [name, handlerInfo] of handlers) {
-            this._messageHandlers.set(name, handlerInfo);
+            this._directMessageHandlers.set(name, handlerInfo);
         }
     }
 
@@ -343,10 +343,10 @@ class Display extends EventDispatcher {
 
     // Message handlers
 
-    _onMessage(data) {
+    _onDirectMessage(data) {
         data = this.authenticateMessageData(data);
         const {action, params} = data;
-        const handlerInfo = this._messageHandlers.get(action);
+        const handlerInfo = this._directMessageHandlers.get(action);
         if (typeof handlerInfo === 'undefined') {
             throw new Error(`Invalid action: ${action}`);
         }


### PR DESCRIPTION
Search popup now has a persistent display mode, which persists across refreshes. Previously, refreshing would cause it to no longer be styled as the search popup.

This will also be used to address a longer-term issue of the backend not being able to store a reference to the window/tab ID of the search popup (due to manifest v3). Therefore, the backend will have to query the tab directly to see if it is the search popup.