### PR TITLE
Settings dictionary import refactor

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -16,7 +16,6 @@
         <textarea id="clipboard-paste-target"></textarea>
 
         <script src="/mixed/lib/handlebars.min.js"></script>
-        <script src="/mixed/lib/jszip.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/core.js"></script>
@@ -33,10 +32,8 @@
         <script src="/bg/js/conditions.js"></script>
         <script src="/bg/js/database.js"></script>
         <script src="/bg/js/dictionary-database.js"></script>
-        <script src="/bg/js/dictionary-importer.js"></script>
         <script src="/bg/js/deinflector.js"></script>
         <script src="/bg/js/json-schema.js"></script>
-        <script src="/bg/js/media-utility.js"></script>
         <script src="/bg/js/options.js"></script>
         <script src="/bg/js/profile-conditions.js"></script>
         <script src="/bg/js/request-builder.js"></script>

--- a/ext/bg/css/settings.css
+++ b/ext/bg/css/settings.css
@@ -16,7 +16,6 @@
  */
 
 
-#dict-spinner, #dict-import-progress,
 .storage-hidden {
     display: none;
 }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -22,7 +22,6 @@
  * AudioUriBuilder
  * ClipboardMonitor
  * DictionaryDatabase
- * DictionaryImporter
  * Environment
  * JsonSchemaValidator
  * Mecab
@@ -41,7 +40,6 @@ class Backend {
     constructor() {
         this._environment = new Environment();
         this._dictionaryDatabase = new DictionaryDatabase();
-        this._dictionaryImporter = new DictionaryImporter();
         this._translator = new Translator(this._dictionaryDatabase);
         this._anki = new AnkiConnect();
         this._mecab = new Mecab();
@@ -130,7 +128,6 @@ class Backend {
             ['getOrCreateSearchPopup',       {async: true,  contentScript: true,  handler: this._onApiGetOrCreateSearchPopup.bind(this)}]
         ]);
         this._messageHandlersWithProgress = new Map([
-            ['importDictionaryArchive', {async: true,  contentScript: false, handler: this._onApiImportDictionaryArchive.bind(this)}],
             ['deleteDictionary',        {async: true,  contentScript: false, handler: this._onApiDeleteDictionary.bind(this)}]
         ]);
 
@@ -756,10 +753,6 @@ class Backend {
         return details;
     }
 
-    async _onApiImportDictionaryArchive({archiveContent, details}, sender, onProgress) {
-        return await this._dictionaryImporter.importDictionary(this._dictionaryDatabase, archiveContent, details, onProgress);
-    }
-
     async _onApiDeleteDictionary({dictionaryName}, sender, onProgress) {
         this._translator.clearDatabaseCaches();
         await this._dictionaryDatabase.deleteDictionary(dictionaryName, {rate: 1000}, onProgress);
@@ -1047,10 +1040,6 @@ class Backend {
 
         handler(params);
         return true;
-    }
-
-    async _importDictionary(archiveSource, onProgress, details) {
-        return await this._dictionaryImporter.importDictionary(this._dictionaryDatabase, archiveSource, onProgress, details);
     }
 
     async _textParseScanning(text, options) {

--- a/ext/bg/js/dictionary-database.js
+++ b/ext/bg/js/dictionary-database.js
@@ -117,8 +117,15 @@ class DictionaryDatabase {
         if (this._db.isOpen()) {
             this._db.close();
         }
-        await Database.deleteDatabase(this._dbName);
+        let result = false;
+        try {
+            await Database.deleteDatabase(this._dbName);
+            result = true;
+        } catch (e) {
+            yomichan.logError(e);
+        }
         await this.prepare();
+        return result;
     }
 
     async deleteDictionary(dictionaryName, progressSettings, onProgress) {

--- a/ext/bg/js/dictionary-importer.js
+++ b/ext/bg/js/dictionary-importer.js
@@ -190,7 +190,7 @@ class DictionaryImporter {
                 try {
                     await dictionaryDatabase.bulkAdd(objectStoreName, entries, i, count);
                 } catch (e) {
-                    errors.push(errorToJson(e));
+                    errors.push(e);
                 }
 
                 loadedCount += count;

--- a/ext/bg/js/settings/dictionary-import-controller.js
+++ b/ext/bg/js/settings/dictionary-import-controller.js
@@ -1,0 +1,334 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/* global
+ * DictionaryDatabase
+ * DictionaryImporter
+ * ObjectPropertyAccessor
+ * api
+ */
+
+class DictionaryImportController {
+    constructor(settingsController, storageController) {
+        this._settingsController = settingsController;
+        this._storageController = storageController;
+        this._modifying = false;
+        this._purgeButton = null;
+        this._purgeConfirmButton = null;
+        this._importFileButton = null;
+        this._importFileInput = null;
+        this._purgeConfirmModal = null;
+        this._errorContainer = null;
+        this._spinner = null;
+        this._purgeNotification = null;
+        this._importInfo = null;
+        this._errorToStringOverrides = [
+            [
+                'A mutation operation was attempted on a database that did not allow mutations.',
+                'Access to IndexedDB appears to be restricted. Firefox seems to require that the history preference is set to "Remember history" before IndexedDB use of any kind is allowed.'
+            ],
+            [
+                'The operation failed for reasons unrelated to the database itself and not covered by any other error code.',
+                'Unable to access IndexedDB due to a possibly corrupt user profile. Try using the "Refresh Firefox" feature to reset your user profile.'
+            ]
+        ];
+    }
+
+    async prepare() {
+        this._purgeButton = document.querySelector('#dict-purge-button');
+        this._purgeConfirmButton = document.querySelector('#dict-purge-confirm');
+        this._importFileButton = document.querySelector('#dict-file-button');
+        this._importFileInput = document.querySelector('#dict-file');
+        this._purgeConfirmModal = document.querySelector('#dict-purge-modal');
+        this._errorContainer = document.querySelector('#dict-error');
+        this._spinner = document.querySelector('#dict-spinner');
+        this._progressContainer = document.querySelector('#dict-import-progress');
+        this._progressBar = this._progressContainer.querySelector('.progress-bar');
+        this._purgeNotification = document.querySelector('#dict-purge');
+        this._importInfo = document.querySelector('#dict-import-info');
+
+        this._purgeButton.addEventListener('click', this._onPurgeButtonClick.bind(this), false);
+        this._purgeConfirmButton.addEventListener('click', this._onPurgeConfirmButtonClick.bind(this), false);
+        this._importFileButton.addEventListener('click', this._onImportButtonClick.bind(this), false);
+        this._importFileInput.addEventListener('change', this._onImportFileChange.bind(this), false);
+    }
+
+    // Private
+
+    _onImportButtonClick() {
+        this._importFileInput.click();
+    }
+
+    _onPurgeButtonClick(e) {
+        e.preventDefault();
+        this._setPurgeModalVisible(true);
+    }
+
+    _onPurgeConfirmButtonClick(e) {
+        e.preventDefault();
+        this._setPurgeModalVisible(false);
+        this._purgeDatabase();
+    }
+
+    _onImportFileChange(e) {
+        const node = e.currentTarget;
+        const files = [...node.files];
+        node.value = null;
+        this._importDictionaries(files);
+    }
+
+    async _purgeDatabase() {
+        if (this._modifying) { return; }
+
+        const purgeNotification = this._purgeNotification;
+
+        const prevention = this._preventPageExit();
+
+        try {
+            this._setModifying(true);
+            this._hideErrors();
+            this._setSpinnerVisible(true);
+            purgeNotification.hidden = false;
+
+            await api.purgeDatabase();
+            const errors = await this._clearDictionarySettings();
+
+            if (errors.length > 0) {
+                this._showErrors(errors);
+            }
+
+            this._triggerDatabaseUpdated('purge');
+        } catch (error) {
+            this._showErrors([error]);
+        } finally {
+            prevention.end();
+            purgeNotification.hidden = true;
+            this._setSpinnerVisible(false);
+            this._storageController.updateStats();
+            this._setModifying(false);
+        }
+    }
+
+    async _importDictionaries(files) {
+        if (this._modifying) { return; }
+
+        const importInfo = this._importInfo;
+        const progressContainer = this._progressContainer;
+        const progressBar = this._progressBar;
+        const storageController = this._storageController;
+
+        const prevention = this._preventPageExit();
+
+        try {
+            this._setModifying(true);
+            this._hideErrors();
+            this._setSpinnerVisible(true);
+            progressContainer.hidden = false;
+
+            const optionsFull = await this._settingsController.getOptionsFull();
+            const importDetails = {
+                prefixWildcardsSupported: optionsFull.global.database.prefixWildcardsSupported
+            };
+
+            const updateProgress = (total, current) => {
+                const percent = (current / total * 100.0);
+                progressBar.style.width = `${percent}%`;
+                storageController.updateStats();
+            };
+
+            const fileCount = files.length;
+            for (let i = 0; i < fileCount; ++i) {
+                progressBar.style.width = '0';
+                if (fileCount > 1) {
+                    importInfo.hidden = false;
+                    importInfo.textContent = `(${i + 1} of ${fileCount})`;
+                }
+
+                await this._importDictionary(files[i], importDetails, updateProgress);
+            }
+        } catch (err) {
+            this._showErrors([err]);
+        } finally {
+            prevention.end();
+            progressContainer.hidden = true;
+            importInfo.textContent = '';
+            importInfo.hidden = true;
+            this._setSpinnerVisible(false);
+            this._setModifying(false);
+        }
+    }
+
+    async _importDictionary(file, importDetails, onProgress) {
+        const dictionaryDatabase = await this._getPreparedDictionaryDatabase();
+        try {
+            const dictionaryImporter = new DictionaryImporter();
+            const archiveContent = await this._readFile(file);
+            const {result, errors} = await dictionaryImporter.importDictionary(dictionaryDatabase, archiveContent, importDetails, onProgress);
+            const errors2 = await this._addDictionarySettings(result.sequenced, result.title);
+
+            if (errors.length > 0) {
+                const allErrors = [...errors, ...errors2];
+                allErrors.push(new Error(`Dictionary may not have been imported properly: ${allErrors.length} error${allErrors.length === 1 ? '' : 's'} reported.`));
+                this._showErrors(allErrors);
+            }
+
+            this._triggerDatabaseUpdated('import');
+        } finally {
+            dictionaryDatabase.close();
+        }
+    }
+
+    async _addDictionarySettings(sequenced, title) {
+        const optionsFull = await this._settingsController.getOptionsFull();
+        const targets = [];
+        const profileCount = optionsFull.profiles.length;
+        for (let i = 0; i < profileCount; ++i) {
+            const {options} = optionsFull.profiles[i];
+            const value = this._createDictionaryOptions();
+            const path1 = ObjectPropertyAccessor.getPathString(['profiles', i, 'options', 'dictionaries', title]);
+            targets.push({action: 'set', path: path1, value});
+
+            if (sequenced && options.general.mainDictionary === '') {
+                const path2 = ObjectPropertyAccessor.getPathString(['profiles', i, 'options', 'general', 'mainDictionary']);
+                targets.push({action: 'set', path: path2, value: title});
+            }
+        }
+        return await this._modifyGlobalSettings(targets);
+    }
+
+    async _clearDictionarySettings() {
+        const optionsFull = await this._settingsController.getOptionsFull();
+        const targets = [];
+        const profileCount = optionsFull.profiles.length;
+        for (let i = 0; i < profileCount; ++i) {
+            const path1 = ObjectPropertyAccessor.getPathString(['profiles', i, 'options', 'dictionaries']);
+            targets.push({action: 'set', path: path1, value: {}});
+            const path2 = ObjectPropertyAccessor.getPathString(['profiles', i, 'options', 'general', 'mainDictionary']);
+            targets.push({action: 'set', path: path2, value: ''});
+        }
+        return await this._modifyGlobalSettings(targets);
+    }
+
+    _setPurgeModalVisible(visible) {
+        const node = $(this._purgeConfirmModal);
+        node.modal(visible ? 'show' : 'hide');
+    }
+
+    _setSpinnerVisible(visible) {
+        this._spinner.hidden = !visible;
+    }
+
+    _preventPageExit() {
+        return this._settingsController.preventPageExit();
+    }
+
+    _showErrors(errors) {
+        const uniqueErrors = new Map();
+        for (const error of errors) {
+            yomichan.logError(error);
+            const errorString = this._errorToString(error);
+            let count = uniqueErrors.get(errorString);
+            if (typeof count === 'undefined') {
+                count = 0;
+            }
+            uniqueErrors.set(errorString, count + 1);
+        }
+
+        const fragment = document.createDocumentFragment();
+        for (const [e, count] of uniqueErrors.entries()) {
+            const div = document.createElement('p');
+            if (count > 1) {
+                div.textContent = `${e} `;
+                const em = document.createElement('em');
+                em.textContent = `(${count})`;
+                div.appendChild(em);
+            } else {
+                div.textContent = `${e}`;
+            }
+            fragment.appendChild(div);
+        }
+
+        this._errorContainer.appendChild(fragment);
+        this._errorContainer.hidden = false;
+    }
+
+    _hideErrors() {
+        this._errorContainer.textContent = '';
+        this._errorContainer.hidden = true;
+    }
+
+    _triggerDatabaseUpdated(cause) {
+        this._settingsController.triggerDatabaseUpdated(cause);
+    }
+
+    _readFile(file) {
+        return new Promise((resolve, reject) => {
+            const reader = new FileReader();
+            reader.onload = () => resolve(reader.result);
+            reader.onerror = () => reject(reader.error);
+            reader.readAsBinaryString(file);
+        });
+    }
+
+    _createDictionaryOptions() {
+        return {
+            priority: 0,
+            enabled: true,
+            allowSecondarySearches: false
+        };
+    }
+
+    _errorToString(error) {
+        error = (typeof error.toString === 'function' ? error.toString() : `${error}`);
+
+        for (const [match, newErrorString] of this._errorToStringOverrides) {
+            if (error.includes(match)) {
+                return newErrorString;
+            }
+        }
+
+        return error;
+    }
+
+    _setModifying(value) {
+        this._modifying = value;
+        this._setButtonsEnabled(!value);
+    }
+
+    _setButtonsEnabled(value) {
+        value = !value;
+        this._purgeButton.disabled = value;
+        this._importFileButton.disabled = value;
+    }
+
+    async _getPreparedDictionaryDatabase() {
+        const dictionaryDatabase = new DictionaryDatabase();
+        await dictionaryDatabase.prepare();
+        return dictionaryDatabase;
+    }
+
+    async _modifyGlobalSettings(targets) {
+        const results = await this._settingsController.modifyGlobalSettings(targets);
+        const errors = [];
+        for (const {error} of results) {
+            if (typeof error !== 'undefined') {
+                errors.push(jsonToError(error));
+            }
+        }
+        return errors;
+    }
+}

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -21,6 +21,7 @@
  * AudioController
  * ClipboardPopupsController
  * DictionaryController
+ * DictionaryImportController
  * GenericSettingController
  * PopupPreviewController
  * ProfileController
@@ -94,8 +95,11 @@ async function setupEnvironmentInfo() {
         const profileController = new ProfileController(settingsController);
         profileController.prepare();
 
-        const dictionaryController = new DictionaryController(settingsController, storageController);
+        const dictionaryController = new DictionaryController(settingsController);
         dictionaryController.prepare();
+
+        const dictionaryImportController = new DictionaryImportController(settingsController, storageController);
+        dictionaryImportController.prepare();
 
         const ankiController = new AnkiController(settingsController);
         ankiController.prepare();

--- a/ext/bg/js/settings/settings-controller.js
+++ b/ext/bg/js/settings/settings-controller.js
@@ -121,6 +121,10 @@ class SettingsController extends EventDispatcher {
         return obj;
     }
 
+    triggerDatabaseUpdated(cause) {
+        this.trigger('databaseUpdated', {cause});
+    }
+
     // Private
 
     _setProfileIndex(value) {

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -587,7 +587,7 @@
 
             <div class="ignore-form-changes">
                 <div>
-                    <img src="/mixed/img/spinner.gif" class="pull-right" id="dict-spinner" alt>
+                    <img src="/mixed/img/spinner.gif" class="pull-right" id="dict-spinner" alt hidden>
                     <h3>Dictionaries</h3>
                 </div>
 
@@ -607,7 +607,7 @@
                 <div id="dict-groups"></div>
                 <div id="dict-groups-extra"></div>
 
-                <div id="dict-import-progress">
+                <div id="dict-import-progress" hidden>
                     Dictionary data is being imported, please be patient...
                     <span id="dict-import-info" hidden></span>
                     <div class="progress">
@@ -1130,6 +1130,7 @@
         <script src="/mixed/lib/jquery.min.js"></script>
         <script src="/mixed/lib/bootstrap/js/bootstrap.min.js"></script>
         <script src="/mixed/lib/handlebars.min.js"></script>
+        <script src="/mixed/lib/jszip.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/core.js"></script>
@@ -1148,6 +1149,13 @@
         <script src="/mixed/js/audio-system.js"></script>
         <script src="/mixed/js/document-util.js"></script>
 
+        <script src="/bg/js/database.js"></script>
+        <script src="/bg/js/dictionary-database.js"></script>
+        <script src="/bg/js/dictionary-importer.js"></script>
+        <script src="/bg/js/json-schema.js"></script>
+        <script src="/bg/js/media-utility.js"></script>
+        <script src="/mixed/js/cache-map.js"></script>
+
         <script src="/bg/js/settings/anki.js"></script>
         <script src="/bg/js/settings/anki-templates.js"></script>
         <script src="/bg/js/settings/audio.js"></script>
@@ -1155,6 +1163,7 @@
         <script src="/bg/js/settings/clipboard-popups-controller.js"></script>
         <script src="/bg/js/settings/conditions-ui.js"></script>
         <script src="/bg/js/settings/dictionaries.js"></script>
+        <script src="/bg/js/settings/dictionary-import-controller.js"></script>
         <script src="/bg/js/settings/generic-setting-controller.js"></script>
         <script src="/bg/js/settings/popup-preview.js"></script>
         <script src="/bg/js/settings/profiles.js"></script>

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -203,10 +203,6 @@ const api = (() => {
 
         // Invoke functions with progress
 
-        importDictionaryArchive(archiveContent, details, onProgress) {
-            return this._invokeWithProgress('importDictionaryArchive', {archiveContent, details}, onProgress);
-        }
-
         deleteDictionary(dictionaryName, onProgress) {
             return this._invokeWithProgress('deleteDictionary', {dictionaryName}, onProgress);
         }


### PR DESCRIPTION
This change refactors the dictionary import and purge functionality. The import is now performed directly on the settings page, rather than on the background page, which is necessary for manifest v3. This also removes some of the direct references to the background page, now using `api` functions instead.

This also resolves https://github.com/FooSoft/yomichan/pull/446#discussion_r410917734, since image validation is now performed directly on the settings page.

This change also fixes an issue where `.purge` throwing an exception would put the extension into an invalid state, since the database would be closed.