### PR TITLE
Add scan dictionary type filters

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -352,7 +352,9 @@
                                                     "showAdvanced": false,
                                                     "scanOnPenHover": true,
                                                     "scanOnPenPress": true,
-                                                    "scanOnPenRelease": false
+                                                    "scanOnPenRelease": false,
+                                                    "searchTerms": true,
+                                                    "searchKanji": true
                                                 }
                                             },
                                             {
@@ -367,7 +369,9 @@
                                                     "showAdvanced": false,
                                                     "scanOnPenHover": true,
                                                     "scanOnPenPress": true,
-                                                    "scanOnPenRelease": false
+                                                    "scanOnPenRelease": false,
+                                                    "searchTerms": true,
+                                                    "searchKanji": true
                                                 }
                                             }
                                         ],
@@ -415,7 +419,9 @@
                                                         "showAdvanced",
                                                         "scanOnPenHover",
                                                         "scanOnPenPress",
-                                                        "scanOnPenRelease"
+                                                        "scanOnPenRelease",
+                                                        "searchTerms",
+                                                        "searchKanji"
                                                     ],
                                                     "properties": {
                                                         "showAdvanced": {
@@ -433,6 +439,14 @@
                                                         "scanOnPenRelease": {
                                                             "type": "boolean",
                                                             "default": false
+                                                        },
+                                                        "searchTerms": {
+                                                            "type": "boolean",
+                                                            "default": true
+                                                        },
+                                                        "searchKanji": {
+                                                            "type": "boolean",
+                                                            "default": true
                                                         }
                                                     }
                                                 }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -522,7 +522,9 @@ class OptionsUtil {
             showAdvanced: false,
             scanOnPenHover: true,
             scanOnPenPress: true,
-            scanOnPenRelease: false
+            scanOnPenRelease: false,
+            searchTerms: true,
+            searchKanji: true
         });
         for (const {options: profileOptions} of options.profiles) {
             profileOptions.general.usePopupWindow = false;

--- a/ext/bg/js/settings/scan-inputs-controller.js
+++ b/ext/bg/js/settings/scan-inputs-controller.js
@@ -101,7 +101,9 @@ class ScanInputsController {
                     showAdvanced: false,
                     scanOnPenHover: true,
                     scanOnPenPress: true,
-                    scanOnPenRelease: false
+                    scanOnPenRelease: false,
+                    searchTerms: true,
+                    searchKanji: true
                 }
             }]
         }]);

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -472,6 +472,8 @@
                             <div class="scan-input-prefix-cell" data-property="options"><div class="scan-input-prefix">Options</div></div>
                             <div class="scan-input-content-cell" data-property="options"><div class="scan-input-input-cell-inner">
                                 <div class="scan-input-type-list-container form-control"><div>
+                                    <div><label class="scan-input-toggle"><input type="checkbox" class="scan-input-settings-checkbox" data-property="options.searchTerms"><span>Search for terms</span></label></div>
+                                    <div><label class="scan-input-toggle"><input type="checkbox" class="scan-input-settings-checkbox" data-property="options.searchKanji"><span>Search for kanji</span></label></div>
                                     <div><label class="scan-input-toggle"><input type="checkbox" class="scan-input-settings-checkbox" data-property="options.scanOnPenHover"><span>Scan on pen hover</span></label></div>
                                     <div><label class="scan-input-toggle"><input type="checkbox" class="scan-input-settings-checkbox" data-property="options.scanOnPenPress"><span>Scan on pen press</span></label></div>
                                     <div><label class="scan-input-toggle"><input type="checkbox" class="scan-input-settings-checkbox" data-property="options.scanOnPenRelease"><span>Scan on pen release</span></label></div>

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -685,7 +685,14 @@ class TextScanner extends EventDispatcher {
         if (this._pendingLookup) { return; }
 
         try {
-            const {index, empty} = inputInfo;
+            const {index, empty, input: sourceInput} = inputInfo;
+            let searchTerms = this._searchTerms;
+            let searchKanji = this._searchKanji;
+            if (sourceInput !== null) {
+                if (searchTerms && !sourceInput.options.searchTerms) { searchTerms = false; }
+                if (searchKanji && !sourceInput.options.searchKanji) { searchKanji = false; }
+            }
+
             const input = {type, cause, index, empty};
 
             this._pendingLookup = true;
@@ -697,7 +704,7 @@ class TextScanner extends EventDispatcher {
 
             const textSource = this._documentUtil.getRangeFromPoint(x, y, this._deepContentScan);
             try {
-                await this._search(textSource, this._searchTerms, this._searchKanji, input);
+                await this._search(textSource, searchTerms, searchKanji, input);
             } finally {
                 if (textSource !== null) {
                     textSource.cleanup();

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -274,8 +274,7 @@ class TextScanner extends EventDispatcher {
         const inputInfo = this._getMatchingInputGroupFromEvent(e, 'mouse');
         if (inputInfo === null) { return; }
 
-        const {index, empty} = inputInfo;
-        this._searchAtFromMouseMove(e.clientX, e.clientY, index, empty);
+        this._searchAtFromMouseMove(e.clientX, e.clientY, inputInfo);
     }
 
     _onMouseDown(e) {
@@ -710,17 +709,18 @@ class TextScanner extends EventDispatcher {
         }
     }
 
-    async _searchAtFromMouseMove(x, y, inputIndex, inputEmpty) {
+    async _searchAtFromMouseMove(x, y, inputInfo) {
         if (this._pendingLookup) { return; }
 
-        if (inputEmpty) {
+        const {index, empty} = inputInfo;
+        if (empty) {
             if (!await this._scanTimerWait()) {
                 // Aborted
                 return;
             }
         }
 
-        await this._searchAt(x, y, {type: 'mouse', cause: 'mouseMove', index: inputIndex, empty: inputEmpty});
+        await this._searchAt(x, y, {type: 'mouse', cause: 'mouseMove', index, empty});
     }
 
     async _searchAtFromTouchStart(e, x, y) {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -119,12 +119,12 @@ class TextScanner extends EventDispatcher {
                 include,
                 exclude,
                 types,
-                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease}
+                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease, searchTerms, searchKanji}
             }) => ({
                 include: this._getInputArray(include),
                 exclude: this._getInputArray(exclude),
                 types: this._getInputTypeSet(types),
-                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease}
+                options: {scanOnPenHover, scanOnPenPress, scanOnPenRelease, searchTerms, searchKanji}
             }));
         }
         if (typeof deepContentScan === 'boolean') {

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -206,19 +206,19 @@ class TextScanner extends EventDispatcher {
 
     async searchLast() {
         if (this._textSourceCurrent !== null && this._inputCurrent !== null) {
-            await this._search(this._textSourceCurrent, this._inputCurrent);
+            await this._search(this._textSourceCurrent, this._searchTerms, this._searchKanji, this._inputCurrent);
             return true;
         }
         return false;
     }
 
     async search(textSource) {
-        return await this._search(textSource, {cause: 'script', index: -1, empty: false});
+        return await this._search(textSource, this._searchTerms, this._searchKanji, {cause: 'script', index: -1, empty: false});
     }
 
     // Private
 
-    async _search(textSource, input) {
+    async _search(textSource, searchTerms, searchKanji, input) {
         let definitions = null;
         let sentence = null;
         let type = null;
@@ -234,7 +234,7 @@ class TextScanner extends EventDispatcher {
             optionsContext = await this._getOptionsContext();
             searched = true;
 
-            const result = await this._findDefinitions(textSource, optionsContext);
+            const result = await this._findDefinitions(textSource, searchTerms, searchKanji, optionsContext);
             if (result !== null) {
                 ({definitions, sentence, type} = result);
                 this._inputCurrent = input;
@@ -638,15 +638,15 @@ class TextScanner extends EventDispatcher {
         return null;
     }
 
-    async _findDefinitions(textSource, optionsContext) {
+    async _findDefinitions(textSource, searchTerms, searchKanji, optionsContext) {
         if (textSource === null) {
             return null;
         }
-        if (this._searchTerms) {
+        if (searchTerms) {
             const results = await this._findTerms(textSource, optionsContext);
             if (results !== null) { return results; }
         }
-        if (this._searchKanji) {
+        if (searchKanji) {
             const results = await this._findKanji(textSource, optionsContext);
             if (results !== null) { return results; }
         }
@@ -697,7 +697,7 @@ class TextScanner extends EventDispatcher {
 
             const textSource = this._documentUtil.getRangeFromPoint(x, y, this._deepContentScan);
             try {
-                await this._search(textSource, input);
+                await this._search(textSource, this._searchTerms, this._searchKanji, input);
             } finally {
                 if (textSource !== null) {
                     textSource.cleanup();


### PR DESCRIPTION
This change allows different scanning modifiers to selectively scan kanji, terms, both, or none. The default is both. This option is under the advanced options for the scanning inputs.

Resolves #79. Also mentioned in #267.