### PR TITLE
Update the AnkiController class to use an instance of AnkiConnect directly

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -113,9 +113,6 @@ class Backend {
             ['getQueryParserTemplatesHtml',  {async: true,  contentScript: true,  handler: this._onApiGetQueryParserTemplatesHtml.bind(this)}],
             ['getZoom',                      {async: true,  contentScript: true,  handler: this._onApiGetZoom.bind(this)}],
             ['getDefaultAnkiFieldTemplates', {async: false, contentScript: true,  handler: this._onApiGetDefaultAnkiFieldTemplates.bind(this)}],
-            ['getAnkiDeckNames',             {async: true,  contentScript: false, handler: this._onApiGetAnkiDeckNames.bind(this)}],
-            ['getAnkiModelNames',            {async: true,  contentScript: false, handler: this._onApiGetAnkiModelNames.bind(this)}],
-            ['getAnkiModelFieldNames',       {async: true,  contentScript: false, handler: this._onApiGetAnkiModelFieldNames.bind(this)}],
             ['getDictionaryInfo',            {async: true,  contentScript: false, handler: this._onApiGetDictionaryInfo.bind(this)}],
             ['getDictionaryCounts',          {async: true,  contentScript: false, handler: this._onApiGetDictionaryCounts.bind(this)}],
             ['purgeDatabase',                {async: true,  contentScript: false, handler: this._onApiPurgeDatabase.bind(this)}],
@@ -724,18 +721,6 @@ class Backend {
 
     _onApiGetDefaultAnkiFieldTemplates() {
         return this._defaultAnkiFieldTemplates;
-    }
-
-    async _onApiGetAnkiDeckNames() {
-        return await this._anki.getDeckNames();
-    }
-
-    async _onApiGetAnkiModelNames() {
-        return await this._anki.getModelNames();
-    }
-
-    async _onApiGetAnkiModelFieldNames({modelName}) {
-        return await this._anki.getModelFieldNames(modelName);
     }
 
     async _onApiGetDictionaryInfo() {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -153,18 +153,6 @@ const api = (() => {
             return this._invoke('getDefaultAnkiFieldTemplates');
         }
 
-        getAnkiDeckNames() {
-            return this._invoke('getAnkiDeckNames');
-        }
-
-        getAnkiModelNames() {
-            return this._invoke('getAnkiModelNames');
-        }
-
-        getAnkiModelFieldNames(modelName) {
-            return this._invoke('getAnkiModelFieldNames', {modelName});
-        }
-
         getDictionaryInfo() {
             return this._invoke('getDictionaryInfo');
         }


### PR DESCRIPTION
This removes the need for some API functions, and should make the Anki server usage more correct, as this uses the correct per-profile options for server/enabled.