### PR TITLE
Fix page type never being detected as search page correctly

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -333,7 +333,7 @@ class DisplaySearch extends Display {
                 await this.setupNestedPopups({
                     depth: 1,
                     useProxyPopup: false,
-                    isSearchPage: true
+                    pageType: 'search'
                 });
             } catch (e) {
                 yomichan.logError(e);

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -62,7 +62,7 @@ class PopupPreviewFrame {
             parentPopupId: null,
             parentFrameId: null,
             useProxyPopup: false,
-            isSearchPage: false,
+            pageType: 'web',
             allowRootFramePopupProxy: false
         });
         this._frontendGetOptionsContextOld = this._frontend.getOptionsContext.bind(this._frontend);

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -41,7 +41,7 @@
             parentPopupId: null,
             parentFrameId: null,
             useProxyPopup: false,
-            isSearchPage: false,
+            pageType: 'web',
             allowRootFramePopupProxy: true
         });
         await frontend.prepare();

--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -184,7 +184,8 @@ class DisplayFloat extends Display {
                     depth,
                     parentPopupId,
                     parentFrameId,
-                    useProxyPopup: true
+                    useProxyPopup: true,
+                    pageType: 'popup'
                 });
             } catch (e) {
                 yomichan.logError(e);

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -30,7 +30,7 @@ class Frontend {
         parentPopupId,
         parentFrameId,
         useProxyPopup,
-        isSearchPage,
+        pageType,
         allowRootFramePopupProxy
     }) {
         this._id = generateId(16);
@@ -55,7 +55,7 @@ class Frontend {
         this._parentPopupId = parentPopupId;
         this._parentFrameId = parentFrameId;
         this._useProxyPopup = useProxyPopup;
-        this._isSearchPage = isSearchPage;
+        this._pageType = pageType;
         this._depth = depth;
         this._frameId = frameId;
         this._popupFactory = popupFactory;
@@ -392,7 +392,7 @@ class Frontend {
         }
         if (this._updatePopupToken !== token) { return; }
 
-        if (this._isSearchPage) {
+        if (this._pageType === 'search') {
             this.setDisabledOverride(!this._options.scanning.enableOnSearchPage);
         }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -361,7 +361,7 @@ class Display extends EventDispatcher {
         }
     }
 
-    async setupNestedPopups({depth, parentPopupId, parentFrameId, useProxyPopup}) {
+    async setupNestedPopups({depth, parentPopupId, parentFrameId, useProxyPopup, pageType}) {
         await dynamicLoader.loadScripts([
             '/mixed/js/text-scanner.js',
             '/mixed/js/frame-client.js',
@@ -385,7 +385,7 @@ class Display extends EventDispatcher {
             parentPopupId,
             parentFrameId,
             useProxyPopup,
-            isSearchPage: false,
+            pageType,
             allowRootFramePopupProxy: true
         });
         await frontend.prepare();


### PR DESCRIPTION
This also makes the page type more explicit, which can be `'web'`, `'popup'`, or `'search'`.