### PR TITLE
Fix "modifier" field being required despite being deleted

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -332,7 +332,6 @@
                                     "delay",
                                     "hideDelay",
                                     "length",
-                                    "modifier",
                                     "deepDomScan",
                                     "popupNestingMaxDepth",
                                     "enablePopupSearch",


### PR DESCRIPTION
Fixes #917:
> And also old exported setting files don't seem to work on this new version.