### PR TITLE
Build system changes

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -134,7 +134,10 @@
             }
         },
         {
-            "files": ["test/**/*.js"],
+            "files": [
+                "test/**/*.js",
+                "dev/**/*.js"
+            ],
             "excludedFiles": ["test/data/html/*.js"],
             "parserOptions": {
                 "ecmaVersion": 8,

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
+*.sh text eol=lf
 ext/*.handlebars text eol=lf
 ext/*.js text eol=lf
 ext/*.json text eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,6 @@
-*.handlebars text eol=lf
+ext/*.handlebars text eol=lf
+ext/*.js text eol=lf
+ext/*.json text eol=lf
+ext/*.css text eol=lf
+ext/*.html text eol=lf
+ext/*.svg text eol=lf

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 node_modules
+builds/

--- a/build.bat
+++ b/build.bat
@@ -1,0 +1,1 @@
+@npm run-script build

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+npm run-script build

--- a/build_zip.sh
+++ b/build_zip.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-rm yomichan_source.zip
-7za a yomichan_source.zip ./ext ./LICENSE ./README.md ./resources ./tmpl
-
-rm yomichan_extension.zip
-7za a yomichan_extension.zip ./ext/*

--- a/dev/build.js
+++ b/dev/build.js
@@ -134,13 +134,24 @@ function getObjectProperties(object, path2, count) {
     return object;
 }
 
+function loadDefaultManifest() {
+    const {manifest} = loadDefaultManifestAndVariants();
+    return manifest;
+}
+
+function loadDefaultManifestAndVariants() {
+    const fileName = path.join(__dirname, 'data', 'manifest-variants.json');
+    const {manifest, variants} = JSON.parse(fs.readFileSync(fileName));
+    return {manifest, variants};
+}
+
 function createManifestString(manifest) {
     return JSON.stringify(manifest, null, 4) + '\n';
 }
 
 
 async function main() {
-    const {manifest, variants} = JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'manifest-variants.json')));
+    const {manifest, variants} = loadDefaultManifestAndVariants();
 
     const rootDir = path.join(__dirname, '..');
     const extDir = path.join(rootDir, 'ext');
@@ -191,6 +202,13 @@ async function main() {
         fs.writeFileSync(manifestPath, createManifestString(manifest));
     }
 }
+
+
+module.exports = {
+    loadDefaultManifest,
+    loadDefaultManifestAndVariants,
+    createManifestString
+};
 
 
 if (require.main === module) { main(); }

--- a/dev/build.js
+++ b/dev/build.js
@@ -1,0 +1,196 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+const childProcess = require('child_process');
+const yomichanTest = require('../test/yomichan-test');
+
+
+function getAllFiles(directory, relativeTo) {
+    const results = [];
+    const directories = [directory];
+    for (const dir of directories) {
+        const fileNames = fs.readdirSync(dir);
+        for (const fileName of fileNames) {
+            const fullFileName = path.join(dir, fileName);
+            const relativeFileName = path.relative(relativeTo, fullFileName);
+            const stats = fs.lstatSync(fullFileName);
+            if (stats.isFile()) {
+                results.push(relativeFileName);
+            } else if (stats.isDirectory()) {
+                directories.push(fullFileName);
+            }
+        }
+    }
+    return results;
+}
+
+async function createZip(directory, outputFileName, sevenZipExes=[], onUpdate=null) {
+    for (const exe of sevenZipExes) {
+        try {
+            childProcess.execFileSync(
+                exe,
+                [
+                    'a',
+                    outputFileName,
+                    '.'
+                ],
+                {
+                    cwd: directory
+                }
+            );
+            return;
+        } catch (e) {
+            // NOP
+        }
+    }
+    return await createJSZip(directory, outputFileName, onUpdate);
+}
+
+async function createJSZip(directory, outputFileName, onUpdate) {
+    const JSZip = yomichanTest.JSZip;
+    const files = getAllFiles(directory, directory);
+    const zip = new JSZip();
+    for (const fileName of files) {
+        zip.file(
+            fileName.replace(/\\/g, '/'),
+            fs.readFileSync(path.join(directory, fileName), {encoding: null, flag: 'r'}),
+            {}
+        );
+    }
+
+    if (typeof onUpdate !== 'function') {
+        onUpdate = () => {}; // NOP
+    }
+
+    const data = await zip.generateAsync({
+        type: 'nodebuffer',
+        compression: 'DEFLATE',
+        compressionOptions: {level: 9}
+    }, onUpdate);
+    process.stdout.write('\n');
+
+    fs.writeFileSync(outputFileName, data, {encoding: null, flag: 'w'});
+}
+
+function createModifiedManifest(manifest, modifications) {
+    manifest = JSON.parse(JSON.stringify(manifest));
+
+    if (Array.isArray(modifications)) {
+        for (const modification of modifications) {
+            const {action, path: path2} = modification;
+            switch (action) {
+                case 'set':
+                    {
+                        const value = getObjectProperties(manifest, path2, path2.length - 1);
+                        const last = path2[path2.length - 1];
+                        value[last] = modification.value;
+                    }
+                    break;
+                case 'replace':
+                    {
+                        const value = getObjectProperties(manifest, path2, path2.length - 1);
+                        const regex = new RegExp(modification.pattern, modification.patternFlags);
+                        const last = path2[path2.length - 1];
+                        let value2 = value[last];
+                        value2 = `${value2}`.replace(regex, modification.replacement);
+                        value[last] = value2;
+                    }
+                    break;
+                case 'delete':
+                    {
+                        const value = getObjectProperties(manifest, path2, path2.length - 1);
+                        const last = path2[path2.length - 1];
+                        delete value[last];
+                    }
+                    break;
+            }
+        }
+    }
+
+    return manifest;
+}
+
+function getObjectProperties(object, path2, count) {
+    for (let i = 0; i < count; ++i) {
+        object = object[path2[i]];
+    }
+    return object;
+}
+
+function createManifestString(manifest) {
+    return JSON.stringify(manifest, null, 4) + '\n';
+}
+
+
+async function main() {
+    const {manifest, variants} = JSON.parse(fs.readFileSync(path.join(__dirname, 'data', 'manifest-variants.json')));
+
+    const rootDir = path.join(__dirname, '..');
+    const extDir = path.join(rootDir, 'ext');
+    const buildDir = path.join(rootDir, 'builds');
+    const manifestPath = path.join(extDir, 'manifest.json');
+    const sevenZipExes = ['7za', '7z'];
+
+    // Create build directory
+    if (!fs.existsSync(buildDir)) {
+        fs.mkdirSync(buildDir, {recursive: true});
+    }
+
+
+    const onUpdate = (metadata) => {
+        let message = `Progress: ${metadata.percent.toFixed(2)}%`;
+        if (metadata.currentFile) {
+            message += ` (${metadata.currentFile})`;
+        }
+
+        readline.clearLine(process.stdout);
+        readline.cursorTo(process.stdout, 0);
+        process.stdout.write(message);
+    };
+
+    try {
+        for (const variant of variants) {
+            const {name, fileName, fileCopies, modifications} = variant;
+            process.stdout.write(`Building ${name}...\n`);
+
+            const fileNameSafe = path.basename(fileName);
+            const modifiedManifest = createModifiedManifest(manifest, modifications);
+            const fullFileName = path.join(buildDir, fileNameSafe);
+            fs.writeFileSync(manifestPath, createManifestString(modifiedManifest));
+            await createZip(extDir, fullFileName, sevenZipExes, onUpdate);
+
+            if (Array.isArray(fileCopies)) {
+                for (const fileName2 of fileCopies) {
+                    const fileName2Safe = path.basename(fileName2);
+                    fs.copyFileSync(fullFileName, path.join(buildDir, fileName2Safe));
+                }
+            }
+
+            process.stdout.write('\n');
+        }
+    } finally {
+        // Restore manifest
+        process.stdout.write('Restoring manifest...\n');
+        fs.writeFileSync(manifestPath, createManifestString(manifest));
+    }
+}
+
+
+if (require.main === module) { main(); }

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -1,0 +1,144 @@
+{
+    "manifest": {
+        "manifest_version": 2,
+        "name": "Yomichan",
+        "version": "20.8.3.0",
+        "description": "Japanese dictionary with Anki integration",
+        "author": "Alex Yatskov",
+        "icons": {
+            "16": "mixed/img/icon16.png",
+            "19": "mixed/img/icon19.png",
+            "32": "mixed/img/icon32.png",
+            "38": "mixed/img/icon38.png",
+            "48": "mixed/img/icon48.png",
+            "64": "mixed/img/icon48.png",
+            "128": "mixed/img/icon128.png"
+        },
+        "browser_action": {
+            "default_icon": {
+                "16": "mixed/img/icon16.png",
+                "19": "mixed/img/icon19.png",
+                "32": "mixed/img/icon32.png",
+                "38": "mixed/img/icon38.png",
+                "48": "mixed/img/icon48.png",
+                "64": "mixed/img/icon48.png",
+                "128": "mixed/img/icon128.png"
+            },
+            "default_title": "Yomichan",
+            "default_popup": "bg/context.html"
+        },
+        "background": {
+            "page": "bg/background.html",
+            "persistent": true
+        },
+        "content_scripts": [
+            {
+                "matches": [
+                    "http://*/*",
+                    "https://*/*",
+                    "file://*/*"
+                ],
+                "js": [
+                    "mixed/js/core.js",
+                    "mixed/js/yomichan.js",
+                    "mixed/js/comm.js",
+                    "mixed/js/dom.js",
+                    "mixed/js/api.js",
+                    "mixed/js/dynamic-loader.js",
+                    "mixed/js/frame-client.js",
+                    "mixed/js/text-scanner.js",
+                    "fg/js/document.js",
+                    "fg/js/dom-text-scanner.js",
+                    "fg/js/popup.js",
+                    "fg/js/source.js",
+                    "fg/js/popup-factory.js",
+                    "fg/js/frame-offset-forwarder.js",
+                    "fg/js/popup-proxy.js",
+                    "fg/js/frontend.js",
+                    "fg/js/content-script-main.js"
+                ],
+                "match_about_blank": true,
+                "all_frames": true
+            }
+        ],
+        "minimum_chrome_version": "57.0.0.0",
+        "options_page": "bg/settings.html",
+        "options_ui": {
+            "page": "bg/settings.html",
+            "open_in_tab": true
+        },
+        "permissions": [
+            "<all_urls>",
+            "storage",
+            "clipboardWrite",
+            "unlimitedStorage",
+            "nativeMessaging",
+            "webRequest",
+            "webRequestBlocking"
+        ],
+        "optional_permissions": [
+            "clipboardRead"
+        ],
+        "commands": {
+            "toggle": {
+                "suggested_key": {
+                    "default": "Alt+Delete"
+                },
+                "description": "Toggle text scanning"
+            },
+            "search": {
+                "suggested_key": {
+                    "default": "Alt+Insert"
+                },
+                "description": "Open search window"
+            }
+        },
+        "web_accessible_resources": [
+            "fg/float.html"
+        ],
+        "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+        "applications": {
+            "gecko": {
+                "id": "alex@foosoft.net",
+                "strict_min_version": "55.0"
+            }
+        }
+    },
+    "variants": [
+        {
+            "name": "default",
+            "fileName": "yomichan.zip",
+            "fileCopies": [
+                "yomichan.xpi"
+            ]
+        },
+        {
+            "name": "dev",
+            "fileName": "yomichan-dev.zip",
+            "fileCopies": [
+                "yomichan-dev.xpi"
+            ],
+            "modifications": [
+                {
+                    "action": "replace",
+                    "path": ["name"],
+                    "pattern": "^.*$",
+                    "patternFlags": "",
+                    "replacement": "$& (development build)"
+                },
+                {
+                    "action": "replace",
+                    "path": ["description"],
+                    "pattern": "^(.*)(?:\\.\\s*)?$",
+                    "patternFlags": "",
+                    "replacement": "$1. This is a development build; get the stable version here: https://tinyurl.com/yaatdjmp"
+                },
+                {
+                    "action": "set",
+                    "path": ["applications", "gecko", "id"],
+                    "value": "alex.testing@foosoft.net"
+                }
+            ]
+        }
+    ]
+}

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -11,7 +11,7 @@
             "32": "mixed/img/icon32.png",
             "38": "mixed/img/icon38.png",
             "48": "mixed/img/icon48.png",
-            "64": "mixed/img/icon48.png",
+            "64": "mixed/img/icon64.png",
             "128": "mixed/img/icon128.png"
         },
         "browser_action": {
@@ -21,7 +21,7 @@
                 "32": "mixed/img/icon32.png",
                 "38": "mixed/img/icon38.png",
                 "48": "mixed/img/icon48.png",
-                "64": "mixed/img/icon48.png",
+                "64": "mixed/img/icon64.png",
                 "128": "mixed/img/icon128.png"
             },
             "default_title": "Yomichan",

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -2,8 +2,8 @@
     "manifest_version": 2,
     "name": "Yomichan",
     "version": "20.8.3.0",
-
     "description": "Japanese dictionary with Anki integration",
+    "author": "Alex Yatskov",
     "icons": {
         "16": "mixed/img/icon16.png",
         "19": "mixed/img/icon19.png",
@@ -26,36 +26,40 @@
         "default_title": "Yomichan",
         "default_popup": "bg/context.html"
     },
-
-    "author": "Alex Yatskov",
     "background": {
         "page": "bg/background.html",
         "persistent": true
     },
-    "content_scripts": [{
-        "matches": ["http://*/*", "https://*/*", "file://*/*"],
-        "js": [
-            "mixed/js/core.js",
-            "mixed/js/yomichan.js",
-            "mixed/js/comm.js",
-            "mixed/js/dom.js",
-            "mixed/js/api.js",
-            "mixed/js/dynamic-loader.js",
-            "mixed/js/frame-client.js",
-            "mixed/js/text-scanner.js",
-            "fg/js/document.js",
-            "fg/js/dom-text-scanner.js",
-            "fg/js/popup.js",
-            "fg/js/source.js",
-            "fg/js/popup-factory.js",
-            "fg/js/frame-offset-forwarder.js",
-            "fg/js/popup-proxy.js",
-            "fg/js/frontend.js",
-            "fg/js/content-script-main.js"
-        ],
-        "match_about_blank": true,
-        "all_frames": true
-    }],
+    "content_scripts": [
+        {
+            "matches": [
+                "http://*/*",
+                "https://*/*",
+                "file://*/*"
+            ],
+            "js": [
+                "mixed/js/core.js",
+                "mixed/js/yomichan.js",
+                "mixed/js/comm.js",
+                "mixed/js/dom.js",
+                "mixed/js/api.js",
+                "mixed/js/dynamic-loader.js",
+                "mixed/js/frame-client.js",
+                "mixed/js/text-scanner.js",
+                "fg/js/document.js",
+                "fg/js/dom-text-scanner.js",
+                "fg/js/popup.js",
+                "fg/js/source.js",
+                "fg/js/popup-factory.js",
+                "fg/js/frame-offset-forwarder.js",
+                "fg/js/popup-proxy.js",
+                "fg/js/frontend.js",
+                "fg/js/content-script-main.js"
+            ],
+            "match_about_blank": true,
+            "all_frames": true
+        }
+    ],
     "minimum_chrome_version": "57.0.0.0",
     "options_page": "bg/settings.html",
     "options_ui": {
@@ -88,7 +92,9 @@
             "description": "Open search window"
         }
     },
-    "web_accessible_resources": ["fg/float.html"],
+    "web_accessible_resources": [
+        "fg/float.html"
+    ],
     "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
     "applications": {
         "gecko": {

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -10,7 +10,7 @@
         "32": "mixed/img/icon32.png",
         "38": "mixed/img/icon38.png",
         "48": "mixed/img/icon48.png",
-        "64": "mixed/img/icon48.png",
+        "64": "mixed/img/icon64.png",
         "128": "mixed/img/icon128.png"
     },
     "browser_action": {
@@ -20,7 +20,7 @@
             "32": "mixed/img/icon32.png",
             "38": "mixed/img/icon38.png",
             "48": "mixed/img/icon48.png",
-            "64": "mixed/img/icon48.png",
+            "64": "mixed/img/icon64.png",
             "128": "mixed/img/icon128.png"
         },
         "default_title": "Yomichan",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
         "test": "test"
     },
     "scripts": {
+        "build": "node ./dev/build.js",
         "test": "npm run test-lint && npm run test-code",
         "test-lint": "eslint . && node ./test/lint/global-declarations.js",
         "test-code": "node ./test/test-schema.js && node ./test/test-dictionary.js && node ./test/test-database.js && node ./test/test-document.js && node ./test/test-object-property-accessor.js && node ./test/test-japanese.js && node ./test/test-text-source-map.js && node ./test/test-dom-text-scanner.js"

--- a/package.json
+++ b/package.json
@@ -7,9 +7,10 @@
     },
     "scripts": {
         "build": "node ./dev/build.js",
-        "test": "npm run test-lint && npm run test-code",
+        "test": "npm run test-lint && npm run test-code && npm run test-manifest",
         "test-lint": "eslint . && node ./test/lint/global-declarations.js",
-        "test-code": "node ./test/test-schema.js && node ./test/test-dictionary.js && node ./test/test-database.js && node ./test/test-document.js && node ./test/test-object-property-accessor.js && node ./test/test-japanese.js && node ./test/test-text-source-map.js && node ./test/test-dom-text-scanner.js"
+        "test-code": "node ./test/test-schema.js && node ./test/test-dictionary.js && node ./test/test-database.js && node ./test/test-document.js && node ./test/test-object-property-accessor.js && node ./test/test-japanese.js && node ./test/test-text-source-map.js && node ./test/test-dom-text-scanner.js",
+        "test-manifest": "node ./test/test-manifest.js"
     },
     "repository": {
         "type": "git",

--- a/test/test-manifest.js
+++ b/test/test-manifest.js
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const {loadDefaultManifest, createManifestString} = require('../dev/build');
+
+
+function loadManifestString() {
+    const manifestPath = path.join(__dirname, '..', 'ext', 'manifest.json');
+    return fs.readFileSync(manifestPath, {encoding: 'utf8'});
+}
+
+function validateManifest() {
+    const manifest1 = loadManifestString();
+    const manifest2 = createManifestString(loadDefaultManifest());
+    assert.strictEqual(manifest1, manifest2, 'Manifest data does not match.');
+}
+
+
+function main() {
+    validateManifest();
+}
+
+
+if (require.main === module) { main(); }


### PR DESCRIPTION
The intent of this change is to set up build system which is simple yet flexible enough to accommodate future needs ([example](https://github.com/FooSoft/yomichan/pull/612#issue-435533656)). This can hopefully remove the need to have the testing and master branch history be divergent as it currently is; I think the reason behind that is so that the manifest.json metadata can be different on both branches.

I am requesting @FooSoft to review this, as you are in charge of creating and deploying builds. I want to make sure any changes I make will still work for your release workflow, and I can make changes as necessary.

* manifest.json style updated to use standard format as output by `JSON.stringify`, for simplicity. This mainly involved some newline and indentation changes, and the `"author"` field was moved to the top for better organization.

* Changed end-of-line convention for some files, for better consistency across different operating systems and development environments.

* Created a simple build.js script, which creates build variants. Currently, it creates four files:
  * yomichan.zip
  * yomichan.xpi
  * yomichan-dev.zip
  * yomichan-dev.xpi

  Currently, there is no difference in the contents of the zip files except for the manifest. Certain modifications are made to the manifest based on the build target. Currently, this just changes the `name`, `description`, and `applications.gecko.id` fields, but in the future, this may do other modifications as well (including/omitting files, manifest v2, browser-specific builds).

  The *.xpi files are copies of their .zip counterparts, which are helpful for testing Firefox builds on certain devices which don't like using .zip files.

* Builds are created using 7-zip (either 7za or 7z executable), the same as the old build_zip.sh file. If neither executable is available, the build system falls back to building using the included JSZip library. Note that when JSZip is used, the resulting file size is a bit larger.

* Builds are created in a "builds" directory, which is ignored by git.

* Added build commands. The following can be used:
  * `node ./dev/build.js` (use \ slash on Windows)
  * `npm run-script build`
  * `./build.sh`
  * `.\build.bat`

* Removed build_zip.sh, as new build commands should be used instead.

### Potential downsides

The extension manifest data now exists in two locations: the standard manifest.json, and the build script's manifest-variants.json. This creates a redundancy which could be confusing and maybe a cause of developer error (putting changes in the wrong file). The manifest file that should be changed is the manifest-variants.json one, which then propagates its changes to the main manifest.json upon building. When changing the manifest, both changes should be made in the same commit (or PR).

There should be some red flags if something is not done correctly, such as git listing diffs that the developer didn't explicitly make. That is, if a change is made to manifest.json and committed, a subsequent `build` command will revert that, indicating that something was done wrong.

So this isn't really a problem per se, just something that has to be known about in order to make updates correctly. At some point, I may add a development guidelines and information file to the project to address things like this.