### PR TITLE
Pointer events support

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -320,6 +320,7 @@
                                 "required": [
                                     "inputs",
                                     "touchInputEnabled",
+                                    "pointerEventsEnabled",
                                     "selectText",
                                     "alphanumeric",
                                     "autoHideResults",
@@ -429,6 +430,10 @@
                                     "touchInputEnabled": {
                                         "type": "boolean",
                                         "default": true
+                                    },
+                                    "pointerEventsEnabled": {
+                                        "type": "boolean",
+                                        "default": false
                                     },
                                     "selectText": {
                                         "type": "boolean",

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -505,6 +505,7 @@ class OptionsUtil {
         //  Updated handlebars templates to include "clipboard-image" definition.
         //  Added hideDelay.
         //  Added inputs to profileOptions.scanning.
+        //  Added pointerEventsEnabled to profileOptions.scanning.
         for (const {conditionGroups} of options.profiles) {
             for (const {conditions} of conditionGroups) {
                 for (const condition of conditions) {
@@ -526,6 +527,7 @@ class OptionsUtil {
         for (const {options: profileOptions} of options.profiles) {
             profileOptions.general.usePopupWindow = false;
             profileOptions.scanning.hideDelay = 0;
+            profileOptions.scanning.pointerEventsEnabled = false;
 
             const {modifier, middleMouse, touchInputEnabled} = profileOptions.scanning;
             const scanningInputs = [];

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -407,6 +407,10 @@
                 </div>
 
                 <div class="checkbox options-advanced">
+                    <label><input type="checkbox" data-setting="scanning.pointerEventsEnabled"> Pointer events input enabled</label>
+                </div>
+
+                <div class="checkbox options-advanced">
                     <label><input type="checkbox" id="deep-dom-scan" data-setting="scanning.deepDomScan"> Deep content scan</label>
                 </div>
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -326,6 +326,7 @@ class Frontend {
             selectText: scanningOptions.selectText,
             delay: scanningOptions.delay,
             touchInputEnabled: scanningOptions.touchInputEnabled,
+            pointerEventsEnabled: scanningOptions.pointerEventsEnabled,
             scanLength: scanningOptions.length,
             sentenceExtent: options.anki.sentenceExt,
             layoutAwareScan: scanningOptions.layoutAwareScan

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -252,6 +252,7 @@ class Display extends EventDispatcher {
                 selectText: scanning.selectText,
                 delay: scanning.delay,
                 touchInputEnabled: scanning.touchInputEnabled,
+                pointerEventsEnabled: scanning.pointerEventsEnabled,
                 scanLength: scanning.length,
                 sentenceExtent: options.anki.sentenceExt,
                 layoutAwareScan: scanning.layoutAwareScan

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -45,6 +45,7 @@ class TextScanner extends EventDispatcher {
         this._selectText = false;
         this._delay = 0;
         this._touchInputEnabled = false;
+        this._pointerEventsEnabled = false;
         this._scanLength = 1;
         this._sentenceExtent = 1;
         this._layoutAwareScan = false;
@@ -106,7 +107,7 @@ class TextScanner extends EventDispatcher {
         }
     }
 
-    setOptions({inputs, deepContentScan, selectText, delay, touchInputEnabled, scanLength, sentenceExtent, layoutAwareScan}) {
+    setOptions({inputs, deepContentScan, selectText, delay, touchInputEnabled, pointerEventsEnabled, scanLength, sentenceExtent, layoutAwareScan}) {
         if (Array.isArray(inputs)) {
             this._inputs = inputs.map(({include, exclude, types}) => ({
                 include: this._getInputArray(include),
@@ -125,6 +126,9 @@ class TextScanner extends EventDispatcher {
         }
         if (typeof touchInputEnabled === 'boolean') {
             this._touchInputEnabled = touchInputEnabled;
+        }
+        if (typeof pointerEventsEnabled === 'boolean') {
+            this._pointerEventsEnabled = pointerEventsEnabled;
         }
         if (typeof scanLength === 'number') {
             this._scanLength = scanLength;
@@ -392,6 +396,10 @@ class TextScanner extends EventDispatcher {
             this._scanTimerPromise.resolve(false);
             this._scanTimerPromise = null;
         }
+    }
+
+    _arePointerEventsSupported() {
+        return (this._pointerEventsEnabled && typeof PointerEvent !== 'undefined');
     }
 
     _hookEvents() {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -109,10 +109,16 @@ class TextScanner extends EventDispatcher {
 
     setOptions({inputs, deepContentScan, selectText, delay, touchInputEnabled, pointerEventsEnabled, scanLength, sentenceExtent, layoutAwareScan}) {
         if (Array.isArray(inputs)) {
-            this._inputs = inputs.map(({include, exclude, types}) => ({
+            this._inputs = inputs.map(({
+                include,
+                exclude,
+                types,
+                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease}
+            }) => ({
                 include: this._getInputArray(include),
                 exclude: this._getInputArray(exclude),
-                types: this._getInputTypeSet(types)
+                types: this._getInputTypeSet(types),
+                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease}
             }));
         }
         if (typeof deepContentScan === 'boolean') {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -388,6 +388,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerOver(e);
+            case 'touch': return this._onTouchPointerOver(e);
         }
     }
 
@@ -395,6 +396,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerDown(e);
+            case 'touch': return this._onTouchPointerDown(e);
         }
     }
 
@@ -402,6 +404,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerMove(e);
+            case 'touch': return this._onTouchPointerMove(e);
         }
     }
 
@@ -409,6 +412,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerUp(e);
+            case 'touch': return this._onTouchPointerUp(e);
         }
     }
 
@@ -416,6 +420,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerCancel(e);
+            case 'touch': return this._onTouchPointerCancel(e);
         }
     }
 
@@ -423,6 +428,7 @@ class TextScanner extends EventDispatcher {
         if (!e.isPrimary) { return; }
         switch (e.pointerType) {
             case 'mouse': return this._onMousePointerOut(e);
+            case 'touch': return this._onTouchPointerOut(e);
         }
     }
 
@@ -448,6 +454,49 @@ class TextScanner extends EventDispatcher {
 
     _onMousePointerOut(e) {
         return this._onMouseOut(e);
+    }
+
+    _onTouchPointerOver() {
+        // NOP
+    }
+
+    _onTouchPointerDown(e) {
+        const {clientX, clientY, pointerId} = e;
+        return this._onPrimaryTouchStart(e, clientX, clientY, pointerId);
+    }
+
+    _onTouchPointerMove(e) {
+        if (!this._preventScroll || !e.cancelable) {
+            return;
+        }
+
+        const inputInfo = this._getMatchingInputGroupFromEvent(e, 'touch');
+        if (inputInfo === null) { return; }
+
+        const {index, empty} = inputInfo;
+        this._searchAt(e.clientX, e.clientY, {type: 'touch', cause: 'touchMove', index, empty});
+    }
+
+    _onTouchPointerUp() {
+        return this._onPrimaryTouchEnd();
+    }
+
+    _onTouchPointerCancel() {
+        return this._onPrimaryTouchEnd();
+    }
+
+    _onTouchPointerOut() {
+        // NOP
+    }
+
+    _onTouchMovePreventScroll(e) {
+        if (!this._preventScroll) { return; }
+
+        if (e.cancelable) {
+            e.preventDefault();
+        } else {
+            this._preventScroll = false;
+        }
     }
 
     async _scanTimerWait() {
@@ -497,7 +546,11 @@ class TextScanner extends EventDispatcher {
             [this._node, 'pointermove', this._onPointerMove.bind(this)],
             [this._node, 'pointerup', this._onPointerUp.bind(this)],
             [this._node, 'pointercancel', this._onPointerCancel.bind(this)],
-            [this._node, 'pointerout', this._onPointerOut.bind(this)]
+            [this._node, 'pointerout', this._onPointerOut.bind(this)],
+            [this._node, 'touchmove', this._onTouchMovePreventScroll.bind(this), {passive: false}],
+            [this._node, 'mousedown', this._onMouseDown.bind(this)],
+            [this._node, 'click', this._onClick.bind(this)],
+            [this._node, 'auxclick', this._onAuxClick.bind(this)]
         ];
     }
 

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -384,6 +384,72 @@ class TextScanner extends EventDispatcher {
         e.preventDefault(); // Disable scroll
     }
 
+    _onPointerOver(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerOver(e);
+        }
+    }
+
+    _onPointerDown(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerDown(e);
+        }
+    }
+
+    _onPointerMove(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerMove(e);
+        }
+    }
+
+    _onPointerUp(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerUp(e);
+        }
+    }
+
+    _onPointerCancel(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerCancel(e);
+        }
+    }
+
+    _onPointerOut(e) {
+        if (!e.isPrimary) { return; }
+        switch (e.pointerType) {
+            case 'mouse': return this._onMousePointerOut(e);
+        }
+    }
+
+    _onMousePointerOver(e) {
+        return this._onMouseOver(e);
+    }
+
+    _onMousePointerDown(e) {
+        return this._onMouseDown(e);
+    }
+
+    _onMousePointerMove(e) {
+        return this._onMouseMove(e);
+    }
+
+    _onMousePointerUp() {
+        // NOP
+    }
+
+    _onMousePointerCancel(e) {
+        return this._onMouseOut(e);
+    }
+
+    _onMousePointerOut(e) {
+        return this._onMouseOut(e);
+    }
+
     async _scanTimerWait() {
         const delay = this._delay;
         const promise = promiseTimeout(delay, true);
@@ -409,14 +475,30 @@ class TextScanner extends EventDispatcher {
     }
 
     _hookEvents() {
-        const eventListenerInfos = this._getMouseEventListeners();
-        if (this._touchInputEnabled) {
-            eventListenerInfos.push(...this._getTouchEventListeners());
+        let eventListenerInfos;
+        if (this._arePointerEventsSupported()) {
+            eventListenerInfos = this._getPointerEventListeners();
+        } else {
+            eventListenerInfos = this._getMouseEventListeners();
+            if (this._touchInputEnabled) {
+                eventListenerInfos.push(...this._getTouchEventListeners());
+            }
         }
 
         for (const [node, type, listener, options] of eventListenerInfos) {
             this._eventListeners.addEventListener(node, type, listener, options);
         }
+    }
+
+    _getPointerEventListeners() {
+        return [
+            [this._node, 'pointerover', this._onPointerOver.bind(this)],
+            [this._node, 'pointerdown', this._onPointerDown.bind(this)],
+            [this._node, 'pointermove', this._onPointerMove.bind(this)],
+            [this._node, 'pointerup', this._onPointerUp.bind(this)],
+            [this._node, 'pointercancel', this._onPointerCancel.bind(this)],
+            [this._node, 'pointerout', this._onPointerOut.bind(this)]
+        ];
     }
 
     _getMouseEventListeners() {


### PR DESCRIPTION
This change adds support for pointer events, which enables custom scanning modifiers for pen devices.

This change works well on Chrome, but has some issues on Firefox, which are presumably browser bugs:
* Pen pointer up/down events register as `touch` events instead of `pen` events. over/out events register correctly as `pen`.
* The above bug also causes the keyboard-mouse input fields on the settings page to not detect pen buttons correctly.
* Pen buttons also are not even detected correctly when buttons are held. On Chrome, they do work as expected.

The events incorrectly registering as `touch` instead of `pen` can probably be worked around, since the `pointerId` is the same for both. This will be done as a separate change later.

Originally mentioned in #267. This feature is disabled by default.