### PR TITLE
Fix log context not being in the correct format

### DIFF
--- a/ext/mixed/js/yomichan.js
+++ b/ext/mixed/js/yomichan.js
@@ -263,7 +263,7 @@ const yomichan = (() => {
         }
 
         _getLogContext() {
-            return this._getUrl();
+            return {url: this._getUrl()};
         }
 
         _onMessage({action, params}, sender, callback) {


### PR DESCRIPTION
Fixes `url` being reported as `undefined` for all errors.