### PR TITLE
Dictionary delete improvements

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -118,7 +118,6 @@ class Backend {
             ['triggerDatabaseUpdated',       {async: false, contentScript: true,  handler: this._onApiTriggerDatabaseUpdated.bind(this)}]
         ]);
         this._messageHandlersWithProgress = new Map([
-            ['deleteDictionary',        {async: true,  contentScript: false, handler: this._onApiDeleteDictionary.bind(this)}]
         ]);
 
         this._commandHandlers = new Map([
@@ -739,11 +738,6 @@ class Backend {
         }
 
         return details;
-    }
-
-    async _onApiDeleteDictionary({dictionaryName}, sender, onProgress) {
-        await this._dictionaryDatabase.deleteDictionary(dictionaryName, {rate: 1000}, onProgress);
-        this._triggerDatabaseUpdated('dictionary', 'delete');
     }
 
     async _onApiModifySettings({targets, source}) {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -700,7 +700,6 @@ class Backend {
     }
 
     async _onApiPurgeDatabase() {
-        this._translator.clearDatabaseCaches();
         await this._dictionaryDatabase.purge();
         this._triggerDatabaseUpdated('dictionary', 'purge');
     }
@@ -743,7 +742,6 @@ class Backend {
     }
 
     async _onApiDeleteDictionary({dictionaryName}, sender, onProgress) {
-        this._translator.clearDatabaseCaches();
         await this._dictionaryDatabase.deleteDictionary(dictionaryName, {rate: 1000}, onProgress);
         this._triggerDatabaseUpdated('dictionary', 'delete');
     }
@@ -1721,6 +1719,7 @@ class Backend {
     }
 
     _triggerDatabaseUpdated(type, cause) {
+        this._translator.clearDatabaseCaches();
         this._sendMessageAllTabs('databaseUpdated', {type, cause});
     }
 

--- a/ext/bg/js/settings/dictionary-controller.js
+++ b/ext/bg/js/settings/dictionary-controller.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DictionaryDatabase
  * Modal
  * ObjectPropertyAccessor
  * api
@@ -349,7 +350,7 @@ class DictionaryController {
                 progressBar.style.width = `${percent}%`;
             };
 
-            await api.deleteDictionary(dictionaryTitle, onProgress);
+            await this._deleteDictionaryInternal(dictionaryTitle, onProgress);
         } catch (e) {
             yomichan.logError(e);
         } finally {
@@ -371,5 +372,21 @@ class DictionaryController {
         const template = document.querySelector(templateSelector);
         const content = document.importNode(template.content, true);
         return content.firstChild;
+    }
+
+    async _deleteDictionaryInternal(dictionaryTitle, onProgress) {
+        const dictionaryDatabase = await this._getPreparedDictionaryDatabase();
+        try {
+            await dictionaryDatabase.deleteDictionary(dictionaryTitle, {rate: 1000}, onProgress);
+            api.triggerDatabaseUpdated('dictionary', 'delete');
+        } finally {
+            dictionaryDatabase.close();
+        }
+    }
+
+    async _getPreparedDictionaryDatabase() {
+        const dictionaryDatabase = new DictionaryDatabase();
+        await dictionaryDatabase.prepare();
+        return dictionaryDatabase;
     }
 }

--- a/ext/mixed/js/api.js
+++ b/ext/mixed/js/api.js
@@ -197,12 +197,6 @@ const api = (() => {
             return this._invoke('triggerDatabaseUpdated', {type, cause});
         }
 
-        // Invoke functions with progress
-
-        deleteDictionary(dictionaryName, onProgress) {
-            return this._invokeWithProgress('deleteDictionary', {dictionaryName}, onProgress);
-        }
-
         // Utilities
 
         _createActionPort(timeout=5000) {


### PR DESCRIPTION
Moves dictionary deletion into the settings page rather than proxying it through the backend. Not tested, but the previous method could potentially cause issues on Manifest v3 since it's a long-running operation. Dictionary importing is now done on the settings page as well, so it adds parity with that.