### PR TITLE
Handle error if _waitForFrontendReady fails when creating a popup proxy

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -357,7 +357,12 @@ class Frontend {
 
     async _getIframeProxyPopup() {
         const targetFrameId = 0; // Root frameId
-        await this._waitForFrontendReady(targetFrameId);
+        try {
+            await this._waitForFrontendReady(targetFrameId);
+        } catch (e) {
+            // Root frame not available
+            return await this._getDefaultPopup();
+        }
 
         const {popupId} = await api.crossFrame.invoke(targetFrameId, 'getPopupInfo');
         if (popupId === null) {


### PR DESCRIPTION
This fixes an issue where iframes on pages which aren't exposed to Yomichan will cause an error. This would occur on Chrome's default home page when it is showing a custom graphic.