### PR TITLE
Anki screenshot refactor

### DIFF
--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -20,11 +20,12 @@
  */
 
 class AnkiNoteBuilder {
-    constructor({anki, audioSystem, renderTemplate, getClipboardImage=null}) {
+    constructor({anki, audioSystem, renderTemplate, getClipboardImage=null, getScreenshot=null}) {
         this._anki = anki;
         this._audioSystem = audioSystem;
         this._renderTemplate = renderTemplate;
         this._getClipboardImage = getClipboardImage;
+        this._getScreenshot = getScreenshot;
     }
 
     async createNote({
@@ -134,9 +135,12 @@ class AnkiNoteBuilder {
         const now = new Date(Date.now());
 
         try {
-            let fileName = `yomichan_browser_screenshot_${reading}_${this._dateToString(now)}.${screenshot.format}`;
+            const {windowId, tabId, ownerFrameId, format, quality} = screenshot;
+            const dataUrl = await this._getScreenshot(windowId, tabId, ownerFrameId, format, quality);
+
+            let fileName = `yomichan_browser_screenshot_${reading}_${this._dateToString(now)}.${format}`;
             fileName = AnkiNoteBuilder.replaceInvalidFileNameCharacters(fileName);
-            const data = screenshot.dataUrl.replace(/^data:[\w\W]*?,/, '');
+            const data = dataUrl.replace(/^data:[\w\W]*?,/, '');
 
             await this._anki.storeMediaFile(fileName, data);
 

--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -130,18 +130,20 @@ class AnkiNoteBuilder {
     async injectScreenshot(definition, fields, screenshot) {
         if (!this._containsMarker(fields, 'screenshot')) { return; }
 
+        const reading = definition.reading;
         const now = new Date(Date.now());
-        let fileName = `yomichan_browser_screenshot_${definition.reading}_${this._dateToString(now)}.${screenshot.format}`;
-        fileName = AnkiNoteBuilder.replaceInvalidFileNameCharacters(fileName);
-        const data = screenshot.dataUrl.replace(/^data:[\w\W]*?,/, '');
 
         try {
-            await this._anki.storeMediaFile(fileName, data);
-        } catch (e) {
-            return;
-        }
+            let fileName = `yomichan_browser_screenshot_${reading}_${this._dateToString(now)}.${screenshot.format}`;
+            fileName = AnkiNoteBuilder.replaceInvalidFileNameCharacters(fileName);
+            const data = screenshot.dataUrl.replace(/^data:[\w\W]*?,/, '');
 
-        definition.screenshotFileName = fileName;
+            await this._anki.storeMediaFile(fileName, data);
+
+            definition.screenshotFileName = fileName;
+        } catch (e) {
+            // NOP
+        }
     }
 
     async injectClipboardImage(definition, fields) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -67,7 +67,9 @@ class Frontend {
         this._isPointerOverPopup = false;
 
         this._runtimeMessageHandlers = new Map([
-            ['requestFrontendReadyBroadcast',        {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}]
+            ['requestFrontendReadyBroadcast', {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}],
+            ['setAllVisibleOverride',         {async: true,  handler: this._onApiSetAllVisibleOverride.bind(this)}],
+            ['clearAllVisibleOverride',       {async: true,  handler: this._onApiClearAllVisibleOverride.bind(this)}]
         ]);
     }
 
@@ -117,9 +119,7 @@ class Frontend {
             ['closePopup',              {async: false, handler: this._onApiClosePopup.bind(this)}],
             ['copySelection',           {async: false, handler: this._onApiCopySelection.bind(this)}],
             ['getPopupInfo',            {async: false, handler: this._onApiGetPopupInfo.bind(this)}],
-            ['getDocumentInformation',  {async: false, handler: this._onApiGetDocumentInformation.bind(this)}],
-            ['setAllVisibleOverride',   {async: true,  handler: this._onApiSetAllVisibleOverride.bind(this)}],
-            ['clearAllVisibleOverride', {async: true,  handler: this._onApiClearAllVisibleOverride.bind(this)}]
+            ['getDocumentInformation',  {async: false, handler: this._onApiGetDocumentInformation.bind(this)}]
         ]);
 
         this._updateContentScale();

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -77,8 +77,8 @@ const api = (() => {
             return this._invoke('kanjiFind', {text, optionsContext});
         }
 
-        definitionAdd(definition, mode, context, details, optionsContext) {
-            return this._invoke('definitionAdd', {definition, mode, context, details, optionsContext});
+        definitionAdd(definition, mode, context, ownerFrameId, optionsContext) {
+            return this._invoke('definitionAdd', {definition, mode, context, ownerFrameId, optionsContext});
         }
 
         definitionsAddable(definitions, modes, context, optionsContext) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1047,18 +1047,9 @@ class Display extends EventDispatcher {
         try {
             this.setSpinnerVisible(true);
 
-            const details = {};
-            if (this._noteUsesScreenshot(mode)) {
-                try {
-                    const screenshot = await this._getScreenshot();
-                    details.screenshot = screenshot;
-                } catch (e) {
-                    // NOP
-                }
-            }
-
+            const ownerFrameId = this._ownerFrameId;
             const noteContext = await this._getNoteContext();
-            const noteId = await api.definitionAdd(definition, mode, noteContext, details, this.getOptionsContext());
+            const noteId = await api.definitionAdd(definition, mode, noteContext, ownerFrameId, this.getOptionsContext());
             if (noteId) {
                 const index = this._definitions.indexOf(definition);
                 const adderButton = this._adderButtonFind(index, mode);
@@ -1133,36 +1124,6 @@ class Display extends EventDispatcher {
         if (this._audioPlaying !== null) {
             this._audioPlaying.pause();
             this._audioPlaying = null;
-        }
-    }
-
-    _noteUsesScreenshot(mode) {
-        const optionsAnki = this._options.anki;
-        const fields = (mode === 'kanji' ? optionsAnki.kanji : optionsAnki.terms).fields;
-        for (const fieldValue of Object.values(fields)) {
-            if (fieldValue.includes('{screenshot}')) {
-                return true;
-            }
-        }
-        return false;
-    }
-
-    async _getScreenshot() {
-        const ownerFrameId = this._ownerFrameId;
-        let token = null;
-        try {
-            if (ownerFrameId !== null) {
-                token = await api.crossFrame.invoke(ownerFrameId, 'setAllVisibleOverride', {value: false, priority: 0, awaitFrame: true});
-            }
-
-            const {format, quality} = this._options.anki.screenshot;
-            const dataUrl = await api.screenshotGet({format, quality});
-
-            return {dataUrl, format};
-        } finally {
-            if (token !== null) {
-                await api.crossFrame.invoke(ownerFrameId, 'clearAllVisibleOverride', {token});
-            }
         }
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1048,8 +1048,9 @@ class Display extends EventDispatcher {
             this.setSpinnerVisible(true);
 
             const ownerFrameId = this._ownerFrameId;
+            const optionsContext = this.getOptionsContext();
             const noteContext = await this._getNoteContext();
-            const noteId = await api.definitionAdd(definition, mode, noteContext, ownerFrameId, this.getOptionsContext());
+            const noteId = await api.definitionAdd(definition, mode, noteContext, ownerFrameId, optionsContext);
             if (noteId) {
                 const index = this._definitions.indexOf(definition);
                 const adderButton = this._adderButtonFind(index, mode);


### PR DESCRIPTION
Screenshot is no longer generated directly from `Display` classes. Instead, it is generated from `AnkiNoteBuilder`, which is more consistent with audio/clipboard injection. This also removes some redundant marker checking code which was present in `Display`.