### PR TITLE
Json schema default value improvement

### DIFF
--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -637,7 +637,8 @@ class JsonSchemaValidator {
                 if (propertySchema === null) { continue; }
                 info.valuePush(property, value);
                 info.schemaPush(property, propertySchema);
-                value[property] = this._getValidValueOrDefault(propertySchema, value[property], info);
+                const hasValue = Object.prototype.hasOwnProperty.call(value, property);
+                value[property] = this._getValidValueOrDefault(propertySchema, hasValue ? value[property] : void 0, info);
                 info.schemaPop();
                 info.valuePop();
             }

--- a/test/test-schema.js
+++ b/test/test-schema.js
@@ -540,6 +540,60 @@ function testGetValidValueOrDefault1() {
                     {test: 'value', test2: 2, test3: 10}
                 ]
             ]
+        },
+
+        // Test value defaulting where hasOwnProperty is false
+        {
+            schema: {
+                type: 'object',
+                required: ['test'],
+                properties: {
+                    test: {
+                        type: 'string',
+                        default: 'default'
+                    }
+                }
+            },
+            inputs: [
+                [
+                    {},
+                    {test: 'default'}
+                ],
+                [
+                    {test: 'value'},
+                    {test: 'value'}
+                ],
+                [
+                    Object.create({test: 'value'}),
+                    {test: 'default'}
+                ]
+            ]
+        },
+        {
+            schema: {
+                type: 'object',
+                required: ['toString'],
+                properties: {
+                    toString: {
+                        type: 'string',
+                        default: 'default'
+                    }
+                }
+            },
+            inputs: [
+                [
+                    {},
+                    {toString: 'default'}
+                ],
+                [
+                    {toString: 'value'},
+                    {toString: 'value'}
+                ],
+                [
+                    Object.create({toString: 'value'}),
+                    {toString: 'default'}
+                ]
+            ]
         }
     ];
 


### PR DESCRIPTION
Require properties to exist (via `hasOwnProperty`) before validating their value.