### PR TITLE
Translator options refactor

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -376,18 +376,19 @@ class Backend {
 
     async _onApiKanjiFind({text, optionsContext}) {
         const options = this.getOptions(optionsContext);
+        const {general: {maxResults}} = options;
         const findKanjiOptions = this._getTranslatorFindKanjiOptions(options);
         const definitions = await this._translator.findKanji(text, findKanjiOptions);
-        definitions.splice(options.general.maxResults);
+        definitions.splice(maxResults);
         return definitions;
     }
 
     async _onApiTermsFind({text, details, optionsContext}) {
         const options = this.getOptions(optionsContext);
-        const mode = options.general.resultOutputMode;
+        const {general: {resultOutputMode: mode, maxResults}} = options;
         const findTermsOptions = this._getTranslatorFindTermsOptions(details, options);
         const [definitions, length] = await this._translator.findTerms(mode, text, findTermsOptions);
-        definitions.splice(options.general.maxResults);
+        definitions.splice(maxResults);
         return {length, definitions};
     }
 
@@ -950,25 +951,26 @@ class Backend {
     }
 
     async _textParseScanning(text, options) {
+        const {scanning: {length: scanningLength}, parsing: {readingMode}} = options;
         const findTermsOptions = this._getTranslatorFindTermsOptions({wildcard: null}, options);
         const results = [];
         while (text.length > 0) {
             const term = [];
             const [definitions, sourceLength] = await this._translator.findTerms(
                 'simple',
-                text.substring(0, options.scanning.length),
+                text.substring(0, scanningLength),
                 findTermsOptions
             );
             if (definitions.length > 0 && sourceLength > 0) {
                 const {expression, reading} = definitions[0];
                 const source = text.substring(0, sourceLength);
                 for (const {text: text2, furigana} of jp.distributeFuriganaInflected(expression, reading, source)) {
-                    const reading2 = jp.convertReading(text2, furigana, options.parsing.readingMode);
+                    const reading2 = jp.convertReading(text2, furigana, readingMode);
                     term.push({text: text2, reading: reading2});
                 }
                 text = text.substring(source.length);
             } else {
-                const reading = jp.convertReading(text[0], '', options.parsing.readingMode);
+                const reading = jp.convertReading(text[0], '', readingMode);
                 term.push({text: text[0], reading});
                 text = text.substring(1);
             }
@@ -978,6 +980,7 @@ class Backend {
     }
 
     async _textParseMecab(text, options) {
+        const {parsing: {readingMode}} = options;
         const results = [];
         const rawResults = await this._mecab.parseText(text);
         for (const [mecabName, parsedLines] of Object.entries(rawResults)) {
@@ -990,7 +993,7 @@ class Backend {
                         jp.convertKatakanaToHiragana(reading),
                         source
                     )) {
-                        const reading2 = jp.convertReading(text2, furigana, options.parsing.readingMode);
+                        const reading2 = jp.convertReading(text2, furigana, readingMode);
                         term.push({text: text2, reading: reading2});
                     }
                     result.push(term);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -38,8 +38,7 @@ class Translator {
         this._tagCache.clear();
     }
 
-    async findTerms(mode, text, details, options) {
-        const findTermsOptions = this._getFindTermsOptions(details, options);
+    async findTerms(mode, text, findTermsOptions) {
         switch (mode) {
             case 'group':
                 return await this._findTermsGrouped(text, findTermsOptions);
@@ -55,7 +54,7 @@ class Translator {
     }
 
     async findKanji(text, options) {
-        const enabledDictionaryMap = this._getEnabledDictionaryMap(options);
+        const {enabledDictionaryMap} = options;
         const kanjiUnique = new Set();
         for (const c of text) {
             kanjiUnique.add(c);
@@ -83,36 +82,6 @@ class Translator {
     }
 
     // Private
-
-    _getFindTermsOptions(details, options) {
-        const {wildcard} = details;
-        const enabledDictionaryMap = this._getEnabledDictionaryMap(options);
-        const {
-            general: {compactTags, mainDictionary},
-            scanning: {alphanumeric},
-            translation: {
-                convertHalfWidthCharacters,
-                convertNumericCharacters,
-                convertAlphabeticCharacters,
-                convertHiraganaToKatakana,
-                convertKatakanaToHiragana,
-                collapseEmphaticSequences
-            }
-        } = options;
-        return {
-            wildcard,
-            compactTags,
-            mainDictionary,
-            alphanumeric,
-            convertHalfWidthCharacters,
-            convertNumericCharacters,
-            convertAlphabeticCharacters,
-            convertHiraganaToKatakana,
-            convertKatakanaToHiragana,
-            collapseEmphaticSequences,
-            enabledDictionaryMap
-        };
-    }
 
     async _getSequencedDefinitions(definitions, mainDictionary, enabledDictionaryMap) {
         const sequenceList = [];
@@ -734,15 +703,6 @@ class Translator {
             throw new Error(`Failed to fetch ${url}: ${response.status}`);
         }
         return await response.json();
-    }
-
-    _getEnabledDictionaryMap(options) {
-        const enabledDictionaryMap = new Map();
-        for (const [title, {enabled, priority, allowSecondarySearches}] of Object.entries(options.dictionaries)) {
-            if (!enabled) { continue; }
-            enabledDictionaryMap.set(title, {priority, allowSecondarySearches});
-        }
-        return enabledDictionaryMap;
     }
 
     _getSecondarySearchDictionaryMap(enabledDictionaryMap) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -1045,7 +1045,7 @@ class Translator {
             // glossary
             // definitionTags
             termTags: this._cloneTags(termTags),
-            definitions,
+            definitions, // type: 'term'
             frequencies: [],
             pitches: []
             // only
@@ -1071,7 +1071,7 @@ class Translator {
             // glossary
             // definitionTags
             // termTags
-            definitions,
+            definitions, // type: 'termMergedByGlossary'
             frequencies: [],
             pitches: []
             // only
@@ -1110,7 +1110,7 @@ class Translator {
             glossary: [...glossary],
             definitionTags,
             // termTags
-            definitions, // Contains duplicate data
+            definitions, // type: 'term'; contains duplicate data
             frequencies: [],
             pitches: [],
             only

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -38,16 +38,16 @@ class Translator {
         this._tagCache.clear();
     }
 
-    async findTerms(mode, text, findTermsOptions) {
+    async findTerms(mode, text, options) {
         switch (mode) {
             case 'group':
-                return await this._findTermsGrouped(text, findTermsOptions);
+                return await this._findTermsGrouped(text, options);
             case 'merge':
-                return await this._findTermsMerged(text, findTermsOptions);
+                return await this._findTermsMerged(text, options);
             case 'split':
-                return await this._findTermsSplit(text, findTermsOptions);
+                return await this._findTermsSplit(text, options);
             case 'simple':
-                return await this._findTermsSimple(text, findTermsOptions);
+                return await this._findTermsSimple(text, options);
             default:
                 return [[], 0];
         }
@@ -250,9 +250,9 @@ class Translator {
         return result;
     }
 
-    async _findTermsGrouped(text, findTermsOptions) {
-        const {compactTags, enabledDictionaryMap} = findTermsOptions;
-        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, findTermsOptions);
+    async _findTermsGrouped(text, options) {
+        const {compactTags, enabledDictionaryMap} = options;
+        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
 
         const groupedDefinitions = this._groupTerms(definitions, enabledDictionaryMap);
         await this._buildTermMeta(groupedDefinitions, enabledDictionaryMap);
@@ -267,11 +267,11 @@ class Translator {
         return [groupedDefinitions, length];
     }
 
-    async _findTermsMerged(text, findTermsOptions) {
-        const {compactTags, mainDictionary, enabledDictionaryMap} = findTermsOptions;
+    async _findTermsMerged(text, options) {
+        const {compactTags, mainDictionary, enabledDictionaryMap} = options;
         const secondarySearchDictionaryMap = this._getSecondarySearchDictionaryMap(enabledDictionaryMap);
 
-        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, findTermsOptions);
+        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
         const {sequencedDefinitions, unsequencedDefinitions} = await this._getSequencedDefinitions(definitions, mainDictionary, enabledDictionaryMap);
         const definitionsMerged = [];
         const usedDefinitions = new Set();
@@ -316,23 +316,23 @@ class Translator {
         return [definitionsMerged, length];
     }
 
-    async _findTermsSplit(text, findTermsOptions) {
-        const {enabledDictionaryMap} = findTermsOptions;
-        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, findTermsOptions);
+    async _findTermsSplit(text, options) {
+        const {enabledDictionaryMap} = options;
+        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
         await this._buildTermMeta(definitions, enabledDictionaryMap);
         this._sortDefinitions(definitions, true);
         return [definitions, length];
     }
 
-    async _findTermsSimple(text, findTermsOptions) {
-        const {enabledDictionaryMap} = findTermsOptions;
-        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, findTermsOptions);
+    async _findTermsSimple(text, options) {
+        const {enabledDictionaryMap} = options;
+        const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
         this._sortDefinitions(definitions, false);
         return [definitions, length];
     }
 
-    async _findTermsInternal(text, enabledDictionaryMap, findTermsOptions) {
-        const {alphanumeric, wildcard} = findTermsOptions;
+    async _findTermsInternal(text, enabledDictionaryMap, options) {
+        const {alphanumeric, wildcard} = options;
         text = this._getSearchableText(text, alphanumeric);
         if (text.length === 0) {
             return [[], 0];
@@ -341,7 +341,7 @@ class Translator {
         const deinflections = (
             wildcard ?
             await this._findTermWildcard(text, enabledDictionaryMap, wildcard) :
-            await this._findTermDeinflections(text, enabledDictionaryMap, findTermsOptions)
+            await this._findTermDeinflections(text, enabledDictionaryMap, options)
         );
 
         let maxLength = 0;
@@ -375,8 +375,8 @@ class Translator {
         }];
     }
 
-    async _findTermDeinflections(text, enabledDictionaryMap, findTermsOptions) {
-        const deinflections = this._getAllDeinflections(text, findTermsOptions);
+    async _findTermDeinflections(text, enabledDictionaryMap, options) {
+        const deinflections = this._getAllDeinflections(text, options);
 
         if (deinflections.length === 0) {
             return [];
@@ -412,9 +412,9 @@ class Translator {
         return deinflections;
     }
 
-    _getAllDeinflections(text, findTermsOptions) {
+    _getAllDeinflections(text, options) {
         const collapseEmphaticOptions = [[false, false]];
-        switch (findTermsOptions.collapseEmphaticSequences) {
+        switch (options.collapseEmphaticSequences) {
             case 'true':
                 collapseEmphaticOptions.push([true, false]);
                 break;
@@ -423,11 +423,11 @@ class Translator {
                 break;
         }
         const textOptionVariantArray = [
-            this._getTextOptionEntryVariants(findTermsOptions.convertHalfWidthCharacters),
-            this._getTextOptionEntryVariants(findTermsOptions.convertNumericCharacters),
-            this._getTextOptionEntryVariants(findTermsOptions.convertAlphabeticCharacters),
-            this._getTextOptionEntryVariants(findTermsOptions.convertHiraganaToKatakana),
-            this._getTextOptionEntryVariants(findTermsOptions.convertKatakanaToHiragana),
+            this._getTextOptionEntryVariants(options.convertHalfWidthCharacters),
+            this._getTextOptionEntryVariants(options.convertNumericCharacters),
+            this._getTextOptionEntryVariants(options.convertAlphabeticCharacters),
+            this._getTextOptionEntryVariants(options.convertHiraganaToKatakana),
+            this._getTextOptionEntryVariants(options.convertKatakanaToHiragana),
             collapseEmphaticOptions
         ];
 


### PR DESCRIPTION
Follow-up of #878. This PR changes the options structure used by `Translator` such that it does not depend on the structure of the profile settings object. Instead, it uses a custom structure which is passed as an `options` object. This should improve integrity for options, as there should be no potential that the options can change during an `await` call. Additionally, since this options structure is created once, the default text parsing algorithm should have slightly better performance.