### PR TITLE
Delay hide option

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -324,6 +324,7 @@
                                     "alphanumeric",
                                     "autoHideResults",
                                     "delay",
+                                    "hideDelay",
                                     "length",
                                     "modifier",
                                     "deepDomScan",
@@ -359,6 +360,11 @@
                                         "type": "number",
                                         "minimum": 0,
                                         "default": 20
+                                    },
+                                    "hideDelay": {
+                                        "type": "number",
+                                        "minimum": 0,
+                                        "default": 0
                                     },
                                     "length": {
                                         "type": "integer",

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -473,6 +473,7 @@ class OptionsUtil {
         //  Options conditions converted to string representations.
         //  Added usePopupWindow.
         //  Updated handlebars templates to include "clipboard-image" definition.
+        //  Added hideDelay.
         for (const {conditionGroups} of options.profiles) {
             for (const {conditions} of conditionGroups) {
                 for (const condition of conditions) {
@@ -487,6 +488,7 @@ class OptionsUtil {
         }
         for (const {options: profileOptions} of options.profiles) {
             profileOptions.general.usePopupWindow = false;
+            profileOptions.scanning.hideDelay = 0;
         }
         await this._addFieldTemplatesToOptions(options, '/bg/data/anki-field-templates-upgrade-v4.handlebars');
         return options;

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -415,8 +415,16 @@
                 </div>
 
                 <div class="form-group options-advanced">
-                    <label for="scan-delay">Scan delay <span class="label-light">(in milliseconds)</span></label>
-                    <input type="number" min="0" id="scan-delay" class="form-control" data-setting="scanning.delay">
+                    <div class="row">
+                        <div class="col-xs-6">
+                            <label for="scan-delay">Scan delay <span class="label-light">(in milliseconds)</span></label>
+                            <input type="number" min="0" id="scan-delay" class="form-control" data-setting="scanning.delay">
+                        </div>
+                        <div class="col-xs-6">
+                            <label for="scan-close-delay">Auto-hide delay <span class="label-light">(in milliseconds)</span></label>
+                            <input type="number" min="0" id="scan-close-delay" class="form-control" data-setting="scanning.hideDelay">
+                        </div>
+                    </div>
                 </div>
 
                 <div class="form-group options-advanced">

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -175,7 +175,7 @@ class Frontend {
     }
 
     _onApiClosePopup() {
-        this._textScanner.clearSelection(false);
+        this._clearSelection(false);
     }
 
     _onApiCopySelection() {
@@ -266,8 +266,12 @@ class Frontend {
         }
 
         if (type === null && this._options.scanning.autoHideResults) {
-            textScanner.clearSelection(false);
+            this._clearSelection(false);
         }
+    }
+
+    _clearSelection(passive) {
+        this._textScanner.clearSelection(passive);
     }
 
     async _updateOptionsInternal() {
@@ -354,7 +358,7 @@ class Frontend {
             this.setDisabledOverride(!this._options.scanning.enableOnSearchPage);
         }
 
-        this._textScanner.clearSelection(true);
+        this._clearSelection(true);
         this._popup = popup;
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -279,6 +279,7 @@ class Frontend {
     }
 
     _clearSelectionDelayed(delay, restart, passive) {
+        if (!this._textScanner.hasSelection()) { return; }
         if (delay > 0) {
             if (this._clearSelectionTimer !== null && !restart) { return; } // Already running
             this._stopClearSelectionDelayed();

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -95,6 +95,8 @@ class Popup extends EventDispatcher {
     // Public functions
 
     prepare() {
+        this._frame.addEventListener('mouseover', this._onFrameMouseOver.bind(this));
+        this._frame.addEventListener('mouseout', this._onFrameMouseOut.bind(this));
         this._frame.addEventListener('mousedown', (e) => e.stopPropagation());
         this._frame.addEventListener('scroll', (e) => e.stopPropagation());
         this._frame.addEventListener('load', this._onFrameLoad.bind(this));
@@ -206,6 +208,14 @@ class Popup extends EventDispatcher {
     }
 
     // Private functions
+
+    _onFrameMouseOver() {
+        this.trigger('framePointerOver', {});
+    }
+
+    _onFrameMouseOut() {
+        this.trigger('framePointerOut', {});
+    }
 
     _inject() {
         let injectPromise = this._injectPromise;

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -144,6 +144,10 @@ class TextScanner extends EventDispatcher {
         return clonedTextSource.text();
     }
 
+    hasSelection() {
+        return (this._textSourceCurrent !== null);
+    }
+
     clearSelection(passive) {
         if (!this._canClearSelection) { return; }
         if (this._textSourceCurrent !== null) {


### PR DESCRIPTION
Resolves #742.

~This feature is not yet complete; there is an issue where the popup will close after being hovered because the delay isn't cancelled when the popup is mouseover'd. This event may have to come from the popup itself, since the mouse move events don't fire for the root window when the cursor is in the frame.~