### PR TITLE
Duplicate scope options

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -774,7 +774,7 @@
                                     "duplicateScope": {
                                         "type": "string",
                                         "default": "collection",
-                                        "enum": ["collection", "deck"]
+                                        "enum": ["collection", "deck", "deck-root"]
                                     },
                                     "fieldTemplates": {
                                         "type": ["string", "null"],

--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -44,6 +44,14 @@ class AnkiNoteBuilder {
             await this._injectMedia(anki, definition, fields, mode, audioDetails, screenshotDetails, clipboardDetails);
         }
 
+        let duplicateScopeDeckName = null;
+        let duplicateScopeCheckChildren = false;
+        if (duplicateScope === 'deck-root') {
+            duplicateScope = 'deck';
+            duplicateScopeDeckName = this.getRootDeckName(deck);
+            duplicateScopeCheckChildren = true;
+        }
+
         const fieldEntries = Object.entries(fields);
         const noteFields = {};
         const note = {
@@ -51,7 +59,13 @@ class AnkiNoteBuilder {
             tags,
             deckName: deck,
             modelName: model,
-            options: {duplicateScope}
+            options: {
+                duplicateScope,
+                duplicateScopeOptions: {
+                    deckName: duplicateScopeDeckName,
+                    checkChildren: duplicateScopeCheckChildren
+                }
+            }
         };
 
         const data = this._createNoteData(definition, mode, context, resultOutputMode, compactGlossaries);
@@ -79,6 +93,11 @@ class AnkiNoteBuilder {
             }
         }
         return false;
+    }
+
+    getRootDeckName(deckName) {
+        const index = deckName.indexOf('::');
+        return index >= 0 ? deckName.substring(0, index) : deckName;
     }
 
     // Private

--- a/ext/bg/js/anki.js
+++ b/ext/bg/js/anki.js
@@ -92,11 +92,24 @@ class AnkiConnect {
         if (!this._enabled) { return []; }
         await this._checkVersion();
         const actions = notes.map((note) => {
-            let query = (duplicateScope === 'deck' ? `"deck:${this._escapeQuery(note.deckName)}" ` : '');
+            let query = '';
+            switch (duplicateScope) {
+                case 'deck':
+                    query = `"deck:${this._escapeQuery(note.deckName)}" `;
+                    break;
+                case 'deck-root':
+                    query = `"deck:${this._escapeQuery(this.getRootDeckName(note.deckName))}" `;
+                    break;
+            }
             query += this._fieldsToQuery(note.fields);
             return {action: 'findNotes', params: {query}};
         });
         return await this._invoke('multi', {actions});
+    }
+
+    getRootDeckName(deckName) {
+        const index = deckName.indexOf('::');
+        return index >= 0 ? deckName.substring(0, index) : deckName;
     }
 
     // Private

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -926,6 +926,7 @@
                         <select class="form-control" id="duplicate-scope" data-setting="anki.duplicateScope">
                             <option value="collection">Collection</option>
                             <option value="deck">Deck</option>
+                            <option value="deck-root">Deck root</option>
                         </select>
                     </div>
 


### PR DESCRIPTION
Add support for card duplication check in the root deck and all children, instead of just one specific deck. Resolves #926. Depends on https://github.com/FooSoft/anki-connect/pull/203.