### PR TITLE
OptionsUtil refactor / options default values

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -41,7 +41,6 @@ class Backend {
         this._mecab = new Mecab();
         this._clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
         this._options = null;
-        this._optionsSchema = null;
         this._optionsSchemaValidator = new JsonSchemaValidator();
         this._profileConditionsSchemaCache = [];
         this._profileConditionsUtil = new ProfileConditions();
@@ -189,7 +188,6 @@ class Backend {
             await this._translator.prepare();
 
             await this._optionsUtil.prepare();
-            this._optionsSchema = this._optionsUtil.optionsSchema;
             this._defaultAnkiFieldTemplates = (await this._fetchAsset('/bg/data/default-anki-field-templates.handlebars')).trim();
             this._options = await this._optionsUtil.load();
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -54,7 +54,7 @@ class Backend {
             requestBuilder: this._requestBuilder,
             useCache: false
         });
-        this._optionsUtil = new OptionsUtil(this._optionsSchemaValidator);
+        this._optionsUtil = new OptionsUtil();
 
         this._clipboardPasteTarget = null;
         this._clipboardPasteTargetInitialized = false;

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -55,7 +55,7 @@ class Backend {
             requestBuilder: this._requestBuilder,
             useCache: false
         });
-        this._optionsUtil = new OptionsUtil();
+        this._optionsUtil = new OptionsUtil(this._optionsSchemaValidator);
 
         this._clipboardPasteTarget = null;
         this._clipboardPasteTargetInitialized = false;
@@ -189,10 +189,10 @@ class Backend {
             }
             await this._translator.prepare();
 
-            this._optionsSchema = await this._fetchAsset('/bg/data/options-schema.json', true);
+            await this._optionsUtil.prepare();
+            this._optionsSchema = this._optionsUtil.optionsSchema;
             this._defaultAnkiFieldTemplates = (await this._fetchAsset('/bg/data/default-anki-field-templates.handlebars')).trim();
             this._options = await this._optionsUtil.load();
-            this._options = this._optionsSchemaValidator.getValidValueOrDefault(this._optionsSchema, this._options);
 
             this._applyOptions('background');
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -41,7 +41,7 @@ class Backend {
         this._mecab = new Mecab();
         this._clipboardMonitor = new ClipboardMonitor({getClipboard: this._onApiClipboardGet.bind(this)});
         this._options = null;
-        this._optionsSchemaValidator = new JsonSchemaValidator();
+        this._profileConditionsSchemaValidator = new JsonSchemaValidator();
         this._profileConditionsSchemaCache = [];
         this._profileConditionsUtil = new ProfileConditions();
         this._defaultAnkiFieldTemplates = null;
@@ -1009,7 +1009,7 @@ class Backend {
                 this._profileConditionsSchemaCache.push(schema);
             }
 
-            if (conditionGroups.length > 0 && this._optionsSchemaValidator.isValid(optionsContext, schema)) {
+            if (conditionGroups.length > 0 && this._profileConditionsSchemaValidator.isValid(optionsContext, schema)) {
                 return profile;
             }
             ++index;
@@ -1020,7 +1020,7 @@ class Backend {
 
     _clearProfileConditionsSchemaCache() {
         this._profileConditionsSchemaCache = [];
-        this._optionsSchemaValidator.clearCache();
+        this._profileConditionsSchemaValidator.clearCache();
     }
 
     _checkLastError() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -223,7 +223,7 @@ class Backend {
 
     getFullOptions(useSchema=false) {
         const options = this._options;
-        return useSchema ? this._optionsSchemaValidator.createProxy(options, this._optionsSchema) : options;
+        return useSchema ? this._optionsUtil.createValidatingProxy(options) : options;
     }
 
     getOptions(optionsContext, useSchema=false) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -79,7 +79,6 @@ class Backend {
 
         this._messageHandlers = new Map([
             ['requestBackendReadySignal',    {async: false, contentScript: true,  handler: this._onApiRequestBackendReadySignal.bind(this)}],
-            ['optionsSchemaGet',             {async: false, contentScript: true,  handler: this._onApiOptionsSchemaGet.bind(this)}],
             ['optionsGet',                   {async: false, contentScript: true,  handler: this._onApiOptionsGet.bind(this)}],
             ['optionsGetFull',               {async: false, contentScript: true,  handler: this._onApiOptionsGetFull.bind(this)}],
             ['optionsSave',                  {async: true,  contentScript: true,  handler: this._onApiOptionsSave.bind(this)}],
@@ -369,10 +368,6 @@ class Backend {
             chrome.tabs.sendMessage(sender.tab.id, data, callback);
             return true;
         }
-    }
-
-    _onApiOptionsSchemaGet() {
-        return this._optionsSchema;
     }
 
     _onApiOptionsGet({optionsContext}) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -788,7 +788,8 @@ class Backend {
     }
 
     async _onApiSetAllSettings({value, source}) {
-        this._options = this._optionsSchemaValidator.getValidValueOrDefault(this._optionsSchema, value);
+        this._optionsUtil.validate(value);
+        this._options = clone(value);
         await this._onApiOptionsSave({source});
     }
 

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -55,6 +55,7 @@ class Backend {
             requestBuilder: this._requestBuilder,
             useCache: false
         });
+        this._optionsUtil = new OptionsUtil();
 
         this._clipboardPasteTarget = null;
         this._clipboardPasteTargetInitialized = false;
@@ -190,7 +191,7 @@ class Backend {
 
             this._optionsSchema = await this._fetchAsset('/bg/data/options-schema.json', true);
             this._defaultAnkiFieldTemplates = (await this._fetchAsset('/bg/data/default-anki-field-templates.handlebars')).trim();
-            this._options = await OptionsUtil.load();
+            this._options = await this._optionsUtil.load();
             this._options = this._optionsSchemaValidator.getValidValueOrDefault(this._optionsSchema, this._options);
 
             this._applyOptions('background');
@@ -385,7 +386,7 @@ class Backend {
     async _onApiOptionsSave({source}) {
         this._clearProfileConditionsSchemaCache();
         const options = this.getFullOptions();
-        await OptionsUtil.save(options);
+        await this._optionsUtil.save(options);
         this._applyOptions(source);
     }
 

--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -149,7 +149,7 @@ class JsonSchemaValidator {
     getValidValueOrDefault(schema, value) {
         let type = this._getValueType(value);
         const schemaType = schema.type;
-        if (!this._isValueTypeAny(value, type, schemaType)) {
+        if (typeof value === 'undefined' || !this._isValueTypeAny(value, type, schemaType)) {
             let assignDefault = true;
 
             const schemaDefault = schema.default;

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -21,10 +21,6 @@ class OptionsUtil {
         this._optionsSchema = null;
     }
 
-    get optionsSchema() {
-        return this._optionsSchema;
-    }
-
     async prepare() {
         this._optionsSchema = await this._fetchAsset('/bg/data/options-schema.json', true);
     }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -129,6 +129,10 @@ class OptionsUtil {
         return this._schemaValidator.getValidValueOrDefault(this._optionsSchema);
     }
 
+    createValidatingProxy(options) {
+        return this._schemaValidator.createProxy(options, this._optionsSchema);
+    }
+
     // Legacy profile updating
 
     _legacyProfileUpdateGetUpdates() {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -15,9 +15,13 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* global
+ * JsonSchemaValidator
+ */
+
 class OptionsUtil {
-    constructor(schemaValidator) {
-        this._schemaValidator = schemaValidator;
+    constructor() {
+        this._schemaValidator = new JsonSchemaValidator();
         this._optionsSchema = null;
     }
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -79,7 +79,7 @@ class OptionsUtil {
                 chrome.storage.local.get(['options'], (store) => {
                     const error = chrome.runtime.lastError;
                     if (error) {
-                        reject(new Error(error));
+                        reject(new Error(error.message));
                     } else {
                         resolve(store.options);
                     }
@@ -98,7 +98,7 @@ class OptionsUtil {
             chrome.storage.local.set({options: JSON.stringify(options)}, () => {
                 const error = chrome.runtime.lastError;
                 if (error) {
-                    reject(new Error(error));
+                    reject(new Error(error.message));
                 } else {
                     resolve();
                 }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -133,6 +133,10 @@ class OptionsUtil {
         return this._schemaValidator.createProxy(options, this._optionsSchema);
     }
 
+    validate(options) {
+        return this._schemaValidator.validate(options, this._optionsSchema);
+    }
+
     // Legacy profile updating
 
     _legacyProfileUpdateGetUpdates() {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -125,7 +125,7 @@ class OptionsUtil {
         });
     }
 
-    async getDefault() {
+    getDefault() {
         return this._schemaValidator.getValidValueOrDefault(this._optionsSchema);
     }
 

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -351,7 +351,7 @@ class OptionsUtil {
             const fieldTemplates = profileOptions.anki.fieldTemplates;
             if (fieldTemplates !== null) {
                 if (addition === null) {
-                    addition = await this._readFile(additionSourceUrl);
+                    addition = await this._fetchAsset(additionSourceUrl);
                 }
                 profileOptions.anki.fieldTemplates = this._addFieldTemplatesBeforeEnd(fieldTemplates, addition);
             }
@@ -373,7 +373,7 @@ class OptionsUtil {
         return fieldTemplates;
     }
 
-    static async _readFile(url) {
+    static async _fetchAsset(url, json=false) {
         url = chrome.runtime.getURL(url);
         const response = await fetch(url, {
             method: 'GET',
@@ -383,7 +383,10 @@ class OptionsUtil {
             redirect: 'follow',
             referrerPolicy: 'no-referrer'
         });
-        return await response.text();
+        if (!response.ok) {
+            throw new Error(`Failed to fetch ${url}: ${response.status}`);
+        }
+        return await (json ? response.json() : response.text());
     }
 
     static _getStringHashCode(string) {

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -16,7 +16,7 @@
  */
 
 class OptionsUtil {
-    static async update(options) {
+    async update(options) {
         // Invalid options
         if (!isObject(options)) {
             options = {};
@@ -72,7 +72,7 @@ class OptionsUtil {
         return await this._applyUpdates(options, this._getVersionUpdates());
     }
 
-    static async load() {
+    async load() {
         let options = null;
         try {
             const optionsStr = await new Promise((resolve, reject) => {
@@ -93,7 +93,7 @@ class OptionsUtil {
         return await this.update(options);
     }
 
-    static save(options) {
+    save(options) {
         return new Promise((resolve, reject) => {
             chrome.storage.local.set({options: JSON.stringify(options)}, () => {
                 const error = chrome.runtime.lastError;
@@ -106,13 +106,13 @@ class OptionsUtil {
         });
     }
 
-    static async getDefault() {
+    async getDefault() {
         return await this.update({});
     }
 
     // Legacy profile updating
 
-    static _legacyProfileUpdateGetUpdates() {
+    _legacyProfileUpdateGetUpdates() {
         return [
             null,
             null,
@@ -203,7 +203,7 @@ class OptionsUtil {
         ];
     }
 
-    static _legacyProfileUpdateGetDefaults() {
+    _legacyProfileUpdateGetDefaults() {
         return {
             general: {
                 enable: true,
@@ -302,7 +302,7 @@ class OptionsUtil {
         };
     }
 
-    static _legacyProfileUpdateAssignDefaults(options) {
+    _legacyProfileUpdateAssignDefaults(options) {
         const defaults = this._legacyProfileUpdateGetDefaults();
 
         const combine = (target, source) => {
@@ -323,7 +323,7 @@ class OptionsUtil {
         return options;
     }
 
-    static _legacyProfileUpdateUpdateVersion(options) {
+    _legacyProfileUpdateUpdateVersion(options) {
         const updates = this._legacyProfileUpdateGetUpdates();
         this._legacyProfileUpdateAssignDefaults(options);
 
@@ -345,7 +345,7 @@ class OptionsUtil {
 
     // Private
 
-    static async _addFieldTemplatesToOptions(options, additionSourceUrl) {
+    async _addFieldTemplatesToOptions(options, additionSourceUrl) {
         let addition = null;
         for (const {options: profileOptions} of options.profiles) {
             const fieldTemplates = profileOptions.anki.fieldTemplates;
@@ -358,7 +358,7 @@ class OptionsUtil {
         }
     }
 
-    static async _addFieldTemplatesBeforeEnd(fieldTemplates, addition) {
+    async _addFieldTemplatesBeforeEnd(fieldTemplates, addition) {
         const pattern = /[ \t]*\{\{~?>\s*\(\s*lookup\s*\.\s*"marker"\s*\)\s*~?\}\}/;
         const newline = '\n';
         let replaced = false;
@@ -373,7 +373,7 @@ class OptionsUtil {
         return fieldTemplates;
     }
 
-    static async _fetchAsset(url, json=false) {
+    async _fetchAsset(url, json=false) {
         url = chrome.runtime.getURL(url);
         const response = await fetch(url, {
             method: 'GET',
@@ -389,7 +389,7 @@ class OptionsUtil {
         return await (json ? response.json() : response.text());
     }
 
-    static _getStringHashCode(string) {
+    _getStringHashCode(string) {
         let hashCode = 0;
 
         if (typeof string !== 'string') { return hashCode; }
@@ -402,7 +402,7 @@ class OptionsUtil {
         return hashCode;
     }
 
-    static async _applyUpdates(options, updates) {
+    async _applyUpdates(options, updates) {
         const targetVersion = updates.length;
         let currentVersion = options.version;
 
@@ -420,7 +420,7 @@ class OptionsUtil {
         return options;
     }
 
-    static _getVersionUpdates() {
+    _getVersionUpdates() {
         return [
             {
                 async: false,
@@ -441,7 +441,7 @@ class OptionsUtil {
         ];
     }
 
-    static _updateVersion1(options) {
+    _updateVersion1(options) {
         // Version 1 changes:
         //  Added options.global.database.prefixWildcardsSupported = false.
         options.global = {
@@ -452,7 +452,7 @@ class OptionsUtil {
         return options;
     }
 
-    static _updateVersion2(options) {
+    _updateVersion2(options) {
         // Version 2 changes:
         //  Legacy profile update process moved into this upgrade function.
         for (const profile of options.profiles) {
@@ -464,14 +464,14 @@ class OptionsUtil {
         return options;
     }
 
-    static async _updateVersion3(options) {
+    async _updateVersion3(options) {
         // Version 3 changes:
         //  Pitch accent Anki field templates added.
         await this._addFieldTemplatesToOptions(options, '/bg/data/anki-field-templates-upgrade-v2.handlebars');
         return options;
     }
 
-    static async _updateVersion4(options) {
+    async _updateVersion4(options) {
         // Version 4 changes:
         //  Options conditions converted to string representations.
         //  Added usePopupWindow.

--- a/ext/bg/js/settings/backup-controller.js
+++ b/ext/bg/js/settings/backup-controller.js
@@ -26,6 +26,7 @@ class BackupController {
         this._settingsExportToken = null;
         this._settingsExportRevoke = null;
         this._currentVersion = 0;
+        this._optionsUtil = new OptionsUtil();
     }
 
     prepare() {
@@ -322,7 +323,7 @@ class BackupController {
         }
 
         // Upgrade options
-        optionsFull = await OptionsUtil.update(optionsFull);
+        optionsFull = await this._optionsUtil.update(optionsFull);
 
         // Check for warnings
         const sanitizationWarnings = this._settingsImportSanitizeOptions(optionsFull, true);
@@ -368,7 +369,7 @@ class BackupController {
         $('#settings-reset-modal').modal('hide');
 
         // Get default options
-        const optionsFull = await OptionsUtil.getDefault();
+        const optionsFull = await this._optionsUtil.getDefault();
 
         // Assign options
         await this._settingsImportSetOptionsFull(optionsFull);

--- a/ext/bg/js/settings/backup-controller.js
+++ b/ext/bg/js/settings/backup-controller.js
@@ -375,7 +375,7 @@ class BackupController {
         $('#settings-reset-modal').modal('hide');
 
         // Get default options
-        const optionsFull = await this._optionsUtil.getDefault();
+        const optionsFull = this._optionsUtil.getDefault();
 
         // Assign options
         await this._settingsImportSetOptionsFull(optionsFull);

--- a/ext/bg/js/settings/backup-controller.js
+++ b/ext/bg/js/settings/backup-controller.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * JsonSchemaValidator
  * OptionsUtil
  * api
  */
@@ -26,10 +27,12 @@ class BackupController {
         this._settingsExportToken = null;
         this._settingsExportRevoke = null;
         this._currentVersion = 0;
-        this._optionsUtil = new OptionsUtil();
+        this._optionsUtil = new OptionsUtil(new JsonSchemaValidator());
     }
 
-    prepare() {
+    async prepare() {
+        await this._optionsUtil.prepare();
+
         document.querySelector('#settings-export').addEventListener('click', this._onSettingsExportClick.bind(this), false);
         document.querySelector('#settings-import').addEventListener('click', this._onSettingsImportClick.bind(this), false);
         document.querySelector('#settings-import-file').addEventListener('change', this._onSettingsImportFileChange.bind(this), false);

--- a/ext/bg/js/settings/backup-controller.js
+++ b/ext/bg/js/settings/backup-controller.js
@@ -144,7 +144,11 @@ class BackupController {
     // Importing
 
     async _settingsImportSetOptionsFull(optionsFull) {
-        await this._settingsController.setAllSettings(optionsFull);
+        try {
+            await this._settingsController.setAllSettings(optionsFull);
+        } catch (e) {
+            yomichan.logError(e);
+        }
     }
 
     _showSettingsImportError(error) {

--- a/ext/bg/js/settings/backup-controller.js
+++ b/ext/bg/js/settings/backup-controller.js
@@ -16,7 +16,6 @@
  */
 
 /* global
- * JsonSchemaValidator
  * OptionsUtil
  * api
  */
@@ -27,7 +26,7 @@ class BackupController {
         this._settingsExportToken = null;
         this._settingsExportRevoke = null;
         this._currentVersion = 0;
-        this._optionsUtil = new OptionsUtil(new JsonSchemaValidator());
+        this._optionsUtil = new OptionsUtil();
     }
 
     async prepare() {

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -49,10 +49,6 @@ const api = (() => {
 
         // Invoke functions
 
-        optionsSchemaGet() {
-            return this._invoke('optionsSchemaGet');
-        }
-
         optionsGet(optionsContext) {
             return this._invoke('optionsGet', {optionsContext});
         }


### PR DESCRIPTION
This change refactors `OptionsUtil`, moves some functionality from `Backend` into it, and changes how default values are assigned.

Default options values are now assigned directly from the schema, bypassing the upgrade process. This change has the side effect of disabling `scanning.middleMouse` by default, which was mentioned in #479. (This is also partially due to the recent changes in how scanning inputs are defined.)