### PR TITLE
Remove unused handlebars script

### DIFF
--- a/ext/bg/background.html
+++ b/ext/bg/background.html
@@ -15,7 +15,6 @@
     <body>
         <textarea id="clipboard-paste-target"></textarea>
 
-        <script src="/mixed/lib/handlebars.min.js"></script>
         <script src="/mixed/lib/wanakana.min.js"></script>
 
         <script src="/mixed/js/core.js"></script>


### PR DESCRIPTION
Handlebars is now only used in display and settings pages.