### PR TITLE
Compact tags refactor

### DIFF
--- a/ext/bg/data/default-anki-field-templates.handlebars
+++ b/ext/bg/data/default-anki-field-templates.handlebars
@@ -1,6 +1,17 @@
 {{#*inline "glossary-single"}}
     {{~#unless brief~}}
-        {{~#if definitionTags~}}<i>({{#each definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
+        {{~#scope~}}
+            {{~#set "any" false}}{{/set~}}
+            {{~#if definitionTags~}}{{#each definitionTags~}}
+                {{~#if (op "||" (op "!" ../data.compactTags) (op "!" redundant))~}}
+                    {{~#if (get "any")}}, {{else}}<i>({{/if~}}
+                    {{name}}
+                    {{~#set "any" true}}{{/set~}}
+                {{~/if~}}
+            {{~/each~}}
+            {{~#if (get "any")}})</i> {{/if~}}
+            {{~/if~}}
+        {{~/scope~}}
         {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
     {{~/unless~}}
     {{~#if glossary.[1]~}}
@@ -92,18 +103,18 @@
     {{~else~}}
         {{~#if group~}}
             {{~#if definition.definitions.[1]~}}
-                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries}}</li>{{/each}}</ol>
+                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries data=../.}}</li>{{/each}}</ol>
             {{~else~}}
-                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries~}}
+                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries data=.~}}
             {{~/if~}}
         {{~else if merge~}}
             {{~#if definition.definitions.[1]~}}
-                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries}}</li>{{/each}}</ol>
+                <ol>{{#each definition.definitions}}<li>{{> glossary-single brief=../brief compactGlossaries=../compactGlossaries data=../.}}</li>{{/each}}</ol>
             {{~else~}}
-                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries~}}
+                {{~> glossary-single definition.definitions.[0] brief=brief compactGlossaries=compactGlossaries data=.~}}
             {{~/if~}}
         {{~else~}}
-            {{~> glossary-single definition brief=brief compactGlossaries=compactGlossaries~}}
+            {{~> glossary-single definition brief=brief compactGlossaries=compactGlossaries data=.~}}
         {{~/if~}}
     {{~/if~}}
     </div>

--- a/ext/bg/js/anki-note-builder.js
+++ b/ext/bg/js/anki-note-builder.js
@@ -35,6 +35,7 @@ class AnkiNoteBuilder {
         duplicateScope='collection',
         resultOutputMode='split',
         compactGlossaries=false,
+        compactTags=false,
         modeOptions: {fields, deck, model},
         audioDetails=null,
         screenshotDetails=null,
@@ -70,7 +71,7 @@ class AnkiNoteBuilder {
             }
         };
 
-        const data = this._createNoteData(definition, mode, context, resultOutputMode, compactGlossaries);
+        const data = this._createNoteData(definition, mode, context, resultOutputMode, compactGlossaries, compactTags);
         const formattedFieldValuePromises = [];
         for (const [, fieldValue] of fieldEntries) {
             const formattedFieldValuePromise = this._formatField(fieldValue, data, templates, errors);
@@ -104,7 +105,7 @@ class AnkiNoteBuilder {
 
     // Private
 
-    _createNoteData(definition, mode, context, resultOutputMode, compactGlossaries) {
+    _createNoteData(definition, mode, context, resultOutputMode, compactGlossaries, compactTags) {
         const pitches = DictionaryDataUtil.getPitchAccentInfos(definition);
         const pitchCount = pitches.reduce((i, v) => i + v.pitches.length, 0);
         return {
@@ -118,6 +119,7 @@ class AnkiNoteBuilder {
             modeTermKana: mode === 'term-kana',
             modeKanji: mode === 'kanji',
             compactGlossaries,
+            compactTags,
             context
         };
     }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1650,7 +1650,7 @@ class Backend {
         const {wildcard} = details;
         const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
         const {
-            general: {compactTags, mainDictionary},
+            general: {mainDictionary},
             scanning: {alphanumeric},
             translation: {
                 convertHalfWidthCharacters,
@@ -1663,7 +1663,6 @@ class Backend {
         } = options;
         return {
             wildcard,
-            compactTags,
             mainDictionary,
             alphanumeric,
             convertHalfWidthCharacters,

--- a/ext/bg/js/settings/anki-templates-controller.js
+++ b/ext/bg/js/settings/anki-templates-controller.js
@@ -183,7 +183,7 @@ class AnkiTemplatesController {
                 const ankiNoteBuilder = new AnkiNoteBuilder({
                     renderTemplate: this._renderTemplate.bind(this)
                 });
-                const {general: {resultOutputMode, compactGlossaries}} = options;
+                const {general: {resultOutputMode, compactGlossaries, compactTags}} = options;
                 const note = await ankiNoteBuilder.createNote({
                     definition,
                     mode,
@@ -191,6 +191,7 @@ class AnkiTemplatesController {
                     templates,
                     resultOutputMode,
                     compactGlossaries,
+                    compactTags,
                     modeOptions: {
                         fields: {field},
                         deck: '',

--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -562,6 +562,10 @@ button.action-button {
     display: inline;
 }
 
+:root[data-compact-tags=true] .tag[data-redundant=true] {
+    display: none;
+}
+
 .term-glossary-separator,
 .term-reason-separator {
     display: inline;

--- a/ext/mixed/js/display-generator.js
+++ b/ext/mixed/js/display-generator.js
@@ -349,6 +349,7 @@ class DisplayGenerator {
         node.title = details.notes;
         inner.textContent = details.name;
         node.dataset.category = details.category;
+        if (details.redundant) { node.dataset.redundant = true; }
 
         return node;
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1413,7 +1413,7 @@ class Display extends EventDispatcher {
 
     async _createNote(definition, mode, context, options, templates, injectMedia) {
         const {
-            general: {resultOutputMode, compactGlossaries},
+            general: {resultOutputMode, compactGlossaries, compactTags},
             anki: {tags, checkForDuplicates, duplicateScope, kanji, terms, screenshot: {format, quality}},
             audio: {sources, customSourceUrl}
         } = options;
@@ -1454,6 +1454,7 @@ class Display extends EventDispatcher {
             duplicateScope,
             resultOutputMode,
             compactGlossaries,
+            compactTags,
             modeOptions
         });
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -725,6 +725,7 @@ class Display extends EventDispatcher {
         data.ankiEnabled = `${options.anki.enable}`;
         data.audioEnabled = `${options.audio.enabled && options.audio.sources.length > 0}`;
         data.compactGlossaries = `${options.general.compactGlossaries}`;
+        data.compactTags = `${options.general.compactTags}`;
         data.enableSearchTags = `${options.scanning.enableSearchTags}`;
         data.showPitchAccentDownstepNotation = `${options.general.showPitchAccentDownstepNotation}`;
         data.showPitchAccentPositionNotation = `${options.general.showPitchAccentPositionNotation}`;

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -608,6 +608,79 @@ ${update2}
 ${update4}
 ${update6}
 {{~> (lookup . "marker") ~}}`.trimStart()
+        },
+        // Definition tags update
+        {
+            old: `
+{{#*inline "glossary-single"}}
+    {{~#unless brief~}}
+        {{~#if definitionTags~}}<i>({{#each definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
+        {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
+    {{~/unless~}}
+{{/inline}}
+
+{{#*inline "glossary-single2"}}
+    {{~#unless brief~}}
+        {{~#if definitionTags~}}<i>({{#each definitionTags}}{{name}}{{#unless @last}}, {{/unless}}{{/each}})</i> {{/if~}}
+        {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
+    {{~/unless~}}
+{{/inline}}
+
+{{#*inline "glossary"}}
+    {{~> glossary-single definition brief=brief compactGlossaries=compactGlossaries~}}
+    {{~> glossary-single definition brief=brief compactGlossaries=../compactGlossaries~}}
+{{/inline}}
+
+{{~> (lookup . "marker") ~}}
+`.trimStart(),
+
+            expected: `
+{{#*inline "glossary-single"}}
+    {{~#unless brief~}}
+        {{~#scope~}}
+            {{~#set "any" false}}{{/set~}}
+            {{~#if definitionTags~}}{{#each definitionTags~}}
+                {{~#if (op "||" (op "!" ../data.compactTags) (op "!" redundant))~}}
+                    {{~#if (get "any")}}, {{else}}<i>({{/if~}}
+                    {{name}}
+                    {{~#set "any" true}}{{/set~}}
+                {{~/if~}}
+            {{~/each~}}
+            {{~#if (get "any")}})</i> {{/if~}}
+            {{~/if~}}
+        {{~/scope~}}
+        {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
+    {{~/unless~}}
+{{/inline}}
+
+{{#*inline "glossary-single2"}}
+    {{~#unless brief~}}
+        {{~#scope~}}
+            {{~#set "any" false}}{{/set~}}
+            {{~#if definitionTags~}}{{#each definitionTags~}}
+                {{~#if (op "||" (op "!" ../data.compactTags) (op "!" redundant))~}}
+                    {{~#if (get "any")}}, {{else}}<i>({{/if~}}
+                    {{name}}
+                    {{~#set "any" true}}{{/set~}}
+                {{~/if~}}
+            {{~/each~}}
+            {{~#if (get "any")}})</i> {{/if~}}
+            {{~/if~}}
+        {{~/scope~}}
+        {{~#if only~}}({{#each only}}{{{.}}}{{#unless @last}}, {{/unless}}{{/each}} only) {{/if~}}
+    {{~/unless~}}
+{{/inline}}
+
+{{#*inline "glossary"}}
+    {{~> glossary-single definition brief=brief compactGlossaries=compactGlossaries data=.~}}
+    {{~> glossary-single definition brief=brief compactGlossaries=../compactGlossaries data=../.~}}
+{{/inline}}
+
+${update2}
+${update4}
+${update6}
+{{~> (lookup . "marker") ~}}
+`.trimStart()
         }
     ];
 


### PR DESCRIPTION
Enabling `compactTags` no longer affects the format of the definitions returned from the backend. Instead, tags are flagged as `redundant`, and these redundant tags are hidden when `compactTags=true`.