### PR TITLE
Add check to verify expressions are strings

### DIFF
--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -1176,6 +1176,8 @@ class Translator {
 
             const expression1 = v1.expression;
             const expression2 = v2.expression;
+            if (typeof expression1 !== 'string' || typeof expression2 !== 'string') { return 0; } // Skip if either is not a string (array)
+
             i = expression2.length - expression1.length;
             if (i !== 0) { return i; }
 


### PR DESCRIPTION
Check would work when the `expression` value is an array, but would not yield the expected results. Instead, just skip the checks for this case.