### PR TITLE
Add api.clipboardGetImage

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -46,5 +46,12 @@
         <script src="/mixed/js/object-property-accessor.js"></script>
 
         <script src="/bg/js/background-main.js"></script>
+
+        <!--
+            Due to a Firefox bug, this next element is purposefully terminated incorrectly.
+            This element must appear directly inside the <body> element, and it must not be closed properly.
+            https://bugzilla.mozilla.org/show_bug.cgi?id=1603985
+        -->
+        <div id="clipboard-image-paste-target" contenteditable="true">
     </body>
 </html>

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -638,18 +638,19 @@ class Backend {
         const {browser} = this._environment.getInfo();
         if (browser === 'firefox' || browser === 'firefox-mobile') {
             return await navigator.clipboard.readText();
-        } else {
-            const target = this._clipboardPasteTarget;
-            if (target === null) {
-                throw new Error('Reading the clipboard is not supported in this context');
-            }
-            target.value = '';
-            target.focus();
-            document.execCommand('paste');
-            const result = target.value;
-            target.value = '';
-            return result;
         }
+
+        const target = this._clipboardPasteTarget;
+        if (target === null) {
+            throw new Error('Reading the clipboard is not supported in this context');
+        }
+
+        target.value = '';
+        target.focus();
+        document.execCommand('paste');
+        const result = target.value;
+        target.value = '';
+        return result;
     }
 
     async _onApiGetDisplayTemplatesHtml() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -640,14 +640,18 @@ class Backend {
             return await navigator.clipboard.readText();
         }
 
+        if (!this._environmentHasDocument()) {
+            throw new Error('Reading the clipboard is not supported in this context');
+        }
+
         const target = this._clipboardPasteTarget;
         if (target === null) {
-            throw new Error('Reading the clipboard is not supported in this context');
+            throw new Error('Clipboard paste target does not exist');
         }
 
         target.value = '';
         target.focus();
-        document.execCommand('paste');
+        this._executePasteCommand();
         const result = target.value;
         target.value = '';
         return result;
@@ -1532,5 +1536,13 @@ class Backend {
         const url = await this._getTabUrl(tabId);
         const isValidTab = urlPredicate(url);
         return isValidTab ? tab : null;
+    }
+
+    _environmentHasDocument() {
+        return (typeof document === 'object' && document !== null);
+    }
+
+    _executePasteCommand() {
+        document.execCommand('paste');
     }
 }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -64,11 +64,8 @@ class Backend {
         });
         this._templateRenderer = new TemplateRenderer();
 
-        this._clipboardPasteTarget = (
-            typeof document === 'object' && document !== null ?
-            document.querySelector('#clipboard-paste-target') :
-            null
-        );
+        this._clipboardPasteTarget = null;
+        this._clipboardPasteTargetInitialized = false;
 
         this._searchPopupTabId = null;
         this._searchPopupTabCreatePromise = null;
@@ -642,6 +639,11 @@ class Backend {
 
         if (!this._environmentHasDocument()) {
             throw new Error('Reading the clipboard is not supported in this context');
+        }
+
+        if (!this._clipboardPasteTargetInitialized) {
+            this._clipboardPasteTarget = document.querySelector('#clipboard-paste-target');
+            this._clipboardPasteTargetInitialized = true;
         }
 
         const target = this._clipboardPasteTarget;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -639,15 +639,15 @@ class Backend {
         if (browser === 'firefox' || browser === 'firefox-mobile') {
             return await navigator.clipboard.readText();
         } else {
-            const clipboardPasteTarget = this._clipboardPasteTarget;
-            if (clipboardPasteTarget === null) {
+            const target = this._clipboardPasteTarget;
+            if (target === null) {
                 throw new Error('Reading the clipboard is not supported in this context');
             }
-            clipboardPasteTarget.value = '';
-            clipboardPasteTarget.focus();
+            target.value = '';
+            target.focus();
             document.execCommand('paste');
-            const result = clipboardPasteTarget.value;
-            clipboardPasteTarget.value = '';
+            const result = target.value;
+            target.value = '';
             return result;
         }
     }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -133,6 +133,10 @@ const api = (() => {
             return this._invoke('clipboardGet');
         }
 
+        clipboardGetImage() {
+            return this._invoke('clipboardGetImage');
+        }
+
         getDisplayTemplatesHtml() {
             return this._invoke('getDisplayTemplatesHtml');
         }


### PR DESCRIPTION
Required for #776. Unfortunately, for Firefox support, this requires the ugly workaround hack to use `document.execCommand('paste');` on the background page. https://bugzilla.mozilla.org/show_bug.cgi?id=1603985