### PR TITLE
Fix search page being focused when changing settings

### DIFF
--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -107,7 +107,7 @@ class Frontend {
 
         yomichan.on('optionsUpdated', this.updateOptions.bind(this));
         yomichan.on('zoomChanged', this._onZoomChanged.bind(this));
-        yomichan.on('closePopups', this._onApiClosePopup.bind(this));
+        yomichan.on('closePopups', this._onClosePopups.bind(this));
         chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
 
         this._textScanner.on('clearSelection', this._onClearSelection.bind(this));
@@ -224,6 +224,10 @@ class Frontend {
     _onZoomChanged({newZoomFactor}) {
         this._pageZoomFactor = newZoomFactor;
         this._updateContentScale();
+    }
+
+    _onClosePopups() {
+        this._clearSelection(true);
     }
 
     _onVisualViewportScroll() {


### PR DESCRIPTION
Using the following steps on Chrome, the tab focus would be changed when changing a settings value:
* Open search page
* Enter query
* Scan a result from that query, opening a nested popup
* Go to options page
* Disable "Enable scanning on search page"
* Search page will be `.focus`'d

This change fixes the issue by making the event passive so that focus is not changed.