### PR TITLE
Use Anki classes directly in Display

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -23,8 +23,6 @@
         <script src="/mixed/js/environment.js"></script>
         <script src="/mixed/js/japanese.js"></script>
 
-        <script src="/bg/js/anki.js"></script>
-        <script src="/bg/js/anki-note-builder.js"></script>
         <script src="/bg/js/backend.js"></script>
         <script src="/bg/js/mecab.js"></script>
         <script src="/bg/js/audio-uri-builder.js"></script>

--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -15,7 +15,6 @@
     <body>
         <textarea id="clipboard-paste-target"></textarea>
 
-        <script src="/mixed/lib/handlebars.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/core.js"></script>
@@ -34,7 +33,6 @@
         <script src="/bg/js/options.js"></script>
         <script src="/bg/js/profile-conditions.js"></script>
         <script src="/bg/js/request-builder.js"></script>
-        <script src="/bg/js/template-renderer.js"></script>
         <script src="/bg/js/simple-dom-parser.js"></script>
         <script src="/bg/js/text-source-map.js"></script>
         <script src="/bg/js/translator.js"></script>

--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -157,8 +157,8 @@ class AnkiNoteBuilder {
         const now = new Date(Date.now());
 
         try {
-            const {windowId, tabId, ownerFrameId, format, quality} = details;
-            const dataUrl = await this._getScreenshot(windowId, tabId, ownerFrameId, format, quality);
+            const {format, quality} = details;
+            const dataUrl = await this._getScreenshot(format, quality);
 
             const {mediaType, data} = this._getDataUrlInfo(dataUrl);
             const extension = this._getImageExtensionFromMediaType(mediaType);

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -27,7 +27,6 @@
  * OptionsUtil
  * ProfileConditions
  * RequestBuilder
- * TemplateRenderer
  * Translator
  * jp
  */
@@ -54,7 +53,6 @@ class Backend {
             requestBuilder: this._requestBuilder,
             useCache: false
         });
-        this._templateRenderer = new TemplateRenderer();
 
         this._clipboardPasteTarget = null;
         this._clipboardPasteTargetInitialized = false;
@@ -85,7 +83,6 @@ class Backend {
             ['kanjiFind',                    {async: true,  contentScript: true,  handler: this._onApiKanjiFind.bind(this)}],
             ['termsFind',                    {async: true,  contentScript: true,  handler: this._onApiTermsFind.bind(this)}],
             ['textParse',                    {async: true,  contentScript: true,  handler: this._onApiTextParse.bind(this)}],
-            ['templateRender',               {async: true,  contentScript: true,  handler: this._onApiTemplateRender.bind(this)}],
             ['commandExec',                  {async: false, contentScript: true,  handler: this._onApiCommandExec.bind(this)}],
             ['audioGetUri',                  {async: true,  contentScript: true,  handler: this._onApiAudioGetUri.bind(this)}],
             ['screenshotGet',                {async: true,  contentScript: true,  handler: this._onApiScreenshotGet.bind(this)}],
@@ -426,10 +423,6 @@ class Backend {
         }
 
         return results;
-    }
-
-    async _onApiTemplateRender({template, data, marker}) {
-        return this._renderTemplate(template, data, marker);
     }
 
     _onApiCommandExec({command, params}) {
@@ -1284,10 +1277,6 @@ class Backend {
             if (value) { return value; }
         }
         return false;
-    }
-
-    async _renderTemplate(template, data, marker) {
-        return await this._templateRenderer.render(template, data, marker);
     }
 
     _getTemplates(options) {

--- a/ext/bg/js/settings/anki-templates-controller.js
+++ b/ext/bg/js/settings/anki-templates-controller.js
@@ -17,6 +17,7 @@
 
 /* global
  * AnkiNoteBuilder
+ * TemplateRenderer
  * api
  */
 
@@ -27,6 +28,7 @@ class AnkiTemplatesController {
         this._cachedDefinitionValue = null;
         this._cachedDefinitionText = null;
         this._defaultFieldTemplates = null;
+        this._templateRenderer = new TemplateRenderer();
     }
 
     async prepare() {
@@ -144,8 +146,7 @@ class AnkiTemplatesController {
                 let templates = options.anki.fieldTemplates;
                 if (typeof templates !== 'string') { templates = this._defaultFieldTemplates; }
                 const ankiNoteBuilder = new AnkiNoteBuilder({
-                    renderTemplate: api.templateRender.bind(api),
-                    getClipboardImage: api.clipboardGetImage.bind(api)
+                    renderTemplate: this._renderTemplate.bind(this)
                 });
                 const {general: {resultOutputMode, compactGlossaries}} = options;
                 const note = await ankiNoteBuilder.createNote({
@@ -176,5 +177,9 @@ class AnkiTemplatesController {
             const input = document.querySelector('#field-templates');
             input.classList.toggle('is-invalid', hasException);
         }
+    }
+
+    async _renderTemplate(template, data, marker) {
+        return await this._templateRenderer.render(template, data, marker);
     }
 }

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -91,6 +91,8 @@
         <script src="/mixed/js/template-handler.js"></script>
         <script src="/mixed/js/text-to-speech-audio.js"></script>
 
+        <script src="/bg/js/anki.js"></script>
+        <script src="/bg/js/anki-note-builder.js"></script>
         <script src="/bg/js/template-renderer.js"></script>
 
         <script src="/bg/js/query-parser-generator.js"></script>

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -91,6 +91,8 @@
         <script src="/mixed/js/template-handler.js"></script>
         <script src="/mixed/js/text-to-speech-audio.js"></script>
 
+        <script src="/bg/js/template-renderer.js"></script>
+
         <script src="/bg/js/query-parser-generator.js"></script>
         <script src="/bg/js/query-parser.js"></script>
         <script src="/bg/js/clipboard-monitor.js"></script>

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -1183,6 +1183,7 @@
         <script src="/bg/js/dictionary-importer.js"></script>
         <script src="/bg/js/json-schema.js"></script>
         <script src="/bg/js/media-utility.js"></script>
+        <script src="/bg/js/template-renderer.js"></script>
 
         <script src="/bg/js/settings/keyboard-mouse-input-field.js"></script>
         <script src="/bg/js/settings/profile-conditions-ui.js"></script>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -68,6 +68,8 @@
         <script src="/mixed/js/template-handler.js"></script>
         <script src="/mixed/js/text-to-speech-audio.js"></script>
 
+        <script src="/bg/js/anki.js"></script>
+        <script src="/bg/js/anki-note-builder.js"></script>
         <script src="/bg/js/template-renderer.js"></script>
 
         <script src="/bg/js/query-parser-generator.js"></script>

--- a/ext/fg/float.html
+++ b/ext/fg/float.html
@@ -44,6 +44,8 @@
             </div>
         </div>
 
+        <script src="/mixed/lib/handlebars.min.js"></script>
+
         <script src="/mixed/js/core.js"></script>
         <script src="/mixed/js/yomichan.js"></script>
         <script src="/mixed/js/comm.js"></script>
@@ -65,6 +67,8 @@
         <script src="/mixed/js/text-scanner.js"></script>
         <script src="/mixed/js/template-handler.js"></script>
         <script src="/mixed/js/text-to-speech-audio.js"></script>
+
+        <script src="/bg/js/template-renderer.js"></script>
 
         <script src="/bg/js/query-parser-generator.js"></script>
         <script src="/bg/js/query-parser.js"></script>

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -119,7 +119,9 @@ class Frontend {
             ['closePopup',              {async: false, handler: this._onApiClosePopup.bind(this)}],
             ['copySelection',           {async: false, handler: this._onApiCopySelection.bind(this)}],
             ['getPopupInfo',            {async: false, handler: this._onApiGetPopupInfo.bind(this)}],
-            ['getDocumentInformation',  {async: false, handler: this._onApiGetDocumentInformation.bind(this)}]
+            ['getDocumentInformation',  {async: false, handler: this._onApiGetDocumentInformation.bind(this)}],
+            ['setAllVisibleOverride',   {async: true,  handler: this._onApiSetAllVisibleOverride.bind(this)}],
+            ['clearAllVisibleOverride', {async: true,  handler: this._onApiClearAllVisibleOverride.bind(this)}]
         ]);
 
         this._updateContentScale();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -67,9 +67,7 @@ class Frontend {
         this._isPointerOverPopup = false;
 
         this._runtimeMessageHandlers = new Map([
-            ['requestFrontendReadyBroadcast', {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}],
-            ['setAllVisibleOverride',         {async: true,  handler: this._onApiSetAllVisibleOverride.bind(this)}],
-            ['clearAllVisibleOverride',       {async: true,  handler: this._onApiClearAllVisibleOverride.bind(this)}]
+            ['requestFrontendReadyBroadcast', {async: false, handler: this._onMessageRequestFrontendReadyBroadcast.bind(this)}]
         ]);
     }
 

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -77,18 +77,6 @@ const api = (() => {
             return this._invoke('kanjiFind', {text, optionsContext});
         }
 
-        definitionAdd(definition, mode, context, ownerFrameId, optionsContext) {
-            return this._invoke('definitionAdd', {definition, mode, context, ownerFrameId, optionsContext});
-        }
-
-        definitionsAddable(definitions, modes, context, optionsContext) {
-            return this._invoke('definitionsAddable', {definitions, modes, context, optionsContext});
-        }
-
-        noteView(noteId) {
-            return this._invoke('noteView', {noteId});
-        }
-
         templateRender(template, data, marker) {
             return this._invoke('templateRender', {data, template, marker});
         }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -77,10 +77,6 @@ const api = (() => {
             return this._invoke('kanjiFind', {text, optionsContext});
         }
 
-        templateRender(template, data, marker) {
-            return this._invoke('templateRender', {data, template, marker});
-        }
-
         audioGetUri(source, expression, reading, details) {
             return this._invoke('audioGetUri', {source, expression, reading, details});
         }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -24,6 +24,7 @@
  * MediaLoader
  * PopupFactory
  * QueryParser
+ * TemplateRenderer
  * WindowScroll
  * api
  * dynamicLoader
@@ -85,6 +86,7 @@ class Display extends EventDispatcher {
         this._ownerFrameId = null;
         this._defaultAnkiFieldTemplates = null;
         this._defaultAnkiFieldTemplatesPromise = null;
+        this._templateRenderer = new TemplateRenderer();
 
         this.registerActions([
             ['close',            () => { this.onEscape(); }],
@@ -1335,5 +1337,9 @@ class Display extends EventDispatcher {
         const value = await api.getDefaultAnkiFieldTemplates();
         this._defaultAnkiFieldTemplates = value;
         return value;
+    }
+
+    async _renderTemplate(template, data, marker) {
+        return await this._templateRenderer.render(template, data, marker);
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -83,6 +83,8 @@ class Display extends EventDispatcher {
         });
         this._mode = null;
         this._ownerFrameId = null;
+        this._defaultAnkiFieldTemplates = null;
+        this._defaultAnkiFieldTemplatesPromise = null;
 
         this.registerActions([
             ['close',            () => { this.onEscape(); }],
@@ -1306,5 +1308,32 @@ class Display extends EventDispatcher {
         }
         this._mode = mode;
         this.trigger('modeChange', {mode});
+    }
+
+    async _getTemplates(options) {
+        let templates = options.anki.fieldTemplates;
+        if (typeof templates === 'string') { return templates; }
+
+        templates = this._defaultAnkiFieldTemplates;
+        if (typeof templates === 'string') { return templates; }
+
+        return await this._getDefaultTemplatesPromise();
+    }
+
+    _getDefaultTemplatesPromise() {
+        if (this._defaultAnkiFieldTemplatesPromise === null) {
+            this._defaultAnkiFieldTemplatesPromise = this._getDefaultTemplates();
+            this._defaultAnkiFieldTemplatesPromise.then(
+                () => { this._defaultAnkiFieldTemplatesPromise = null; },
+                () => {} // NOP
+            );
+        }
+        return this._defaultAnkiFieldTemplatesPromise;
+    }
+
+    async _getDefaultTemplates() {
+        const value = await api.getDefaultAnkiFieldTemplates();
+        this._defaultAnkiFieldTemplates = value;
+        return value;
     }
 }


### PR DESCRIPTION
This change moves the usage of `AnkiConnect` and `AnkiNoteBuilder` into `Display` (and the respective settings controllers). This change is necessary to create the sandboxed iframe with manifest v3 support, since the background page (service worker) will no longer support DOM.