### PR TITLE
Remove window from performance object access

### DIFF
--- a/ext/mixed/js/timer.js
+++ b/ext/mixed/js/timer.js
@@ -31,7 +31,7 @@ class Timer {
     }
 
     sample(name) {
-        const time = window.performance.now();
+        const time = performance.now();
         this.samples.push({
             name,
             time,


### PR DESCRIPTION
Allows it to be used for testing Manifest v3 things.