### PR TITLE
Update merged definitions to have consistent structure

### DIFF
--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -1089,7 +1089,7 @@ class Translator {
             // glossary
             // definitionTags
             // termTags
-            definitions, // type: 'termMergedByGlossary'
+            definitions, // type: 'termMergedByGlossary', 'term'
             frequencies: [],
             pitches: [],
             // only

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -199,7 +199,7 @@ class Translator {
             const compatibilityDefinition = this._createMergedTermDefinition(
                 source,
                 rawSource,
-                definitions2,
+                this._convertTermDefinitionsToMergedGlossaryTermDefinitions(definitions2),
                 [expression],
                 [reading],
                 termDetailsList,
@@ -641,6 +641,18 @@ class Translator {
                 termTagsMap.set(name, this._cloneTag(tag));
             }
         }
+    }
+
+    _convertTermDefinitionsToMergedGlossaryTermDefinitions(definitions) {
+        const convertedDefinitions = [];
+        for (const definition of definitions) {
+            const {source, rawSource, expression, reading} = definition;
+            const expressions = new Set([expression]);
+            const readings = new Set([reading]);
+            const convertedDefinition = this._createMergedGlossaryTermDefinition(source, rawSource, [definition], expressions, readings, expressions, readings);
+            convertedDefinitions.push(convertedDefinition);
+        }
+        return convertedDefinitions;
     }
 
     // Metadata building
@@ -1089,7 +1101,7 @@ class Translator {
             // glossary
             // definitionTags
             // termTags
-            definitions, // type: 'termMergedByGlossary', 'term'
+            definitions, // type: 'termMergedByGlossary'
             frequencies: [],
             pitches: [],
             // only


### PR DESCRIPTION
~The 'term' type will be used for compatibility definitions in merged mode. For now, only the comment is updated.~

The definitions are now converted to a consistent `termMerged` type.