### PR TITLE
Add lint test to validate <script>s in HTML files

### DIFF
--- a/dev/lint/html-scripts.js
+++ b/dev/lint/html-scripts.js
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2020  Yomichan Authors
+ * Author: Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+const fs = require('fs');
+const path = require('path');
+const assert = require('assert');
+const {JSDOM} = require('jsdom');
+const {getAllFiles} = require('../util');
+
+
+function lstatSyncSafe(fileName) {
+    try {
+        return fs.lstatSync(fileName);
+    } catch (e) {
+        return null;
+    }
+}
+
+function validateHtmlScripts(fileName, extDir) {
+    const domSource = fs.readFileSync(fileName, {encoding: 'utf8'});
+    const dom = new JSDOM(domSource);
+    const {window} = dom;
+    const {document} = window;
+    try {
+        const scripts = document.querySelectorAll('script');
+        for (const script of scripts) {
+            const {src} = script;
+            assert.ok(typeof src === 'string', `<script> missing src attribute in ${fileName}`);
+            assert.ok(src.startsWith('/'), `<script> src attribute is not absolute in ${fileName} (src=${JSON.stringify(src)})`);
+            const relativeSrc = src.substring(1);
+            assert.ok(!path.isAbsolute(relativeSrc), `<script> src attribute is invalid in ${fileName} (src=${JSON.stringify(src)})`);
+            const fullSrc = path.join(extDir, relativeSrc);
+            const stats = lstatSyncSafe(fullSrc);
+            assert.ok(stats !== null, `<script> src file not found in ${fileName} (src=${JSON.stringify(src)})`);
+            assert.ok(stats.isFile(), `<script> src file invalid in ${fileName} (src=${JSON.stringify(src)})`);
+        }
+    } finally {
+        window.close();
+    }
+}
+
+
+function main() {
+    try {
+        const extDir = path.resolve(__dirname, '..', '..', 'ext');
+        const pattern = /\.html$/;
+        const ignorePattern = /[\\/]ext[\\/]mixed[\\/]lib[\\/]/;
+        const fileNames = getAllFiles(extDir, null, (f) => pattern.test(f) && !ignorePattern.test(f));
+        for (const fileName of fileNames) {
+            validateHtmlScripts(fileName, extDir);
+        }
+    } catch (e) {
+        console.error(e);
+        process.exit(-1);
+        return;
+    }
+    process.exit(0);
+}
+
+
+if (require.main === module) { main(); }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "scripts": {
         "build": "node ./dev/build.js",
         "test": "npm run test-lint && npm run test-code && npm run test-manifest",
-        "test-lint": "eslint . && node ./dev/lint/global-declarations.js",
+        "test-lint": "eslint . && node ./dev/lint/global-declarations.js && node ./dev/lint/html-scripts.js",
         "test-code": "node ./test/test-all.js ./test --skip ./test/test-manifest.js",
         "test-manifest": "node ./test/test-manifest.js"
     },


### PR DESCRIPTION
Validates that script tags are using the expected format and actually point to a valid file.