### PR TITLE
Fix sessionStorage not being supported when cookies are disabled

### DIFF
--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1323,7 +1323,7 @@ class Display extends EventDispatcher {
         try {
             mode = sessionStorage.getItem('mode');
         } catch (e) {
-            // Chromium-based browsers can throw an "Access is denied for this document." error when cookie blocking is enabled.
+            // Browsers can throw a SecurityError when cookie blocking is enabled.
         }
         this._setMode(mode, false);
     }
@@ -1338,7 +1338,7 @@ class Display extends EventDispatcher {
                     sessionStorage.setItem('mode', mode);
                 }
             } catch (e) {
-                // Chromium-based browsers can throw an "Access is denied for this document." error when cookie blocking is enabled.
+                // Browsers can throw a SecurityError when cookie blocking is enabled.
             }
         }
         this._mode = mode;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1319,17 +1319,26 @@ class Display extends EventDispatcher {
     }
 
     _updateMode() {
-        const mode = sessionStorage.getItem('mode');
+        let mode = null;
+        try {
+            mode = sessionStorage.getItem('mode');
+        } catch (e) {
+            // Chromium-based browsers can throw an "Access is denied for this document." error when cookie blocking is enabled.
+        }
         this._setMode(mode, false);
     }
 
     _setMode(mode, save) {
         if (mode === this._mode) { return; }
         if (save) {
-            if (mode === null) {
-                sessionStorage.removeItem('mode');
-            } else {
-                sessionStorage.setItem('mode', mode);
+            try {
+                if (mode === null) {
+                    sessionStorage.removeItem('mode');
+                } else {
+                    sessionStorage.setItem('mode', mode);
+                }
+            } catch (e) {
+                // Chromium-based browsers can throw an "Access is denied for this document." error when cookie blocking is enabled.
             }
         }
         this._mode = mode;


### PR DESCRIPTION
Fixes #754. [See docs](https://developer.mozilla.org/en-US/docs/Web/API/Window/sessionStorage).