### PR TITLE
Generalize AnkiNoteBuilder to not use audioSystem directly

### DIFF
--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -20,9 +20,9 @@
  */
 
 class AnkiNoteBuilder {
-    constructor({audioSystem, renderTemplate, getClipboardImage=null, getScreenshot=null}) {
-        this._audioSystem = audioSystem;
+    constructor({renderTemplate, getDefinitionAudio=null, getClipboardImage=null, getScreenshot=null}) {
         this._renderTemplate = renderTemplate;
+        this._getDefinitionAudio = getDefinitionAudio;
         this._getClipboardImage = getClipboardImage;
         this._getScreenshot = getScreenshot;
     }
@@ -130,7 +130,7 @@ class AnkiNoteBuilder {
             if (fileName === null) { return; }
             fileName = this._replaceInvalidFileNameCharacters(fileName);
 
-            const {audio} = await this._audioSystem.getDefinitionAudio(
+            const {audio: data} = await this._getDefinitionAudio(
                 audioSourceDefinition,
                 sources,
                 {
@@ -141,7 +141,6 @@ class AnkiNoteBuilder {
                 }
             );
 
-            const data = this._arrayBufferToBase64(audio);
             await anki.storeMediaFile(fileName, data);
 
             definition.audioFileName = fileName;
@@ -258,10 +257,6 @@ class AnkiNoteBuilder {
     _replaceInvalidFileNameCharacters(fileName) {
         // eslint-disable-next-line no-control-regex
         return fileName.replace(/[<>:"/\\|?*\x00-\x1F]/g, '-');
-    }
-
-    _arrayBufferToBase64(arrayBuffer) {
-        return btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
     }
 
     _stringReplaceAsync(str, regex, replacer) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -58,8 +58,8 @@ class Backend {
             useCache: false
         });
         this._ankiNoteBuilder = new AnkiNoteBuilder({
-            audioSystem: this._audioSystem,
             renderTemplate: this._renderTemplate.bind(this),
+            getDefinitionAudio: this._getDefinitionAudio.bind(this),
             getClipboardImage: this._onApiClipboardImageGet.bind(this),
             getScreenshot: this._getScreenshot.bind(this)
         });
@@ -124,7 +124,8 @@ class Backend {
             ['getSettings',                  {async: false, contentScript: true,  handler: this._onApiGetSettings.bind(this)}],
             ['setAllSettings',               {async: true,  contentScript: false, handler: this._onApiSetAllSettings.bind(this)}],
             ['getOrCreateSearchPopup',       {async: true,  contentScript: true,  handler: this._onApiGetOrCreateSearchPopup.bind(this)}],
-            ['isTabSearchPopup',             {async: true,  contentScript: true,  handler: this._onApiIsTabSearchPopup.bind(this)}]
+            ['isTabSearchPopup',             {async: true,  contentScript: true,  handler: this._onApiIsTabSearchPopup.bind(this)}],
+            ['getDefinitionAudio',           {async: true,  contentScript: true,  handler: this._onApiGetDefinitionAudio.bind(this)}]
         ]);
         this._messageHandlersWithProgress = new Map([
             ['deleteDictionary',        {async: true,  contentScript: false, handler: this._onApiDeleteDictionary.bind(this)}]
@@ -825,6 +826,10 @@ class Backend {
         const baseUrl = chrome.runtime.getURL('/bg/search.html');
         const tab = typeof tabId === 'number' ? await this._checkTabUrl(tabId, (url) => url.startsWith(baseUrl)) : null;
         return (tab !== null);
+    }
+
+    async _onApiGetDefinitionAudio({definition, sources, details}) {
+        return this._getDefinitionAudio(definition, sources, details);
     }
 
     // Command handlers
@@ -1630,5 +1635,9 @@ class Backend {
                 }
             }
         }
+    }
+
+    async _getDefinitionAudio(definition, sources, details) {
+        return await this._audioSystem.getDefinitionAudio(definition, sources, details);
     }
 }

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -185,7 +185,11 @@ class AudioSystem {
             throw new Error('Could not retrieve audio');
         }
 
-        return arrayBuffer;
+        return this._arrayBufferToBase64(arrayBuffer);
+    }
+
+    _arrayBufferToBase64(arrayBuffer) {
+        return btoa(String.fromCharCode(...new Uint8Array(arrayBuffer)));
     }
 
     _isAudioValid(audio) {


### PR DESCRIPTION
This is necessary since the `AudioSystem` instance in `Display` doesn't support downloading binary. This must be done via the backend.