### PR TITLE
Mouse button modifier update

### DIFF
--- a/ext/mixed/js/document-util.js
+++ b/ext/mixed/js/document-util.js
@@ -312,12 +312,14 @@ class DocumentUtil {
     }
 
     static _getActiveButtons(event, set) {
-        const {buttons} = event;
+        let {buttons} = event;
         if (typeof buttons === 'number' && buttons > 0) {
             for (let i = 0; i < 6; ++i) {
                 const buttonFlag = (1 << i);
                 if ((buttons & buttonFlag) !== 0) {
                     set.add(`mouse${i}`);
+                    buttons &= ~buttonFlag;
+                    if (buttons === 0) { break; }
                 }
             }
         }

--- a/ext/mixed/js/document-util.js
+++ b/ext/mixed/js/document-util.js
@@ -313,7 +313,7 @@ class DocumentUtil {
 
     static _getActiveButtons(event, set) {
         const {buttons} = event;
-        if (typeof buttons === 'number') {
+        if (typeof buttons === 'number' && buttons > 0) {
             for (let i = 0; i < 6; ++i) {
                 const buttonFlag = (1 << i);
                 if ((buttons & buttonFlag) !== 0) {


### PR DESCRIPTION
* Prevents an issue on Firefox where `buttons` might be `-1` for certain pointer events (presumably another bug).
* Exits early when remaining flags are 0.