### PR TITLE
Move generateId to core.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -107,6 +107,7 @@
                 "escapeRegExp": "readonly",
                 "deferPromise": "readonly",
                 "clone": "readonly",
+                "generateId": "readonly",
                 "EventDispatcher": "readonly",
                 "EventListenerCollection": "readonly"
             }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -739,7 +739,7 @@ class Backend {
         if (typeof tabId !== 'number') { throw new Error('Sender has invalid tab ID'); }
 
         const frameId = sender.frameId;
-        const id = yomichan.generateId(16);
+        const id = generateId(16);
         const details = {
             name: 'action-port',
             id

--- a/ext/bg/js/settings/settings-controller.js
+++ b/ext/bg/js/settings/settings-controller.js
@@ -25,7 +25,7 @@ class SettingsController extends EventDispatcher {
     constructor(profileIndex=0) {
         super();
         this._profileIndex = profileIndex;
-        this._source = yomichan.generateId(16);
+        this._source = generateId(16);
         this._pageExitPreventions = new Set();
         this._pageExitPreventionEventListeners = new EventListenerCollection();
     }

--- a/ext/fg/js/frame-offset-forwarder.js
+++ b/ext/fg/js/frame-offset-forwarder.js
@@ -42,7 +42,7 @@ class FrameOffsetForwarder {
             return [0, 0];
         }
 
-        const uniqueId = yomichan.generateId(16);
+        const uniqueId = generateId(16);
 
         const frameOffsetPromise = yomichan.getTemporaryListenerResult(
             chrome.runtime.onMessage,

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -33,7 +33,7 @@ class Frontend {
         isSearchPage,
         allowRootFramePopupProxy
     }) {
-        this._id = yomichan.generateId(16);
+        this._id = generateId(16);
         this._popup = null;
         this._disabledOverride = false;
         this._options = null;

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -86,7 +86,7 @@ class PopupFactory {
         if (frameId === this._frameId) {
             // New unique id
             if (id === null) {
-                id = yomichan.generateId(16);
+                id = generateId(16);
             }
             const popup = new Popup(id, depth, frameId, ownerFrameId);
             if (parent !== null) {

--- a/ext/mixed/js/core.js
+++ b/ext/mixed/js/core.js
@@ -197,6 +197,16 @@ if (typeof window === 'object' && window !== null) {
     window.clone = clone;
 }
 
+function generateId(length) {
+    const array = new Uint8Array(length);
+    crypto.getRandomValues(array);
+    let id = '';
+    for (const value of array) {
+        id += value.toString(16).padStart(2, '0');
+    }
+    return id;
+}
+
 
 /*
  * Async utilities

--- a/ext/mixed/js/display-history.js
+++ b/ext/mixed/js/display-history.js
@@ -166,7 +166,7 @@ class DisplayHistory extends EventDispatcher {
     }
 
     _generateId() {
-        return yomichan.generateId(16);
+        return generateId(16);
     }
 
     _clear() {

--- a/ext/mixed/js/frame-client.js
+++ b/ext/mixed/js/frame-client.js
@@ -90,7 +90,7 @@ class FrameClient {
                         case 'frameEndpointReady':
                             {
                                 const {secret} = params;
-                                const token = yomichan.generateId(16);
+                                const token = generateId(16);
                                 tokenMap.set(secret, token);
                                 postMessage('frameEndpointConnect', {secret, token, hostFrameId});
                             }

--- a/ext/mixed/js/frame-endpoint.js
+++ b/ext/mixed/js/frame-endpoint.js
@@ -21,7 +21,7 @@
 
 class FrameEndpoint {
     constructor() {
-        this._secret = yomichan.generateId(16);
+        this._secret = generateId(16);
         this._token = null;
         this._eventListeners = new EventListenerCollection();
         this._eventListenersSetup = false;

--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -84,16 +84,6 @@ const yomichan = (() => {
             this.sendMessage({action: 'yomichanReady'});
         }
 
-        generateId(length) {
-            const array = new Uint8Array(length);
-            crypto.getRandomValues(array);
-            let id = '';
-            for (const value of array) {
-                id += value.toString(16).padStart(2, '0');
-            }
-            return id;
-        }
-
         isExtensionUrl(url) {
             try {
                 return url.startsWith(chrome.runtime.getURL('/'));


### PR DESCRIPTION
Function doesn't need to be tied to the `yomichan` object instance. Moving it allows it to be used in core.js, if necessary.