### PR TITLE
Custom audio URL random

### DIFF
--- a/ext/bg/js/audio-downloader.js
+++ b/ext/bg/js/audio-downloader.js
@@ -31,6 +31,7 @@ class AudioDownloader {
             ['text-to-speech-reading', this._getInfoTextToSpeechReading.bind(this)],
             ['custom', this._getInfoCustom.bind(this)]
         ]);
+        this._customUrlFormatPattern = /\{([^}]*)\}/g;
     }
 
     async getInfo(source, expression, reading, details) {
@@ -202,7 +203,7 @@ class AudioDownloader {
             throw new Error('No custom URL defined');
         }
         const data = {expression, reading};
-        const url = customSourceUrl.replace(/\{([^}]*)\}/g, (m0, m1) => (hasOwn(data, m1) ? `${data[m1]}` : m0));
+        const url = customSourceUrl.replace(this._customUrlFormatPattern, (m0, m1) => (hasOwn(data, m1) ? `${data[m1]}` : m0));
         return {type: 'url', details: {url}};
     }
 


### PR DESCRIPTION
Adds support for generating random strings as part of custom audio URLs. The format is:

`{random:CHARACTERS,COUNT}`

* `CHARACTERS` - a sequence of characters or character ranges.
  * A single character is just that character, e.g. `X`.
  * Characters ranges are defined in the format `X-Z`, which includes the characters `X`, `Z`, and all characters between.
  * There is no delimiter between character/range groups.
  * Characters can optionally be prefixed with a `\`, which can be used to include a raw `-` character without forming a group.
* `COUNT` - non-negative base-10 integer.

Example: `{random:a-zA-Z0-9\-,32}` to generate a 32 character string including alphanumeric characters and a dash.

Resolves #898?