### PR TITLE
Query parser text scanner options refactor

### DIFF
--- a/ext/bg/js/query-parser.js
+++ b/ext/bg/js/query-parser.js
@@ -103,28 +103,25 @@ class QueryParser extends EventDispatcher {
 
     _onParserChange(e) {
         const value = e.target.value;
+        this._setSelectedParser(value);
+    }
+
+    _refreshSelectedParser() {
+        if (this._parseResults.length > 0 && !this._getParseResult()) {
+            const value = this._parseResults[0].id;
+            this._setSelectedParser(value);
+        }
+    }
+
+    _setSelectedParser(value) {
+        const optionsContext = this._getOptionsContext();
         api.modifySettings([{
             action: 'set',
             path: 'parsing.selectedParser',
             value,
             scope: 'profile',
-            optionsContext: this._getOptionsContext()
+            optionsContext
         }], 'search');
-    }
-
-    _refreshSelectedParser() {
-        if (this._parseResults.length > 0) {
-            if (!this._getParseResult()) {
-                const value = this._parseResults[0].id;
-                api.modifySettings([{
-                    action: 'set',
-                    path: 'parsing.selectedParser',
-                    value,
-                    scope: 'profile',
-                    optionsContext: this._getOptionsContext()
-                }], 'search');
-            }
-        }
     }
 
     _getParseResult() {

--- a/ext/bg/js/query-parser.js
+++ b/ext/bg/js/query-parser.js
@@ -25,9 +25,12 @@
 class QueryParser extends EventDispatcher {
     constructor({getOptionsContext, setSpinnerVisible}) {
         super();
-        this._options = null;
         this._getOptionsContext = getOptionsContext;
         this._setSpinnerVisible = setSpinnerVisible;
+        this._selectedParser = null;
+        this._scanLength = 1;
+        this._sentenceExtent = 1;
+        this._layoutAwareScan = false;
         this._parseResults = [];
         this._queryParser = document.querySelector('#query-parser-content');
         this._queryParserSelect = document.querySelector('#query-parser-select-container');
@@ -46,19 +49,26 @@ class QueryParser extends EventDispatcher {
         this._queryParser.addEventListener('click', this._onClick.bind(this));
     }
 
-    setOptions(options) {
-        this._options = options;
-        const scanningOptions = options.scanning;
-        this._textScanner.setOptions({
-            deepContentScan: scanningOptions.deepDomScan,
-            selectText: scanningOptions.selectText,
-            modifier: scanningOptions.modifier,
-            useMiddleMouse: scanningOptions.middleMouse,
-            delay: scanningOptions.delay,
-            touchInputEnabled: scanningOptions.touchInputEnabled
-        });
+    setOptions({selectedParser, scanLength, sentenceExtent, layoutAwareScan, termSpacing, scanning}) {
+        if (selectedParser === null || typeof selectedParser === 'string') {
+            this._selectedParser = selectedParser;
+        }
+        if (typeof scanLength === 'number') {
+            this._scanLength = scanLength;
+        }
+        if (typeof sentenceExtent === 'number') {
+            this._sentenceExtent = sentenceExtent;
+        }
+        if (typeof layoutAwareScan === 'boolean') {
+            this._layoutAwareScan = layoutAwareScan;
+        }
+        if (typeof termSpacing === 'boolean') {
+            this._queryParser.dataset.termSpacing = `${termSpacing}`;
+        }
+        if (scanning !== null && typeof scanning === 'object') {
+            this._textScanner.setOptions(scanning);
+        }
         this._textScanner.setEnabled(true);
-        this._queryParser.dataset.termSpacing = `${options.parsing.termSpacing}`;
     }
 
     async setText(text) {
@@ -84,7 +94,9 @@ class QueryParser extends EventDispatcher {
     async _search(textSource, cause) {
         if (textSource === null) { return null; }
 
-        const {length: scanLength, layoutAwareScan} = this._options.scanning;
+        const scanLength = this._scanLength;
+        const sentenceExtent = this._sentenceExtent;
+        const layoutAwareScan = this._layoutAwareScan;
         const searchText = this._textScanner.getTextSourceContent(textSource, scanLength, layoutAwareScan);
         if (searchText.length === 0) { return null; }
 
@@ -92,7 +104,6 @@ class QueryParser extends EventDispatcher {
         const {definitions, length} = await api.termsFind(searchText, {}, optionsContext);
         if (definitions.length === 0) { return null; }
 
-        const sentenceExtent = this._options.anki.sentenceExt;
         const sentence = docSentenceExtract(textSource, sentenceExtent, layoutAwareScan);
 
         textSource.setEndOffset(length, layoutAwareScan);
@@ -133,7 +144,7 @@ class QueryParser extends EventDispatcher {
     }
 
     _getParseResult() {
-        const {selectedParser} = this._options.parsing;
+        const selectedParser = this._selectedParser;
         return this._parseResults.find((r) => r.id === selectedParser);
     }
 
@@ -150,7 +161,7 @@ class QueryParser extends EventDispatcher {
     _renderParserSelect() {
         this._queryParserSelect.textContent = '';
         if (this._parseResults.length > 1) {
-            const {selectedParser} = this._options.parsing;
+            const selectedParser = this._selectedParser;
             const select = this._queryParserGenerator.createParserSelect(this._parseResults, selectedParser);
             select.addEventListener('change', this._onParserChange.bind(this));
             this._queryParserSelect.appendChild(select);

--- a/ext/bg/js/query-parser.js
+++ b/ext/bg/js/query-parser.js
@@ -48,7 +48,15 @@ class QueryParser extends EventDispatcher {
 
     setOptions(options) {
         this._options = options;
-        this._textScanner.setOptions(options);
+        const scanningOptions = options.scanning;
+        this._textScanner.setOptions({
+            deepContentScan: scanningOptions.deepDomScan,
+            selectText: scanningOptions.selectText,
+            modifier: scanningOptions.modifier,
+            useMiddleMouse: scanningOptions.middleMouse,
+            delay: scanningOptions.delay,
+            touchInputEnabled: scanningOptions.touchInputEnabled
+        });
         this._textScanner.setEnabled(true);
         this._queryParser.dataset.termSpacing = `${options.parsing.termSpacing}`;
     }

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -233,11 +233,20 @@ class Frontend {
 
     async _updateOptionsInternal() {
         const optionsContext = await this.getOptionsContext();
-        this._options = await api.optionsGet(optionsContext);
+        const options = await api.optionsGet(optionsContext);
+        const scanningOptions = options.scanning;
+        this._options = options;
 
         await this._updatePopup();
 
-        this._textScanner.setOptions(this._options);
+        this._textScanner.setOptions({
+            deepContentScan: scanningOptions.deepDomScan,
+            selectText: scanningOptions.selectText,
+            modifier: scanningOptions.modifier,
+            useMiddleMouse: scanningOptions.middleMouse,
+            delay: scanningOptions.delay,
+            touchInputEnabled: scanningOptions.touchInputEnabled
+        });
         this._updateTextScannerEnabled();
 
         const ignoreNodes = ['.scan-disable', '.scan-disable *'];

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -207,11 +207,29 @@ class Display extends EventDispatcher {
     }
 
     async updateOptions() {
-        this._options = await api.optionsGet(this.getOptionsContext());
-        this._updateDocumentOptions(this._options);
-        this._updateTheme(this._options.general.popupTheme);
-        this.setCustomCss(this._options.general.customPopupCss);
-        this._queryParser.setOptions(this._options);
+        const options = await api.optionsGet(this.getOptionsContext());
+        const scanning = options.scanning;
+        this._options = options;
+
+        this._updateDocumentOptions(options);
+        this._updateTheme(options.general.popupTheme);
+        this.setCustomCss(options.general.customPopupCss);
+
+        this._queryParser.setOptions({
+            selectedParser: options.parsing.selectedParser,
+            scanLength: scanning.length,
+            sentenceExtent: options.anki.sentenceExt,
+            layoutAwareScan: scanning.layoutAwareScan,
+            termSpacing: options.parsing.termSpacing,
+            scanning: {
+                deepContentScan: scanning.deepDomScan,
+                selectText: scanning.selectText,
+                modifier: scanning.modifier,
+                useMiddleMouse: scanning.middleMouse,
+                delay: scanning.delay,
+                touchInputEnabled: scanning.touchInputEnabled
+            }
+        });
     }
 
     addMultipleEventListeners(selector, type, listener, options) {


### PR DESCRIPTION
Decouples the internal options format used for `TextScanner` and `QueryParser` from the core options object. This makes these classes not store a reference to an options object, but instead only the values of the pertinent options.