### PR TITLE
Move searchTerms/searchKanji to front of object definitions

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -352,12 +352,12 @@
                                                 },
                                                 "options": {
                                                     "showAdvanced": false,
+                                                    "searchTerms": true,
+                                                    "searchKanji": true,
                                                     "scanOnTouchMove": true,
                                                     "scanOnPenHover": true,
                                                     "scanOnPenPress": true,
                                                     "scanOnPenRelease": false,
-                                                    "searchTerms": true,
-                                                    "searchKanji": true,
                                                     "preventTouchScrolling": false
                                                 }
                                             },
@@ -371,12 +371,12 @@
                                                 },
                                                 "options": {
                                                     "showAdvanced": false,
+                                                    "searchTerms": true,
+                                                    "searchKanji": true,
                                                     "scanOnTouchMove": true,
                                                     "scanOnPenHover": true,
                                                     "scanOnPenPress": true,
                                                     "scanOnPenRelease": false,
-                                                    "searchTerms": true,
-                                                    "searchKanji": true,
                                                     "preventTouchScrolling": true
                                                 }
                                             }
@@ -423,18 +423,26 @@
                                                     "type": "object",
                                                     "required": [
                                                         "showAdvanced",
+                                                        "searchTerms",
+                                                        "searchKanji",
                                                         "scanOnTouchMove",
                                                         "scanOnPenHover",
                                                         "scanOnPenPress",
                                                         "scanOnPenRelease",
-                                                        "searchTerms",
-                                                        "searchKanji",
                                                         "preventTouchScrolling"
                                                     ],
                                                     "properties": {
                                                         "showAdvanced": {
                                                             "type": "boolean",
                                                             "default": false
+                                                        },
+                                                        "searchTerms": {
+                                                            "type": "boolean",
+                                                            "default": true
+                                                        },
+                                                        "searchKanji": {
+                                                            "type": "boolean",
+                                                            "default": true
                                                         },
                                                         "scanOnTouchMove": {
                                                             "type": "boolean",
@@ -451,14 +459,6 @@
                                                         "scanOnPenRelease": {
                                                             "type": "boolean",
                                                             "default": false
-                                                        },
-                                                        "searchTerms": {
-                                                            "type": "boolean",
-                                                            "default": true
-                                                        },
-                                                        "searchKanji": {
-                                                            "type": "boolean",
-                                                            "default": true
                                                         },
                                                         "preventTouchScrolling": {
                                                             "type": "boolean",

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -522,12 +522,12 @@ class OptionsUtil {
         }
         const createInputDefaultOptions = () => ({
             showAdvanced: false,
+            searchTerms: true,
+            searchKanji: true,
             scanOnTouchMove: true,
             scanOnPenHover: true,
             scanOnPenPress: true,
             scanOnPenRelease: false,
-            searchTerms: true,
-            searchKanji: true,
             preventTouchScrolling: true
         });
         for (const {options: profileOptions} of options.profiles) {

--- a/ext/bg/js/settings/scan-inputs-controller.js
+++ b/ext/bg/js/settings/scan-inputs-controller.js
@@ -99,12 +99,12 @@ class ScanInputsController {
                 types: {mouse: true, touch: false, pen: false},
                 options: {
                     showAdvanced: false,
+                    searchTerms: true,
+                    searchKanji: true,
                     scanOnTouchMove: true,
                     scanOnPenHover: true,
                     scanOnPenPress: true,
                     scanOnPenRelease: false,
-                    searchTerms: true,
-                    searchKanji: true,
                     preventTouchScrolling: true
                 }
             }]

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -120,12 +120,28 @@ class TextScanner extends EventDispatcher {
                 include,
                 exclude,
                 types,
-                options: {scanOnTouchMove, scanOnPenHover, scanOnPenPress, scanOnPenRelease, searchTerms, searchKanji, preventTouchScrolling}
+                options: {
+                    searchTerms,
+                    searchKanji,
+                    scanOnTouchMove,
+                    scanOnPenHover,
+                    scanOnPenPress,
+                    scanOnPenRelease,
+                    preventTouchScrolling
+                }
             }) => ({
                 include: this._getInputArray(include),
                 exclude: this._getInputArray(exclude),
                 types: this._getInputTypeSet(types),
-                options: {scanOnTouchMove, scanOnPenHover, scanOnPenPress, scanOnPenRelease, searchTerms, searchKanji, preventTouchScrolling}
+                options: {
+                    searchTerms,
+                    searchKanji,
+                    scanOnTouchMove,
+                    scanOnPenHover,
+                    scanOnPenPress,
+                    scanOnPenRelease,
+                    preventTouchScrolling
+                }
             }));
         }
         if (typeof deepContentScan === 'boolean') {

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -333,12 +333,12 @@ function createProfileOptionsUpdatedTestData1() {
                     },
                     options: {
                         showAdvanced: false,
+                        searchTerms: true,
+                        searchKanji: true,
                         scanOnTouchMove: true,
                         scanOnPenHover: true,
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
-                        searchTerms: true,
-                        searchKanji: true,
                         preventTouchScrolling: true
                     }
                 },
@@ -352,12 +352,12 @@ function createProfileOptionsUpdatedTestData1() {
                     },
                     options: {
                         showAdvanced: false,
+                        searchTerms: true,
+                        searchKanji: true,
                         scanOnTouchMove: true,
                         scanOnPenHover: true,
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
-                        searchTerms: true,
-                        searchKanji: true,
                         preventTouchScrolling: true
                     }
                 },
@@ -371,12 +371,12 @@ function createProfileOptionsUpdatedTestData1() {
                     },
                     options: {
                         showAdvanced: false,
+                        searchTerms: true,
+                        searchKanji: true,
                         scanOnTouchMove: true,
                         scanOnPenHover: true,
                         scanOnPenPress: true,
                         scanOnPenRelease: false,
-                        searchTerms: true,
-                        searchKanji: true,
                         preventTouchScrolling: true
                     }
                 }


### PR DESCRIPTION
Should be a better organization, as searchTerms/searchKanji are less likely to have any related changes be made.