### PR TITLE
Translator definition source term (and other info)

### DIFF
--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -879,7 +879,7 @@ class Translator {
     }
 
     _addUniqueTermInfos(definitions, termInfoMap) {
-        for (const {expression, reading, termTags} of definitions) {
+        for (const {expression, reading, sourceTerm, termTags} of definitions) {
             let readingMap = termInfoMap.get(expression);
             if (typeof readingMap === 'undefined') {
                 readingMap = new Map();
@@ -889,6 +889,7 @@ class Translator {
             let termInfo = readingMap.get(reading);
             if (typeof termInfo === 'undefined') {
                 termInfo = {
+                    sourceTerm,
                     termTagsMap: new Map()
                 };
                 readingMap.set(reading, termInfo);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -983,6 +983,7 @@ class Translator {
         this._sortTags(termTagsExpanded);
 
         const furiganaSegments = jp.distributeFurigana(expression, reading);
+        const expressionDetailsList = [this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
 
         return {
             type: 'term',
@@ -997,7 +998,7 @@ class Translator {
             dictionaryPriority,
             expression,
             reading,
-            // expressions
+            expressions: expressionDetailsList,
             furiganaSegments,
             glossary,
             definitionTags: definitionTagsExpanded,
@@ -1013,6 +1014,7 @@ class Translator {
         const {expression, reading, furiganaSegments, reasons, termTags, source, rawSource, sourceTerm} = definitions[0];
         const score = this._getMaxDefinitionScore(definitions);
         const dictionaryPriority = this._getMaxDictionaryPriority(definitions);
+        const expressionDetailsList = [this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
         return {
             type: 'termGrouped',
             // id
@@ -1026,7 +1028,7 @@ class Translator {
             dictionaryPriority,
             expression,
             reading,
-            // expressions
+            expressions: expressionDetailsList,
             furiganaSegments, // Contains duplicate data
             // glossary
             // definitionTags

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -215,7 +215,7 @@ class Translator {
         this._addUniqueTermInfos(relatedDefinitions, termInfoMap);
 
         let secondaryDefinitions = await this._getMergedSecondarySearchResults(termInfoMap, secondarySearchDictionaryMap);
-        secondaryDefinitions = [unsequencedDefinitions, ...secondaryDefinitions]; // TODO : is unsequencedDefinitions necessary
+        secondaryDefinitions = [unsequencedDefinitions, ...secondaryDefinitions];
 
         this._removeUsedDefinitions(secondaryDefinitions, termInfoMap, usedDefinitions);
         this._removeDuplicateDefinitions(secondaryDefinitions);

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -1074,6 +1074,10 @@ class Translator {
             only.push(...getSetIntersection(readings, allReadings));
         }
 
+        const termInfoMap = new Map();
+        this._addUniqueTermInfos(definitions, termInfoMap);
+        const expressionDetailsList = this._createExpressionDetailsListFromTermInfoMap(termInfoMap);
+
         const definitionTags = this._getUniqueDefinitionTags(definitions);
         this._sortTags(definitionTags);
 
@@ -1093,7 +1097,7 @@ class Translator {
             dictionaryPriority,
             expression: [...expressions],
             reading: [...readings],
-            // expressions
+            expressions: expressionDetailsList,
             // furiganaSegments
             glossary: [...glossary],
             definitionTags,

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -252,10 +252,10 @@ class Translator {
 
         const expressionDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {
-            for (const [reading, {termTagsMap}] of readingMap.entries()) {
+            for (const [reading, {termTagsMap, sourceTerm}] of readingMap.entries()) {
                 const termTags = [...termTagsMap.values()];
                 this._sortTags(termTags);
-                expressionDetailsList.push(this._createExpressionDetails(expression, reading, termTags));
+                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, termTags));
             }
         }
 
@@ -346,8 +346,8 @@ class Translator {
 
         const unusedDefinitions = unsequencedDefinitions.filter((definition) => !usedDefinitions.has(definition));
         for (const groupedDefinition of this._groupTerms(unusedDefinitions, enabledDictionaryMap)) {
-            const {reasons, score, expression, reading, source, rawSource, dictionary, termTags} = groupedDefinition;
-            const expressionDetails = this._createExpressionDetails(expression, reading, termTags);
+            const {reasons, score, expression, reading, source, rawSource, sourceTerm, dictionary, termTags} = groupedDefinition;
+            const expressionDetails = this._createExpressionDetails(sourceTerm, expression, reading, termTags);
             const compatibilityDefinition = this._createMergedTermDefinition(
                 source,
                 rawSource,
@@ -1111,10 +1111,11 @@ class Translator {
         };
     }
 
-    _createExpressionDetails(expression, reading, termTags) {
+    _createExpressionDetails(sourceTerm, expression, reading, termTags) {
         const termFrequency = this._scoreToTermFrequency(this._getTermTagsScoreSum(termTags));
         const furiganaSegments = jp.distributeFurigana(expression, reading);
         return {
+            sourceTerm,
             expression,
             reading,
             furiganaSegments,

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -250,7 +250,7 @@ class Translator {
 
         this._sortDefinitions(glossaryDefinitions, true);
 
-        const expressionDetailsList = this._createExpressionDetailsListFromTermInfoMap(termInfoMap);
+        const termDetailsList = this._createTermDetailsListFromTermInfoMap(termInfoMap);
 
         return this._createMergedTermDefinition(
             source,
@@ -258,7 +258,7 @@ class Translator {
             glossaryDefinitions,
             [...allExpressions],
             [...allReadings],
-            expressionDetailsList,
+            termDetailsList,
             reasons,
             dictionary,
             score
@@ -340,14 +340,14 @@ class Translator {
         const unusedDefinitions = unsequencedDefinitions.filter((definition) => !usedDefinitions.has(definition));
         for (const groupedDefinition of this._groupTerms(unusedDefinitions, enabledDictionaryMap)) {
             const {reasons, score, expression, reading, source, rawSource, sourceTerm, dictionary, furiganaSegments, termTags} = groupedDefinition;
-            const expressionDetails = this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags);
+            const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
             const compatibilityDefinition = this._createMergedTermDefinition(
                 source,
                 rawSource,
                 definitions,
                 [expression],
                 [reading],
-                [expressionDetails],
+                termDetailsList,
                 reasons,
                 dictionary,
                 score
@@ -983,7 +983,7 @@ class Translator {
         this._sortTags(termTagsExpanded);
 
         const furiganaSegments = jp.distributeFurigana(expression, reading);
-        const expressionDetailsList = [this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
+        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
 
         return {
             type: 'term',
@@ -998,7 +998,7 @@ class Translator {
             dictionaryPriority,
             expression,
             reading,
-            expressions: expressionDetailsList,
+            expressions: termDetailsList,
             furiganaSegments,
             glossary,
             definitionTags: definitionTagsExpanded,
@@ -1014,7 +1014,7 @@ class Translator {
         const {expression, reading, furiganaSegments, reasons, termTags, source, rawSource, sourceTerm} = definitions[0];
         const score = this._getMaxDefinitionScore(definitions);
         const dictionaryPriority = this._getMaxDictionaryPriority(definitions);
-        const expressionDetailsList = [this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
+        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
         return {
             type: 'termGrouped',
             // id
@@ -1028,7 +1028,7 @@ class Translator {
             dictionaryPriority,
             expression,
             reading,
-            expressions: expressionDetailsList,
+            expressions: termDetailsList,
             furiganaSegments, // Contains duplicate data
             // glossary
             // definitionTags
@@ -1040,7 +1040,7 @@ class Translator {
         };
     }
 
-    _createMergedTermDefinition(source, rawSource, definitions, expressions, readings, expressionDetailsList, reasons, dictionary, score) {
+    _createMergedTermDefinition(source, rawSource, definitions, expressions, readings, termDetailsList, reasons, dictionary, score) {
         const dictionaryPriority = this._getMaxDictionaryPriority(definitions);
         return {
             type: 'termMerged',
@@ -1055,7 +1055,7 @@ class Translator {
             dictionaryPriority,
             expression: expressions,
             reading: readings,
-            expressions: expressionDetailsList,
+            expressions: termDetailsList,
             // furiganaSegments
             // glossary
             // definitionTags
@@ -1078,7 +1078,7 @@ class Translator {
 
         const termInfoMap = new Map();
         this._addUniqueTermInfos(definitions, termInfoMap);
-        const expressionDetailsList = this._createExpressionDetailsListFromTermInfoMap(termInfoMap);
+        const termDetailsList = this._createTermDetailsListFromTermInfoMap(termInfoMap);
 
         const definitionTags = this._getUniqueDefinitionTags(definitions);
         this._sortTags(definitionTags);
@@ -1099,7 +1099,7 @@ class Translator {
             dictionaryPriority,
             expression: [...expressions],
             reading: [...readings],
-            expressions: expressionDetailsList,
+            expressions: termDetailsList,
             // furiganaSegments
             glossary: [...glossary],
             definitionTags,
@@ -1111,19 +1111,19 @@ class Translator {
         };
     }
 
-    _createExpressionDetailsListFromTermInfoMap(termInfoMap) {
-        const expressionDetailsList = [];
+    _createTermDetailsListFromTermInfoMap(termInfoMap) {
+        const termDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {
             for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {
                 const termTags = [...termTagsMap.values()];
                 this._sortTags(termTags);
-                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
+                termDetailsList.push(this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
             }
         }
-        return expressionDetailsList;
+        return termDetailsList;
     }
 
-    _createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags) {
+    _createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags) {
         const termFrequency = this._scoreToTermFrequency(this._getTermTagsScoreSum(termTags));
         return {
             sourceTerm,

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -774,7 +774,7 @@ class Translator {
             }
 
             let removeIndex = i;
-            if (definition.expression.length > existing[1].expression.length) {
+            if (definition.source.length > existing[1].source.length) {
                 definitionGroups.set(id, [i, definition]);
                 removeIndex = existing[0];
             }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -252,10 +252,10 @@ class Translator {
 
         const expressionDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {
-            for (const [reading, {termTagsMap, sourceTerm}] of readingMap.entries()) {
+            for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {
                 const termTags = [...termTagsMap.values()];
                 this._sortTags(termTags);
-                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, termTags));
+                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
             }
         }
 
@@ -346,8 +346,8 @@ class Translator {
 
         const unusedDefinitions = unsequencedDefinitions.filter((definition) => !usedDefinitions.has(definition));
         for (const groupedDefinition of this._groupTerms(unusedDefinitions, enabledDictionaryMap)) {
-            const {reasons, score, expression, reading, source, rawSource, sourceTerm, dictionary, termTags} = groupedDefinition;
-            const expressionDetails = this._createExpressionDetails(sourceTerm, expression, reading, termTags);
+            const {reasons, score, expression, reading, source, rawSource, sourceTerm, dictionary, furiganaSegments, termTags} = groupedDefinition;
+            const expressionDetails = this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags);
             const compatibilityDefinition = this._createMergedTermDefinition(
                 source,
                 rawSource,
@@ -879,7 +879,7 @@ class Translator {
     }
 
     _addUniqueTermInfos(definitions, termInfoMap) {
-        for (const {expression, reading, sourceTerm, termTags} of definitions) {
+        for (const {expression, reading, sourceTerm, furiganaSegments, termTags} of definitions) {
             let readingMap = termInfoMap.get(expression);
             if (typeof readingMap === 'undefined') {
                 readingMap = new Map();
@@ -890,6 +890,7 @@ class Translator {
             if (typeof termInfo === 'undefined') {
                 termInfo = {
                     sourceTerm,
+                    furiganaSegments,
                     termTagsMap: new Map()
                 };
                 readingMap.set(reading, termInfo);
@@ -1111,14 +1112,13 @@ class Translator {
         };
     }
 
-    _createExpressionDetails(sourceTerm, expression, reading, termTags) {
+    _createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags) {
         const termFrequency = this._scoreToTermFrequency(this._getTermTagsScoreSum(termTags));
-        const furiganaSegments = jp.distributeFurigana(expression, reading);
         return {
             sourceTerm,
             expression,
             reading,
-            furiganaSegments,
+            furiganaSegments, // Contains duplicate data
             termTags,
             termFrequency,
             frequencies: [],

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -175,8 +175,9 @@ class Translator {
         if (sequenceList.length > 0) {
             const databaseDefinitions = await this._database.findTermsBySequenceBulk(sequenceList, mainDictionary);
             for (const databaseDefinition of databaseDefinitions) {
-                const {definitions: definitions2, source, rawSource, sourceTerm, reasons} = sequencedDefinitions[databaseDefinition.index];
-                const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, reasons, enabledDictionaryMap);
+                const {definitions: definitions2} = sequencedDefinitions[databaseDefinition.index];
+                const {expression} = databaseDefinition;
+                const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, expression, expression, expression, [], enabledDictionaryMap);
                 definitions2.push(definition);
             }
         }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -250,14 +250,7 @@ class Translator {
 
         this._sortDefinitions(glossaryDefinitions, true);
 
-        const expressionDetailsList = [];
-        for (const [expression, readingMap] of termInfoMap.entries()) {
-            for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {
-                const termTags = [...termTagsMap.values()];
-                this._sortTags(termTags);
-                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
-            }
-        }
+        const expressionDetailsList = this._createExpressionDetailsListFromTermInfoMap(termInfoMap);
 
         return this._createMergedTermDefinition(
             source,
@@ -1110,6 +1103,18 @@ class Translator {
             pitches: [],
             only
         };
+    }
+
+    _createExpressionDetailsListFromTermInfoMap(termInfoMap) {
+        const expressionDetailsList = [];
+        for (const [expression, readingMap] of termInfoMap.entries()) {
+            for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {
+                const termTags = [...termTagsMap.values()];
+                this._sortTags(termTags);
+                expressionDetailsList.push(this._createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
+            }
+        }
+        return expressionDetailsList;
     }
 
     _createExpressionDetails(sourceTerm, expression, reading, furiganaSegments, termTags) {


### PR DESCRIPTION
This change adds `sourceTerm` to single-part dictionary entries and to the `expressions` array of definition entries. Additionally, `expressions` is now present on all definition entries, and the `source`/`rawSource` of related (sequenced) terms has been adjusted to match the `expression` of those terms.

The addition of `sourceTerm` should provided enough information to support #560 and #559.