### PR TITLE
Move findTerms and findKanji functions into TextScanner

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -255,7 +255,10 @@ class Frontend {
             modifier: scanningOptions.modifier,
             useMiddleMouse: scanningOptions.middleMouse,
             delay: scanningOptions.delay,
-            touchInputEnabled: scanningOptions.touchInputEnabled
+            touchInputEnabled: scanningOptions.touchInputEnabled,
+            scanLength: scanningOptions.length,
+            sentenceExtent: options.anki.sentenceExt,
+            layoutAwareScan: scanningOptions.layoutAwareScan
         });
         this._updateTextScannerEnabled();
 
@@ -376,8 +379,8 @@ class Frontend {
             if (textSource !== null) {
                 const optionsContext = await this.getOptionsContext();
                 results = (
-                    await this._findTerms(textSource, optionsContext) ||
-                    await this._findKanji(textSource, optionsContext)
+                    await this._textScanner.findTerms(textSource, optionsContext) ||
+                    await this._textScanner.findKanji(textSource, optionsContext)
                 );
                 if (results !== null) {
                     const focus = (cause === 'mouse');
@@ -399,32 +402,6 @@ class Frontend {
         }
 
         return results;
-    }
-
-    async _findTerms(textSource, optionsContext) {
-        const {length: scanLength, layoutAwareScan} = this._options.scanning;
-        const searchText = this._textScanner.getTextSourceContent(textSource, scanLength, layoutAwareScan);
-        if (searchText.length === 0) { return null; }
-
-        const {definitions, length} = await api.termsFind(searchText, {}, optionsContext);
-        if (definitions.length === 0) { return null; }
-
-        textSource.setEndOffset(length, layoutAwareScan);
-
-        return {definitions, type: 'terms'};
-    }
-
-    async _findKanji(textSource, optionsContext) {
-        const layoutAwareScan = this._options.scanning.layoutAwareScan;
-        const searchText = this._textScanner.getTextSourceContent(textSource, 1, layoutAwareScan);
-        if (searchText.length === 0) { return null; }
-
-        const definitions = await api.kanjiFind(searchText, optionsContext);
-        if (definitions.length === 0) { return null; }
-
-        textSource.setEndOffset(1, layoutAwareScan);
-
-        return {definitions, type: 'kanji'};
     }
 
     async _showExtensionUnloaded(textSource) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -228,9 +228,6 @@ class Display extends EventDispatcher {
 
         this._queryParser.setOptions({
             selectedParser: options.parsing.selectedParser,
-            scanLength: scanning.length,
-            sentenceExtent: options.anki.sentenceExt,
-            layoutAwareScan: scanning.layoutAwareScan,
             termSpacing: options.parsing.termSpacing,
             scanning: {
                 deepContentScan: scanning.deepDomScan,
@@ -238,7 +235,10 @@ class Display extends EventDispatcher {
                 modifier: scanning.modifier,
                 useMiddleMouse: scanning.middleMouse,
                 delay: scanning.delay,
-                touchInputEnabled: scanning.touchInputEnabled
+                touchInputEnabled: scanning.touchInputEnabled,
+                scanLength: scanning.length,
+                sentenceExtent: options.anki.sentenceExt,
+                layoutAwareScan: scanning.layoutAwareScan
             }
         });
     }


### PR DESCRIPTION
Very similar code for the `findTerms` function was shared by `Frontend` and `QueryParser`, so both functions are now moved so that they can actually be shared.