### PR TITLE
Fix screenshot popup hide

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -108,11 +108,13 @@ class Frontend {
         this._textScanner.on('activeModifiersChanged', this._onActiveModifiersChanged.bind(this));
 
         api.crossFrame.registerHandlers([
-            ['getUrl',                 {async: false, handler: this._onApiGetUrl.bind(this)}],
-            ['closePopup',             {async: false, handler: this._onApiClosePopup.bind(this)}],
-            ['copySelection',          {async: false, handler: this._onApiCopySelection.bind(this)}],
-            ['getPopupInfo',           {async: false, handler: this._onApiGetPopupInfo.bind(this)}],
-            ['getDocumentInformation', {async: false, handler: this._onApiGetDocumentInformation.bind(this)}]
+            ['getUrl',                  {async: false, handler: this._onApiGetUrl.bind(this)}],
+            ['closePopup',              {async: false, handler: this._onApiClosePopup.bind(this)}],
+            ['copySelection',           {async: false, handler: this._onApiCopySelection.bind(this)}],
+            ['getPopupInfo',            {async: false, handler: this._onApiGetPopupInfo.bind(this)}],
+            ['getDocumentInformation',  {async: false, handler: this._onApiGetDocumentInformation.bind(this)}],
+            ['setAllVisibleOverride',   {async: true,  handler: this._onApiSetAllVisibleOverride.bind(this)}],
+            ['clearAllVisibleOverride', {async: true,  handler: this._onApiClearAllVisibleOverride.bind(this)}]
         ]);
 
         this._updateContentScale();
@@ -194,6 +196,14 @@ class Frontend {
         return {
             title: document.title
         };
+    }
+
+    async _onApiSetAllVisibleOverride({value, priority}) {
+        return await this._popupFactory.setAllVisibleOverride(value, priority);
+    }
+
+    async _onApiClearAllVisibleOverride({token}) {
+        return await this._popupFactory.clearAllVisibleOverride(token);
     }
 
     // Private

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -192,8 +192,12 @@ class Frontend {
         };
     }
 
-    async _onApiSetAllVisibleOverride({value, priority}) {
-        return await this._popupFactory.setAllVisibleOverride(value, priority);
+    async _onApiSetAllVisibleOverride({value, priority, awaitFrame}) {
+        const result = await this._popupFactory.setAllVisibleOverride(value, priority);
+        if (awaitFrame) {
+            await promiseAnimationFrame(100);
+        }
+        return result;
     }
 
     async _onApiClearAllVisibleOverride({token}) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -62,7 +62,6 @@ class Frontend {
         this._updatePopupToken = null;
 
         this._runtimeMessageHandlers = new Map([
-            ['popupSetVisibleOverride',              {async: false, handler: this._onMessagePopupSetVisibleOverride.bind(this)}],
             ['requestFrontendReadyBroadcast',        {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}]
         ]);
     }
@@ -162,11 +161,6 @@ class Frontend {
     }
 
     // Message handlers
-
-    _onMessagePopupSetVisibleOverride({visible}) {
-        if (this._popup === null) { return; }
-        this._popup.setVisibleOverride(visible);
-    }
 
     _onMessageRequestFrontendReadyBroadcast({frameId}) {
         this._signalFrontendReady(frameId);

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -39,6 +39,7 @@ class PopupFactory {
             ['hide',                 {async: false, handler: this._onApiHide.bind(this)}],
             ['isVisible',            {async: true,  handler: this._onApiIsVisibleAsync.bind(this)}],
             ['setVisibleOverride',   {async: true,  handler: this._onApiSetVisibleOverride.bind(this)}],
+            ['clearVisibleOverride', {async: true,  handler: this._onApiClearVisibleOverride.bind(this)}],
             ['containsPoint',        {async: true,  handler: this._onApiContainsPoint.bind(this)}],
             ['showContent',          {async: true,  handler: this._onApiShowContent.bind(this)}],
             ['setCustomCss',         {async: false, handler: this._onApiSetCustomCss.bind(this)}],
@@ -134,9 +135,14 @@ class PopupFactory {
         return await popup.isVisible();
     }
 
-    async _onApiSetVisibleOverride({id, visible}) {
+    async _onApiSetVisibleOverride({id, value, priority}) {
         const popup = this._getPopup(id);
-        return await popup.setVisibleOverride(visible);
+        return await popup.setVisibleOverride(value, priority);
+    }
+
+    async _onApiClearVisibleOverride({id, token}) {
+        const popup = this._getPopup(id);
+        return await popup.clearVisibleOverride(token);
     }
 
     async _onApiContainsPoint({id, x, y}) {

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -86,8 +86,12 @@ class PopupProxy extends EventDispatcher {
         return this._invokeSafe('isVisible', {id: this._id}, false);
     }
 
-    setVisibleOverride(visible) {
-        return this._invokeSafe('setVisibleOverride', {id: this._id, visible});
+    async setVisibleOverride(value, priority) {
+        return this._invokeSafe('setVisibleOverride', {id: this._id, value, priority});
+    }
+
+    async clearVisibleOverride(token) {
+        return this._invokeSafe('clearVisibleOverride', {id: this._id, token});
     }
 
     async containsPoint(x, y) {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -95,11 +95,12 @@ class Popup extends EventDispatcher {
     // Public functions
 
     prepare() {
-        this._updateVisibility();
         this._frame.addEventListener('mousedown', (e) => e.stopPropagation());
         this._frame.addEventListener('scroll', (e) => e.stopPropagation());
         this._frame.addEventListener('load', this._onFrameLoad.bind(this));
+        this._visible.on('change', this._onVisibleChange.bind(this));
         yomichan.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
+        this._onVisibleChange({value: this.isVisibleSync()});
     }
 
     async setOptionsContext(optionsContext, source) {
@@ -131,9 +132,7 @@ class Popup extends EventDispatcher {
     }
 
     async setVisibleOverride(value, priority) {
-        const token = this._visible.setOverride(value, priority);
-        this._updateVisibility();
-        return token;
+        return this._visible.setOverride(value, priority);
     }
 
     async clearVisibleOverride(token) {
@@ -397,11 +396,10 @@ class Popup extends EventDispatcher {
 
     _setVisible(visible) {
         this._visible.defaultValue = visible;
-        this._updateVisibility();
     }
 
-    _updateVisibility() {
-        this._frame.style.setProperty('visibility', this.isVisibleSync() ? 'visible' : 'hidden', 'important');
+    _onVisibleChange({value}) {
+        this._frame.style.setProperty('visibility', value ? 'visible' : 'hidden', 'important');
     }
 
     _focusParent() {

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -34,8 +34,7 @@ class Popup extends EventDispatcher {
         this._childrenSupported = true;
         this._injectPromise = null;
         this._injectPromiseComplete = false;
-        this._visible = false;
-        this._visibleOverride = null;
+        this._visible = new DynamicProperty(false);
         this._options = null;
         this._optionsContext = null;
         this._contentScale = 1.0;
@@ -131,9 +130,14 @@ class Popup extends EventDispatcher {
         return this.isVisibleSync();
     }
 
-    setVisibleOverride(visible) {
-        this._visibleOverride = visible;
+    async setVisibleOverride(value, priority) {
+        const token = this._visible.setOverride(value, priority);
         this._updateVisibility();
+        return token;
+    }
+
+    async clearVisibleOverride(token) {
+        return this._visible.clearOverride(token);
     }
 
     async containsPoint(x, y) {
@@ -177,7 +181,7 @@ class Popup extends EventDispatcher {
     }
 
     isVisibleSync() {
-        return (this._visibleOverride !== null ? this._visibleOverride : this._visible);
+        return this._visible.value;
     }
 
     updateTheme() {
@@ -392,7 +396,7 @@ class Popup extends EventDispatcher {
     }
 
     _setVisible(visible) {
-        this._visible = visible;
+        this._visible.defaultValue = visible;
         this._updateVisibility();
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1145,9 +1145,12 @@ class Display extends EventDispatcher {
     }
 
     async _getScreenshot() {
+        const ownerFrameId = this._ownerFrameId;
+        let token = null;
         try {
-            await this._setPopupVisibleOverride(false);
-            await promiseTimeout(1); // Wait for popup to be hidden.
+            if (ownerFrameId !== null) {
+                token = await api.crossFrame.invoke(ownerFrameId, 'setAllVisibleOverride', {value: false, priority: 0});
+            }
 
             const {format, quality} = this._options.anki.screenshot;
             const dataUrl = await api.screenshotGet({format, quality});
@@ -1155,16 +1158,14 @@ class Display extends EventDispatcher {
 
             return {dataUrl, format};
         } finally {
-            await this._setPopupVisibleOverride(null);
+            if (token !== null) {
+                await api.crossFrame.invoke(ownerFrameId, 'clearAllVisibleOverride', {token});
+            }
         }
     }
 
     _getFirstExpressionIndex() {
         return this._options.general.resultOutputMode === 'merge' ? 0 : -1;
-    }
-
-    _setPopupVisibleOverride(visible) {
-        return api.broadcastTab('popupSetVisibleOverride', {visible});
     }
 
     _getEntry(index) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1149,7 +1149,7 @@ class Display extends EventDispatcher {
         let token = null;
         try {
             if (ownerFrameId !== null) {
-                token = await api.crossFrame.invoke(ownerFrameId, 'setAllVisibleOverride', {value: false, priority: 0});
+                token = await api.crossFrame.invoke(ownerFrameId, 'setAllVisibleOverride', {value: false, priority: 0, awaitFrame: true});
             }
 
             const {format, quality} = this._options.anki.screenshot;


### PR DESCRIPTION
This change updates how popup visibility overrides are handled. Visibility is now tracked using `DynamicProperty`, meaning overrides are handled more flexibly. Additionally, `PopupFactory` can now apply overrides to all popups with a single function call.

Popup visibility changes during screenshots are now applied directly to the owner frame using `api.crossFrame`, meaning that the resulting change can be awaited. In addition, there is an `await` for the next animation frame, which should ensure that the CSS changes are actually applied when creating the screenshot.

Since a broadcast message for the entire tab is no longer used to hide popups, this means that a card being created from a nested popup will capture the parent popup in the screenshot. This should be a better behaviour; previously, the source term might not have appeared anywhere in the screenshot under these conditions.

Fixes #741.