### PR TITLE
Settings scanning refactor

### DIFF
--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -387,10 +387,6 @@
                 <h3>Scanning Options</h3>
 
                 <div class="checkbox">
-                    <label><input type="checkbox" id="touch-input-enabled" data-setting="scanning.touchInputEnabled"> Touch input enabled</label>
-                </div>
-
-                <div class="checkbox">
                     <label><input type="checkbox" id="select-matched-text" data-setting="scanning.selectText"> Select matched text</label>
                 </div>
 
@@ -404,6 +400,10 @@
 
                 <div class="checkbox">
                     <label><input type="checkbox" id="layout-aware-scan" data-setting="scanning.layoutAwareScan"> Layout-aware scan</label>
+                </div>
+
+                <div class="checkbox options-advanced">
+                    <label><input type="checkbox" id="touch-input-enabled" data-setting="scanning.touchInputEnabled"> Touch input enabled</label>
                 </div>
 
                 <div class="checkbox options-advanced">

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -407,7 +407,7 @@
                 </div>
 
                 <div class="checkbox options-advanced">
-                    <label><input type="checkbox" id="deep-dom-scan" data-setting="scanning.deepDomScan"> Deep DOM scan</label>
+                    <label><input type="checkbox" id="deep-dom-scan" data-setting="scanning.deepDomScan"> Deep content scan</label>
                 </div>
 
                 <div class="form-group options-advanced">


### PR DESCRIPTION
* Moves input for `scanning.touchInputEnabled`.
* Makes `scanning.touchInputEnabled` an advanced option.
* Renames `Deep DOM scan` to `Deep content scan`.