### PR TITLE
Defer assignment of marker when rendering templates

### DIFF
--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -81,9 +81,8 @@ class AnkiNoteBuilder {
     async formatField(field, data, templates, errors=null) {
         const pattern = /\{([\w-]+)\}/g;
         return await AnkiNoteBuilder.stringReplaceAsync(field, pattern, async (g0, marker) => {
-            data.marker = marker;
             try {
-                return await this._renderTemplate(templates, data);
+                return await this._renderTemplate(templates, data, marker);
             } catch (e) {
                 if (errors) { errors.push(e); }
                 return `{${marker}-render-error}`;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -522,8 +522,8 @@ class Backend {
         return await this._anki.guiBrowse(`nid:${noteId}`);
     }
 
-    async _onApiTemplateRender({template, data}) {
-        return this._renderTemplate(template, data);
+    async _onApiTemplateRender({template, data, marker}) {
+        return this._renderTemplate(template, data, marker);
     }
 
     _onApiCommandExec({command, params}) {
@@ -1354,8 +1354,8 @@ class Backend {
         return false;
     }
 
-    async _renderTemplate(template, data) {
-        return await this._templateRenderer.render(template, data);
+    async _renderTemplate(template, data, marker) {
+        return await this._templateRenderer.render(template, data, marker);
     }
 
     _getTemplates(options) {

--- a/ext/bg/js/template-renderer.js
+++ b/ext/bg/js/template-renderer.js
@@ -28,7 +28,7 @@ class TemplateRenderer {
         this._stateStack = null;
     }
 
-    async render(template, data) {
+    async render(template, data, marker) {
         if (!this._helpersRegistered) {
             this._registerHelpers();
             this._helpersRegistered = true;
@@ -42,11 +42,19 @@ class TemplateRenderer {
             cache.set(template, instance);
         }
 
+        const markerPre = data.marker;
+        const markerPreHas = hasOwn(data, 'marker');
         try {
             this._stateStack = [new Map()];
+            data.marker = marker;
             return instance(data).trim();
         } finally {
             this._stateStack = null;
+            if (markerPreHas) {
+                data.marker = markerPre;
+            } else {
+                delete data.marker;
+            }
         }
     }
 

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -89,8 +89,8 @@ const api = (() => {
             return this._invoke('noteView', {noteId});
         }
 
-        templateRender(template, data) {
-            return this._invoke('templateRender', {data, template});
+        templateRender(template, data, marker) {
+            return this._invoke('templateRender', {data, template, marker});
         }
 
         audioGetUri(definition, source, details) {


### PR DESCRIPTION
Fixes an issue #612 is having, where the value of `marker` is seeing only the last assigned value. This is because pre-#612, the executor is synchronous, and sees the most recent `marker` value. Post-#612 is asynchronous, and will therefore see the last value.