### PR TITLE
Refactor nested popup/frontend setup

### DIFF
--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -25,7 +25,7 @@
 
 class DisplaySearch extends Display {
     constructor() {
-        super();
+        super('search');
         this._searchButton = document.querySelector('#search-button');
         this._queryInput = document.querySelector('#search-textbox');
         this._introElement = document.querySelector('#intro');
@@ -84,8 +84,6 @@ class DisplaySearch extends Display {
         this._clipboardMonitorEnableCheckbox.addEventListener('change', this._onClipboardMonitorEnableChange.bind(this));
 
         this._onModeChange();
-
-        await this._prepareNestedPopups();
 
         this.initializeState();
 
@@ -317,33 +315,6 @@ class DisplaySearch extends Display {
             this._introElement.style.transition = '';
         }
         this._introElement.style.height = '0';
-    }
-
-    async _prepareNestedPopups() {
-        let complete = false;
-
-        const onOptionsUpdated = async () => {
-            const optionsContext = this.getOptionsContext();
-            const options = await api.optionsGet(optionsContext);
-            if (!options.scanning.enableOnSearchPage || complete) { return; }
-
-            complete = true;
-            yomichan.off('optionsUpdated', onOptionsUpdated);
-
-            try {
-                await this.setupNestedPopups({
-                    depth: 1,
-                    useProxyPopup: false,
-                    pageType: 'search'
-                });
-            } catch (e) {
-                yomichan.logError(e);
-            }
-        };
-
-        yomichan.on('optionsUpdated', onOptionsUpdated);
-
-        await onOptionsUpdated();
     }
 
     async _setClipboardMonitorEnabled(value) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -379,10 +379,6 @@ class Frontend {
         }
         if (this._updatePopupToken !== token) { return; }
 
-        if (this._pageType === 'search') {
-            this.setDisabledOverride(!this._options.scanning.enableOnSearchPage);
-        }
-
         this._clearSelection(true);
         this._popupEventListeners.removeAllEventListeners();
         this._popup = popup;
@@ -525,11 +521,7 @@ class Frontend {
     }
 
     _updateTextScannerEnabled() {
-        const enabled = (
-            this._options.general.enable &&
-            this._depth <= this._options.scanning.popupNestingMaxDepth &&
-            !this._disabledOverride
-        );
+        const enabled = (this._options.general.enable && !this._disabledOverride);
         this._textScanner.setEnabled(enabled);
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -255,12 +255,13 @@ class Popup extends EventDispatcher {
 
         // Configure
         await this._invokeSafe('configure', {
-            frameId: this._frameId,
+            depth: this._depth,
+            parentPopupId: this._id,
+            parentFrameId: this._frameId,
             ownerFrameId: this._ownerFrameId,
-            popupId: this._id,
-            optionsContext: this._optionsContext,
             childrenSupported: this._childrenSupported,
-            scale: this._contentScale
+            scale: this._contentScale,
+            optionsContext: this._optionsContext
         });
     }
 


### PR DESCRIPTION
Merges nested popup/frontend setup into the core `Display` class, improving amount of shared code. This also fixes an issue where the first nested popup wouldn't work on the search page when the option `Enable scanning on search page` was `true`, but `Maximum number of additional popups` was `0`.