### PR TITLE
JSON schema refactor

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -25,6 +25,7 @@
  * DictionaryImporter
  * Environment
  * JsonSchema
+ * JsonSchemaProxyHandler
  * Mecab
  * ObjectPropertyAccessor
  * OptionsUtil
@@ -48,6 +49,7 @@ class Backend {
         this._clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
         this._options = null;
         this._optionsSchema = null;
+        this._optionsSchemaValidator = new JsonSchemaProxyHandler();
         this._defaultAnkiFieldTemplates = null;
         this._requestBuilder = new RequestBuilder();
         this._audioUriBuilder = new AudioUriBuilder({
@@ -235,7 +237,7 @@ class Backend {
 
     getFullOptions(useSchema=false) {
         const options = this._options;
-        return useSchema ? JsonSchema.createProxy(options, this._optionsSchema) : options;
+        return useSchema ? this._optionsSchemaValidator.createProxy(options, this._optionsSchema) : options;
     }
 
     getOptions(optionsContext, useSchema=false) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -24,7 +24,7 @@
  * DictionaryDatabase
  * DictionaryImporter
  * Environment
- * JsonSchemaProxyHandler
+ * JsonSchemaValidator
  * Mecab
  * ObjectPropertyAccessor
  * OptionsUtil
@@ -48,7 +48,7 @@ class Backend {
         this._clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
         this._options = null;
         this._optionsSchema = null;
-        this._optionsSchemaValidator = new JsonSchemaProxyHandler();
+        this._optionsSchemaValidator = new JsonSchemaValidator();
         this._defaultAnkiFieldTemplates = null;
         this._requestBuilder = new RequestBuilder();
         this._audioUriBuilder = new AudioUriBuilder({

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -24,7 +24,6 @@
  * DictionaryDatabase
  * DictionaryImporter
  * Environment
- * JsonSchema
  * JsonSchemaProxyHandler
  * Mecab
  * ObjectPropertyAccessor
@@ -206,7 +205,7 @@ class Backend {
             this._optionsSchema = await this._fetchAsset('/bg/data/options-schema.json', true);
             this._defaultAnkiFieldTemplates = (await this._fetchAsset('/bg/data/default-anki-field-templates.handlebars')).trim();
             this._options = await OptionsUtil.load();
-            this._options = JsonSchema.getValidValueOrDefault(this._optionsSchema, this._options);
+            this._options = this._optionsSchemaValidator.getValidValueOrDefault(this._optionsSchema, this._options);
 
             this._applyOptions('background');
 
@@ -794,7 +793,7 @@ class Backend {
     }
 
     async _onApiSetAllSettings({value, source}) {
-        this._options = JsonSchema.getValidValueOrDefault(this._optionsSchema, value);
+        this._options = this._optionsSchemaValidator.getValidValueOrDefault(this._optionsSchema, value);
         await this._onApiOptionsSave({source});
     }
 

--- a/ext/bg/js/dictionary-importer.js
+++ b/ext/bg/js/dictionary-importer.js
@@ -17,13 +17,14 @@
 
 /* global
  * JSZip
- * JsonSchema
+ * JsonSchemaValidator
  * mediaUtility
  */
 
 class DictionaryImporter {
     constructor() {
         this._schemas = new Map();
+        this._jsonSchemaValidator = new JsonSchemaValidator();
     }
 
     async importDictionary(dictionaryDatabase, archiveSource, details, onProgress) {
@@ -241,7 +242,7 @@ class DictionaryImporter {
 
     _validateJsonSchema(value, schema, fileName) {
         try {
-            JsonSchema.validate(value, schema);
+            this._jsonSchemaValidator.validate(value, schema);
         } catch (e) {
             throw this._formatSchemaError(e, fileName);
         }

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -694,13 +694,3 @@ class JsonSchemaValidationError extends Error {
         this.info = info;
     }
 }
-
-class JsonSchema {
-    static validate(value, schema) {
-        return new JsonSchemaValidator().validate(value, schema);
-    }
-
-    static getValidValueOrDefault(schema, value) {
-        return new JsonSchemaValidator().getValidValueOrDefault(schema, value);
-    }
-}

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -172,7 +172,11 @@ class JsonSchemaValidator {
         return value;
     }
 
-    getPropertySchema(schema, property, value, path=null) {
+    getPropertySchema(schema, property, value) {
+        return this._getPropertySchema(schema, property, value, null);
+    }
+
+    _getPropertySchema(schema, property, value, path) {
         const type = this.getSchemaOrValueType(schema, value);
         switch (type) {
             case 'object':
@@ -458,7 +462,7 @@ class JsonSchemaValidator {
 
         for (let i = 0, ii = value.length; i < ii; ++i) {
             const schemaPath = [];
-            const propertySchema = this.getPropertySchema(schema, i, value, schemaPath);
+            const propertySchema = this._getPropertySchema(schema, i, value, schemaPath);
             if (propertySchema === null) {
                 throw new JsonSchemaValidationError(`No schema found for array[${i}]`, value, schema, info);
             }
@@ -517,7 +521,7 @@ class JsonSchemaValidator {
 
         for (const property of properties) {
             const schemaPath = [];
-            const propertySchema = this.getPropertySchema(schema, property, value, schemaPath);
+            const propertySchema = this._getPropertySchema(schema, property, value, schemaPath);
             if (propertySchema === null) {
                 throw new JsonSchemaValidationError(`No schema found for ${property}`, value, schema, info);
             }
@@ -604,14 +608,14 @@ class JsonSchemaValidator {
             for (const property of required) {
                 properties.delete(property);
 
-                const propertySchema = this.getPropertySchema(schema, property, value);
+                const propertySchema = this._getPropertySchema(schema, property, value, null);
                 if (propertySchema === null) { continue; }
                 value[property] = this.getValidValueOrDefault(propertySchema, value[property]);
             }
         }
 
         for (const property of properties) {
-            const propertySchema = this.getPropertySchema(schema, property, value);
+            const propertySchema = this._getPropertySchema(schema, property, value, null);
             if (propertySchema === null) {
                 Reflect.deleteProperty(value, property);
             } else {
@@ -624,7 +628,7 @@ class JsonSchemaValidator {
 
     populateArrayDefaults(value, schema) {
         for (let i = 0, ii = value.length; i < ii; ++i) {
-            const propertySchema = this.getPropertySchema(schema, i, value);
+            const propertySchema = this._getPropertySchema(schema, i, value, null);
             if (propertySchema === null) { continue; }
             value[i] = this.getValidValueOrDefault(propertySchema, value[i]);
         }

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -132,6 +132,15 @@ class JsonSchemaValidator {
         return new Proxy(target, new JsonSchemaProxyHandler(schema, this));
     }
 
+    isValid(value, schema) {
+        try {
+            this.validate(value, schema);
+            return true;
+        } catch (e) {
+            return false;
+        }
+    }
+
     validate(value, schema) {
         const info = new JsonSchemaTraversalInfo(value, schema);
         this._validate(value, schema, info);

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -155,7 +155,7 @@ class JsonSchemaValidator {
             }
 
             if (assignDefault) {
-                value = this.getDefaultTypeValue(schemaType);
+                value = this._getDefaultTypeValue(schemaType);
                 type = this._getValueType(value);
             }
         }
@@ -581,7 +581,7 @@ class JsonSchemaValidator {
         return value1 === value2;
     }
 
-    getDefaultTypeValue(type) {
+    _getDefaultTypeValue(type) {
         if (typeof type === 'string') {
             switch (type) {
                 case 'null':

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -73,7 +73,7 @@ class JsonSchemaProxyHandler {
         }
 
         const value = target[property];
-        return value !== null && typeof value === 'object' ? JsonSchema.createProxy(value, propertySchema) : value;
+        return value !== null && typeof value === 'object' ? this._jsonSchemaValidator.createProxy(value, propertySchema) : value;
     }
 
     set(target, property, value) {
@@ -126,6 +126,10 @@ class JsonSchemaProxyHandler {
 class JsonSchemaValidator {
     constructor() {
         this._regexCache = new CacheMap(100, (pattern, flags) => new RegExp(pattern, flags));
+    }
+
+    createProxy(target, schema) {
+        return new Proxy(target, new JsonSchemaProxyHandler(schema, this));
     }
 
     getPropertySchema(schema, property, value, path=null) {
@@ -681,11 +685,6 @@ class JsonSchemaValidationError extends Error {
 }
 
 class JsonSchema {
-    static createProxy(target, schema) {
-        const validator = new JsonSchemaValidator();
-        return new Proxy(target, new JsonSchemaProxyHandler(schema, validator));
-    }
-
     static validate(value, schema) {
         return new JsonSchemaValidator().validate(value, schema, new JsonSchemaTraversalInfo(value, schema));
     }

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -94,7 +94,7 @@ class JsonSchemaProxyHandler {
             throw new Error(`Property ${property} not supported`);
         }
 
-        value = JsonSchema.clone(value);
+        value = clone(value);
 
         this._jsonSchemaValidator.validate(value, propertySchema, new JsonSchemaTraversalInfo(value, propertySchema));
 
@@ -569,7 +569,7 @@ class JsonSchemaValidator {
 
             const schemaDefault = schema.default;
             if (typeof schemaDefault !== 'undefined') {
-                value = JsonSchema.clone(schemaDefault);
+                value = clone(schemaDefault);
                 type = this.getValueType(value);
                 assignDefault = !this.isValueTypeAny(value, type, schemaType);
             }
@@ -692,9 +692,5 @@ class JsonSchema {
 
     static getValidValueOrDefault(schema, value) {
         return new JsonSchemaValidator().getValidValueOrDefault(schema, value);
-    }
-
-    static clone(value) {
-        return clone(value);
     }
 }

--- a/test/dictionary-validate.js
+++ b/test/dictionary-validate.js
@@ -26,7 +26,7 @@ vm.execute([
     'mixed/js/cache-map.js',
     'bg/js/json-schema.js'
 ]);
-const JsonSchema = vm.get('JsonSchema');
+const JsonSchemaValidator = vm.get('JsonSchemaValidator');
 
 
 function readSchema(relativeFileName) {
@@ -45,7 +45,7 @@ async function validateDictionaryBanks(zip, fileNameFormat, schema) {
         if (!file) { break; }
 
         const data = JSON.parse(await file.async('string'));
-        JsonSchema.validate(data, schema);
+        new JsonSchemaValidator().validate(data, schema);
 
         ++index;
     }
@@ -60,7 +60,7 @@ async function validateDictionary(archive, schemas) {
     const index = JSON.parse(await indexFile.async('string'));
     const version = index.format || index.version;
 
-    JsonSchema.validate(index, schemas.index);
+    new JsonSchemaValidator().validate(index, schemas.index);
 
     await validateDictionaryBanks(archive, 'term_bank_?.json', version === 1 ? schemas.termBankV1 : schemas.termBankV3);
     await validateDictionaryBanks(archive, 'term_meta_bank_?.json', schemas.termMetaBankV3);

--- a/test/schema-validate.js
+++ b/test/schema-validate.js
@@ -24,7 +24,7 @@ vm.execute([
     'mixed/js/cache-map.js',
     'bg/js/json-schema.js'
 ]);
-const JsonSchema = vm.get('JsonSchema');
+const JsonSchemaValidator = vm.get('JsonSchemaValidator');
 
 
 function main() {
@@ -45,7 +45,7 @@ function main() {
             console.log(`Validating ${dataFileName}...`);
             const dataSource = fs.readFileSync(dataFileName, {encoding: 'utf8'});
             const data = JSON.parse(dataSource);
-            JsonSchema.validate(data, schema);
+            new JsonSchemaValidator().validate(data, schema);
             console.log('No issues found');
         } catch (e) {
             console.warn(e);

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -24,7 +24,7 @@ vm.execute([
     'mixed/js/cache-map.js',
     'bg/js/json-schema.js'
 ]);
-const JsonSchema = vm.get('JsonSchema');
+const JsonSchemaValidator = vm.get('JsonSchemaValidator');
 
 
 function testValidate1() {
@@ -55,7 +55,7 @@ function testValidate1() {
 
     const schemaValidate = (value) => {
         try {
-            JsonSchema.validate(value, schema);
+            new JsonSchemaValidator().validate(value, schema);
             return true;
         } catch (e) {
             return false;
@@ -396,7 +396,7 @@ function testValidate2() {
 
     const schemaValidate = (value, schema) => {
         try {
-            JsonSchema.validate(value, schema);
+            new JsonSchemaValidator().validate(value, schema);
             return true;
         } catch (e) {
             return false;
@@ -555,7 +555,7 @@ function testGetValidValueOrDefault1() {
 
     for (const {schema, inputs} of data) {
         for (const [value, expected] of inputs) {
-            const actual = JsonSchema.getValidValueOrDefault(schema, value);
+            const actual = new JsonSchemaValidator().getValidValueOrDefault(schema, value);
             vm.assert.deepStrictEqual(actual, expected);
         }
     }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -54,12 +54,7 @@ function testValidate1() {
     };
 
     const schemaValidate = (value) => {
-        try {
-            new JsonSchemaValidator().validate(value, schema);
-            return true;
-        } catch (e) {
-            return false;
-        }
+        return new JsonSchemaValidator().isValid(value, schema);
     };
 
     const jsValidate = (value) => {
@@ -395,12 +390,7 @@ function testValidate2() {
     ];
 
     const schemaValidate = (value, schema) => {
-        try {
-            new JsonSchemaValidator().validate(value, schema);
-            return true;
-        } catch (e) {
-            return false;
-        }
+        return new JsonSchemaValidator().isValid(value, schema);
     };
 
     for (const {schema, inputs} of data) {


### PR DESCRIPTION
* Use `JsonSchemaValidator` instead of static `JsonSchema` class.
* Use private functions.
* Better reuse of `JsonSchemaValidator` for child proxies.