### PR TITLE
Text scanning options propagation

### DIFF
--- a/ext/fg/js/float.js
+++ b/ext/fg/js/float.js
@@ -61,11 +61,6 @@ class DisplayFloat extends Display {
         this._invokeOwner('closePopup');
     }
 
-    async setOptionsContext(optionsContext) {
-        super.setOptionsContext(optionsContext);
-        await this.updateOptions();
-    }
-
     async getDocumentTitle() {
         try {
             const targetFrameId = 0;
@@ -99,9 +94,7 @@ class DisplayFloat extends Display {
 
     async _onMessageConfigure({frameId, ownerFrameId, popupId, optionsContext, childrenSupported, scale}) {
         this.ownerFrameId = ownerFrameId;
-        this.setOptionsContext(optionsContext);
-
-        await this.updateOptions();
+        await this.setOptionsContext(optionsContext);
 
         if (childrenSupported && !this._nestedPopupsPrepared) {
             const {depth} = optionsContext;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -147,7 +147,6 @@ class Frontend {
             if (!yomichan.isExtensionUnloaded) {
                 throw e;
             }
-            this._showExtensionUnloaded(null);
         }
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -473,7 +473,6 @@ class Frontend {
     }
 
     _showContent(textSource, focus, definitions, type, sentence, optionsContext) {
-        const {url} = optionsContext;
         const query = textSource.text();
         const details = {
             focus,
@@ -486,7 +485,7 @@ class Frontend {
             state: {
                 focusEntry: 0,
                 sentence,
-                url
+                optionsContext
             },
             content: {
                 definitions

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -480,12 +480,12 @@ class Frontend {
         }
     }
 
-    async _showExtensionUnloaded(textSource) {
+    _showExtensionUnloaded(textSource) {
         if (textSource === null) {
             textSource = this._textScanner.getCurrentTextSource();
             if (textSource === null) { return; }
         }
-        this._showPopupContent(textSource, await this._getOptionsContext());
+        this._showPopupContent(textSource, null);
     }
 
     _showContent(textSource, focus, definitions, type, sentence, optionsContext) {
@@ -578,7 +578,7 @@ class Frontend {
             this._popup !== null &&
             await this._popup.isVisible()
         ) {
-            this._showPopupContent(textSource, await this._getOptionsContext());
+            this._showPopupContent(textSource, null);
         }
     }
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -33,7 +33,6 @@ class Frontend {
         pageType,
         allowRootFramePopupProxy
     }) {
-        this._id = generateId(16);
         this._popup = null;
         this._disabledOverride = false;
         this._options = null;
@@ -386,7 +385,7 @@ class Frontend {
         const optionsContext = await this._getOptionsContext();
         if (this._updatePopupToken !== token) { return; }
         if (popup !== null) {
-            await popup.setOptionsContext(optionsContext, this._id);
+            await popup.setOptionsContext(optionsContext);
         }
         if (this._updatePopupToken !== token) { return; }
 
@@ -521,7 +520,6 @@ class Frontend {
             this._popup !== null ?
             this._popup.showContent(
                 {
-                    source: this._id,
                     optionsContext,
                     elementRect: textSource.getRect(),
                     writingMode: textSource.getWritingMode()

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -227,8 +227,9 @@ class Display extends EventDispatcher {
         return this._optionsContext;
     }
 
-    setOptionsContext(optionsContext) {
+    async setOptionsContext(optionsContext) {
         this._optionsContext = optionsContext;
+        await this.updateOptions();
     }
 
     async updateOptions() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -821,6 +821,16 @@ class Display extends EventDispatcher {
             changeHistory = true;
         }
 
+        let {sentence=null, optionsContext=null, focusEntry=null, scrollX=null, scrollY=null} = state;
+        if (!(typeof optionsContext === 'object' && optionsContext !== null)) {
+            optionsContext = this.getOptionsContext();
+            state.optionsContext = optionsContext;
+            changeHistory = true;
+        }
+        let {url} = optionsContext;
+        if (typeof url !== 'string') { url = window.location.href; }
+        sentence = this._getValidSentenceData(sentence);
+
         source = this.postProcessQuery(source);
         let full = urlSearchParams.get('full');
         full = (full === null ? source : this.postProcessQuery(full));
@@ -835,6 +845,9 @@ class Display extends EventDispatcher {
             changeHistory = true;
         }
 
+        await this._setOptionsContextIfDifferent(optionsContext);
+        if (this._setContentToken !== token) { return true; }
+
         if (changeHistory) {
             this._historyStateUpdate(state, content);
         }
@@ -842,10 +855,6 @@ class Display extends EventDispatcher {
         eventArgs.source = source;
         eventArgs.content = content;
         this.trigger('contentUpdating', eventArgs);
-
-        let {sentence=null, url=null, focusEntry=null, scrollX=null, scrollY=null} = state;
-        if (typeof url !== 'string') { url = window.location.href; }
-        sentence = this._getValidSentenceData(sentence);
 
         this._definitions = definitions;
 
@@ -1485,5 +1494,10 @@ class Display extends EventDispatcher {
             }
         }
         return true;
+    }
+
+    async _setOptionsContextIfDifferent(optionsContext) {
+        if (deepEqual(this._optionsContext, optionsContext)) { return; }
+        await this.setOptionsContext(optionsContext);
     }
 }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -508,7 +508,7 @@ class Display extends EventDispatcher {
         }
     }
 
-    _onQueryParserSearch({type, definitions, sentence, inputInfo: {cause}, textSource}) {
+    _onQueryParserSearch({type, definitions, sentence, inputInfo: {cause}, textSource, optionsContext}) {
         const query = textSource.text();
         const history = (cause === 'click');
         const details = {
@@ -517,7 +517,7 @@ class Display extends EventDispatcher {
             params: this._createSearchParams(type, query, false),
             state: {
                 sentence,
-                url: window.location.href
+                optionsContext
             },
             content: {
                 definitions
@@ -571,7 +571,7 @@ class Display extends EventDispatcher {
                 state: {
                     focusEntry: 0,
                     sentence: state.sentence,
-                    url: state.url
+                    optionsContext: state.optionsContext
                 },
                 content: {
                     definitions
@@ -630,7 +630,7 @@ class Display extends EventDispatcher {
             state: {
                 focusEntry: 0,
                 sentence,
-                url: state.url
+                optionsContext: state.optionsContext
             },
             content: {
                 definitions
@@ -780,8 +780,7 @@ class Display extends EventDispatcher {
         }
     }
 
-    async _findDefinitions(isTerms, source, urlSearchParams) {
-        const optionsContext = this.getOptionsContext();
+    async _findDefinitions(isTerms, source, urlSearchParams, optionsContext) {
         if (isTerms) {
             const findDetails = {};
             if (urlSearchParams.get('wildcards') !== 'off') {
@@ -830,7 +829,7 @@ class Display extends EventDispatcher {
 
         let {definitions} = content;
         if (!Array.isArray(definitions)) {
-            definitions = await this._findDefinitions(isTerms, source, urlSearchParams);
+            definitions = await this._findDefinitions(isTerms, source, urlSearchParams, optionsContext);
             if (this._setContentToken !== token) { return true; }
             content.definitions = definitions;
             changeHistory = true;

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -238,6 +238,14 @@ class TextScanner extends EventDispatcher {
 
     // Private
 
+    async _getOptionsContextForInput(inputInfo) {
+        const optionsContext = clone(await this._getOptionsContext());
+        const {modifiers, modifierKeys} = inputInfo;
+        optionsContext.modifiers = [...modifiers];
+        optionsContext.modifierKeys = [...modifierKeys];
+        return optionsContext;
+    }
+
     async _search(textSource, searchTerms, searchKanji, inputInfo) {
         let definitions = null;
         let sentence = null;
@@ -251,7 +259,7 @@ class TextScanner extends EventDispatcher {
                 return;
             }
 
-            optionsContext = await this._getOptionsContext();
+            optionsContext = await this._getOptionsContextForInput(inputInfo);
             searched = true;
 
             const result = await this._findDefinitions(textSource, searchTerms, searchKanji, optionsContext);
@@ -810,7 +818,6 @@ class TextScanner extends EventDispatcher {
     _getMatchingInputGroupFromEvent(type, cause, event) {
         const modifiers = DocumentUtil.getActiveModifiersAndButtons(event);
         const modifierKeys = DocumentUtil.getActiveModifiers(event);
-        this.trigger('activeModifiersChanged', {modifiers, modifierKeys});
         return this._getMatchingInputGroup(type, cause, modifiers, modifierKeys);
     }
 


### PR DESCRIPTION
This change updates how `optionsContext` is propagated to the popup during the scanning process. `TextScanner` is now in charge of applying the modifiers to the object, and `Frontend` no longer uses them. These options are passed to the `Display` classes, which use them for definitions lookup.

This change enables modifier keys to work for the query parser, which fixes #558.