### PR TITLE
Browser manifest updates

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -102,7 +102,7 @@
             "fg/float.html",
             "bg/template-renderer.html"
         ],
-        "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
+        "content_security_policy": "script-src 'self'; object-src 'self'"
     },
     "variants": [
         {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -153,7 +153,7 @@
                     "value": {
                         "gecko": {
                             "id": "alex@foosoft.net",
-                            "strict_min_version": "55.0"
+                            "strict_min_version": "57.0"
                         }
                     }
                 }

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -103,12 +103,6 @@
             "bg/template-renderer.html"
         ],
         "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-        "applications": {
-            "gecko": {
-                "id": "alex@foosoft.net",
-                "strict_min_version": "55.0"
-            }
-        }
     },
     "variants": [
         {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -62,7 +62,6 @@
             }
         ],
         "minimum_chrome_version": "57.0.0.0",
-        "options_page": "bg/settings.html",
         "options_ui": {
             "page": "bg/settings.html",
             "open_in_tab": true

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -106,18 +106,63 @@
     },
     "variants": [
         {
-            "name": "default",
-            "fileName": "yomichan.zip",
-            "fileCopies": [
-                "yomichan.xpi"
+            "name": "chrome",
+            "fileName": "yomichan-chrome.zip"
+        },
+        {
+            "name": "chrome-dev",
+            "fileName": "yomichan-chrome-dev.zip",
+            "modifications": [
+                {
+                    "action": "replace",
+                    "path": ["name"],
+                    "pattern": "^.*$",
+                    "patternFlags": "",
+                    "replacement": "$& (development build)"
+                },
+                {
+                    "action": "replace",
+                    "path": ["description"],
+                    "pattern": "^(.*)(?:\\.\\s*)?$",
+                    "patternFlags": "",
+                    "replacement": "$1. This is a development build; get the stable version here: https://tinyurl.com/yaatdjmp"
+                }
             ]
         },
         {
-            "name": "dev",
-            "fileName": "yomichan-dev.zip",
-            "fileCopies": [
-                "yomichan-dev.xpi"
-            ],
+            "name": "firefox",
+            "fileName": "yomichan-firefox.xpi",
+            "modifications": [
+                {
+                    "action": "remove",
+                    "path": ["web_accessible_resources"],
+                    "item": "bg/template-renderer.html"
+                },
+                {
+                    "action": "delete",
+                    "path": ["sandbox"]
+                },
+                {
+                    "action": "set",
+                    "path": ["content_security_policy"],
+                    "value": "script-src 'self' 'unsafe-eval'; object-src 'self'"
+                },
+                {
+                    "action": "set",
+                    "path": ["browser_specific_settings"],
+                    "value": {
+                        "gecko": {
+                            "id": "alex@foosoft.net",
+                            "strict_min_version": "55.0"
+                        }
+                    }
+                }
+            ]
+        },
+        {
+            "name": "firefox-dev",
+            "inherit": "firefox",
+            "fileName": "yomichan-firefox-dev.xpi",
             "modifications": [
                 {
                     "action": "replace",
@@ -135,7 +180,7 @@
                 },
                 {
                     "action": "set",
-                    "path": ["applications", "gecko", "id"],
+                    "path": ["browser_specific_settings", "gecko", "id"],
                     "value": "alex.testing@foosoft.net"
                 }
             ]

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -61,7 +61,6 @@
         }
     ],
     "minimum_chrome_version": "57.0.0.0",
-    "options_page": "bg/settings.html",
     "options_ui": {
         "page": "bg/settings.html",
         "open_in_tab": true
@@ -102,11 +101,5 @@
         "fg/float.html",
         "bg/template-renderer.html"
     ],
-    "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'",
-    "applications": {
-        "gecko": {
-            "id": "alex@foosoft.net",
-            "strict_min_version": "55.0"
-        }
-    }
+    "content_security_policy": "script-src 'self'; object-src 'self'"
 }


### PR DESCRIPTION
This change splits builds into four different variants:
* `yomichan-chrome.zip`
* `yomichan-chrome-dev.zip`
* `yomichan-firefox.xpi`
* `yomichan-firefox-dev.xpi`

Differences:
* For the Chrome variants, the default `content_security_policy` has been changed to remove `script-src 'unsafe-eval'`; the sandbox is used instead for template rendering.
* For the Chrome variants, the `applications` entry in the manifest has been removed.
* For Firefox variants, the `applications` entry has been replaced with [`browser_specific_settings`](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/browser_specific_settings). This should be the newer version of the old `applications` entry, supported in Firefox 48+ (our min version is 55). [Info](https://discourse.mozilla.org/t/consider-renaming-the-webextensions-applications-manifest-key-to-browser-specific-settings/31394)
* For Firefox variants, the `sandbox` entry is removed because it is not supported. Additionally, `"bg/template-renderer.html"` is removed from `web_accessible_resources`, since it cannot be sandboxed.
* Firefox minimum version increase from 55 to 57 to prevent some warnings about potential unsupported APIs.

Resolves #828.