### PR TITLE
Translator organization

### DIFF
--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -837,6 +837,8 @@ class Translator {
         }
     }
 
+    // Simple helpers
+
     _scoreToTermFrequency(score) {
         if (score > 0) {
             return 'popular';
@@ -887,6 +889,8 @@ class Translator {
         }
     }
 
+    // Reduction functions
+
     _getTermTagsScoreSum(termTags) {
         let result = 0;
         for (const {score} of termTags) {
@@ -918,6 +922,8 @@ class Translator {
         }
         return result;
     }
+
+    // Common data creation and cloning functions
 
     _cloneTag(tag) {
         const {name, category, notes, order, score, dictionary} = tag;
@@ -1150,6 +1156,8 @@ class Translator {
             pitches: []
         };
     }
+
+    // Sorting functions
 
     _sortTags(tags) {
         if (tags.length <= 1) { return; }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -680,56 +680,6 @@ class Translator {
         return {reading, pitches, dictionary};
     }
 
-    _scoreToTermFrequency(score) {
-        if (score > 0) {
-            return 'popular';
-        } else if (score < 0) {
-            return 'rare';
-        } else {
-            return 'normal';
-        }
-    }
-
-    _getNameBase(name) {
-        const pos = name.indexOf(':');
-        return (pos >= 0 ? name.substring(0, pos) : name);
-    }
-
-    *_getArrayVariants(arrayVariants) {
-        const ii = arrayVariants.length;
-
-        let total = 1;
-        for (let i = 0; i < ii; ++i) {
-            total *= arrayVariants[i].length;
-        }
-
-        for (let a = 0; a < total; ++a) {
-            const variant = [];
-            let index = a;
-            for (let i = 0; i < ii; ++i) {
-                const entryVariants = arrayVariants[i];
-                variant.push(entryVariants[index % entryVariants.length]);
-                index = Math.floor(index / entryVariants.length);
-            }
-            yield variant;
-        }
-    }
-
-    _getSearchableText(text, allowAlphanumericCharacters) {
-        if (allowAlphanumericCharacters) {
-            return text;
-        }
-
-        let newText = '';
-        for (const c of text) {
-            if (!jp.isCodePointJapanese(c.codePointAt(0))) {
-                break;
-            }
-            newText += c;
-        }
-        return newText;
-    }
-
     _getSecondarySearchDictionaryMap(enabledDictionaryMap) {
         const secondarySearchDictionaryMap = new Map();
         for (const [title, dictionary] of enabledDictionaryMap.entries()) {
@@ -884,6 +834,56 @@ class Translator {
                 if (termTagsMap.has(name)) { continue; }
                 termTagsMap.set(name, this._cloneTag(tag));
             }
+        }
+    }
+
+    _scoreToTermFrequency(score) {
+        if (score > 0) {
+            return 'popular';
+        } else if (score < 0) {
+            return 'rare';
+        } else {
+            return 'normal';
+        }
+    }
+
+    _getNameBase(name) {
+        const pos = name.indexOf(':');
+        return (pos >= 0 ? name.substring(0, pos) : name);
+    }
+
+    _getSearchableText(text, allowAlphanumericCharacters) {
+        if (allowAlphanumericCharacters) {
+            return text;
+        }
+
+        let newText = '';
+        for (const c of text) {
+            if (!jp.isCodePointJapanese(c.codePointAt(0))) {
+                break;
+            }
+            newText += c;
+        }
+        return newText;
+    }
+
+    *_getArrayVariants(arrayVariants) {
+        const ii = arrayVariants.length;
+
+        let total = 1;
+        for (let i = 0; i < ii; ++i) {
+            total *= arrayVariants[i].length;
+        }
+
+        for (let a = 0; a < total; ++a) {
+            const variant = [];
+            let index = a;
+            for (let i = 0; i < ii; ++i) {
+                const entryVariants = arrayVariants[i];
+                variant.push(entryVariants[index % entryVariants.length]);
+                index = Math.floor(index / entryVariants.length);
+            }
+            yield variant;
         }
     }
 

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -682,20 +682,6 @@ class Translator {
         return {reading, pitches, dictionary};
     }
 
-    _getSecondarySearchDictionaryMap(enabledDictionaryMap) {
-        const secondarySearchDictionaryMap = new Map();
-        for (const [title, dictionary] of enabledDictionaryMap.entries()) {
-            if (!dictionary.allowSecondarySearches) { continue; }
-            secondarySearchDictionaryMap.set(title, dictionary);
-        }
-        return secondarySearchDictionaryMap;
-    }
-
-    _getDictionaryPriority(dictionary, enabledDictionaryMap) {
-        const info = enabledDictionaryMap.get(dictionary);
-        return typeof info !== 'undefined' ? info.priority : 0;
-    }
-
     _removeDuplicateDefinitions(definitions) {
         const definitionGroups = new Map();
         for (let i = 0, ii = definitions.length; i < ii; ++i) {
@@ -869,6 +855,20 @@ class Translator {
             newText += c;
         }
         return newText;
+    }
+
+    _getSecondarySearchDictionaryMap(enabledDictionaryMap) {
+        const secondarySearchDictionaryMap = new Map();
+        for (const [title, dictionary] of enabledDictionaryMap.entries()) {
+            if (!dictionary.allowSecondarySearches) { continue; }
+            secondarySearchDictionaryMap.set(title, dictionary);
+        }
+        return secondarySearchDictionaryMap;
+    }
+
+    _getDictionaryPriority(dictionary, enabledDictionaryMap) {
+        const info = enabledDictionaryMap.get(dictionary);
+        return typeof info !== 'undefined' ? info.priority : 0;
     }
 
     *_getArrayVariants(arrayVariants) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -510,14 +510,6 @@ class Translator {
         return deinflections;
     }
 
-    _getTextOptionEntryVariants(value) {
-        switch (value) {
-            case 'true': return [true];
-            case 'variant': return [false, true];
-            default: return [false];
-        }
-    }
-
     async _buildTermMeta(definitions, enabledDictionaryMap) {
         const terms = [];
         for (const definition of definitions) {
@@ -835,6 +827,14 @@ class Translator {
             newText += c;
         }
         return newText;
+    }
+
+    _getTextOptionEntryVariants(value) {
+        switch (value) {
+            case 'true': return [true];
+            case 'variant': return [false, true];
+            default: return [false];
+        }
     }
 
     _getSecondarySearchDictionaryMap(enabledDictionaryMap) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -222,7 +222,7 @@ class Translator {
         return [definitionsMerged, length];
     }
 
-    // Find terms/kanji internal implementation
+    // Find terms internal implementation
 
     async _findTermsInternal(text, enabledDictionaryMap, options) {
         const {alphanumeric, wildcard} = options;
@@ -632,6 +632,8 @@ class Translator {
             }
         }
     }
+
+    // Metadata building
 
     async _buildTermMeta(definitions, enabledDictionaryMap) {
         const terms = [];

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -734,26 +734,6 @@ class Translator {
         }
     }
 
-    _getTagNamesWithCategory(tags, category) {
-        const results = [];
-        for (const tag of tags) {
-            if (tag.category !== category) { continue; }
-            results.push(tag.name);
-        }
-        results.sort();
-        return results;
-    }
-
-    _removeTagsWithCategory(tags, removeCategoriesSet) {
-        for (let i = 0, ii = tags.length; i < ii; ++i) {
-            const {category} = tags[i];
-            if (!removeCategoriesSet.has(category)) { continue; }
-            tags.splice(i, 1);
-            --i;
-            --ii;
-        }
-    }
-
     _groupTerms(definitions) {
         const groups = new Map();
         for (const definition of definitions) {
@@ -869,6 +849,26 @@ class Translator {
     _getDictionaryPriority(dictionary, enabledDictionaryMap) {
         const info = enabledDictionaryMap.get(dictionary);
         return typeof info !== 'undefined' ? info.priority : 0;
+    }
+
+    _getTagNamesWithCategory(tags, category) {
+        const results = [];
+        for (const tag of tags) {
+            if (tag.category !== category) { continue; }
+            results.push(tag.name);
+        }
+        results.sort();
+        return results;
+    }
+
+    _removeTagsWithCategory(tags, removeCategoriesSet) {
+        for (let i = 0, ii = tags.length; i < ii; ++i) {
+            const {category} = tags[i];
+            if (!removeCategoriesSet.has(category)) { continue; }
+            tags.splice(i, 1);
+            --i;
+            --ii;
+        }
     }
 
     *_getArrayVariants(arrayVariants) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -289,18 +289,6 @@ class Translator {
         return [...definitionTagsMap.values()];
     }
 
-    _getTermTagsScoreSum(termTags) {
-        let result = 0;
-        for (const {score} of termTags) { result += score; }
-        return result;
-    }
-
-    _getSourceTermMatchCountSum(definitions) {
-        let result = 0;
-        for (const {sourceTermExactMatchCount} of definitions) { result += sourceTermExactMatchCount; }
-        return result;
-    }
-
     async _findTermsGrouped(text, options) {
         const {compactTags, enabledDictionaryMap} = options;
         const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
@@ -897,6 +885,22 @@ class Translator {
                 termTagsMap.set(name, this._cloneTag(tag));
             }
         }
+    }
+
+    _getTermTagsScoreSum(termTags) {
+        let result = 0;
+        for (const {score} of termTags) {
+            result += score;
+        }
+        return result;
+    }
+
+    _getSourceTermMatchCountSum(definitions) {
+        let result = 0;
+        for (const {sourceTermExactMatchCount} of definitions) {
+            result += sourceTermExactMatchCount;
+        }
+        return result;
     }
 
     _getMaxDefinitionScore(definitions) {


### PR DESCRIPTION
Final organization of the `Translator` class. This change is intended to make it easier to find function implementations and have to scroll less between related functionality, as mentioned in #878.