### PR TITLE
Text scanner improvements

### DIFF
--- a/ext/bg/js/query-parser.js
+++ b/ext/bg/js/query-parser.js
@@ -34,8 +34,6 @@ class QueryParser extends EventDispatcher {
         this._queryParserModeSelect = document.querySelector('#query-parser-mode-select');
         this._textScanner = new TextScanner({
             node: this._queryParser,
-            ignoreElements: () => [],
-            ignorePoint: null,
             getOptionsContext,
             documentUtil,
             searchTerms: true,

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -62,7 +62,7 @@ class DisplaySearch extends Display {
     async prepare() {
         await super.prepare();
         await this.updateOptions();
-        yomichan.on('optionsUpdated', () => this.updateOptions());
+        yomichan.on('optionsUpdated', this._onOptionsUpdated.bind(this));
 
         this.on('contentUpdating', this._onContentUpdating.bind(this));
         this.on('modeChange', this._onModeChange.bind(this));
@@ -126,15 +126,6 @@ class DisplaySearch extends Display {
         }
     }
 
-    async updateOptions() {
-        await super.updateOptions();
-        if (!this._isPrepared) { return; }
-        const query = this._queryInput.value;
-        if (query) {
-            this._onSearchQueryUpdated(query, false);
-        }
-    }
-
     postProcessQuery(query) {
         if (this._wanakanaEnabled) {
             try {
@@ -147,6 +138,14 @@ class DisplaySearch extends Display {
     }
 
     // Private
+
+    async _onOptionsUpdated() {
+        await this.updateOptions();
+        const query = this._queryInput.value;
+        if (query) {
+            this._onSearchQueryUpdated(query, false);
+        }
+    }
 
     _onContentUpdating({type, content, source}) {
         let animate = false;

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -143,7 +143,7 @@ class DisplaySearch extends Display {
         await this.updateOptions();
         const query = this._queryInput.value;
         if (query) {
-            this._onSearchQueryUpdated(query, false);
+            this._search(false);
         }
     }
 
@@ -182,12 +182,12 @@ class DisplaySearch extends Display {
         e.preventDefault();
         e.stopImmediatePropagation();
         this.blurElement(e.currentTarget);
-        this._search();
+        this._search(true);
     }
 
     _onSearch(e) {
         e.preventDefault();
-        this._search();
+        this._search(true);
     }
 
     _onCopy() {
@@ -196,27 +196,8 @@ class DisplaySearch extends Display {
     }
 
     _onExternalSearchUpdate({text, animate=true}) {
-        this._onSearchQueryUpdated(text, animate);
-    }
-
-    _onSearchQueryUpdated(query, animate) {
-        const details = {
-            focus: false,
-            history: false,
-            params: {
-                query
-            },
-            state: {
-                focusEntry: 0,
-                sentence: {text: query, offset: 0},
-                url: window.location.href
-            },
-            content: {
-                definitions: null,
-                animate
-            }
-        };
-        this.setContent(details);
+        this._queryInput.value = text;
+        this._search(animate);
     }
 
     _onWanakanaEnableChange(e) {
@@ -361,9 +342,25 @@ class DisplaySearch extends Display {
         });
     }
 
-    _search() {
+    _search(animate) {
         const query = this._queryInput.value;
-        this._onSearchQueryUpdated(query, true);
+        const details = {
+            focus: false,
+            history: false,
+            params: {
+                query
+            },
+            state: {
+                focusEntry: 0,
+                sentence: {text: query, offset: 0},
+                url: window.location.href
+            },
+            content: {
+                definitions: null,
+                animate
+            }
+        };
+        this.setContent(details);
     }
 
     _updateSearchHeight() {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -322,11 +322,13 @@ class Frontend {
         });
         this._updateTextScannerEnabled();
 
-        const ignoreNodes = ['.scan-disable', '.scan-disable *'];
-        if (!this._options.scanning.enableOnPopupExpressions) {
-            ignoreNodes.push('.source-text', '.source-text *');
+        if (this._pageType !== 'web') {
+            const ignoreNodes = ['.scan-disable', '.scan-disable *'];
+            if (!scanningOptions.enableOnPopupExpressions) {
+                ignoreNodes.push('.source-text', '.source-text *');
+            }
+            this._textScanner.ignoreNodes = ignoreNodes.join(',');
         }
-        this._textScanner.ignoreNodes = ignoreNodes.join(',');
 
         this._updateContentScale();
 

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -323,11 +323,11 @@ class Frontend {
         this._updateTextScannerEnabled();
 
         if (this._pageType !== 'web') {
-            const ignoreNodes = ['.scan-disable', '.scan-disable *'];
+            const excludeSelectors = ['.scan-disable', '.scan-disable *'];
             if (!scanningOptions.enableOnPopupExpressions) {
-                ignoreNodes.push('.source-text', '.source-text *');
+                excludeSelectors.push('.source-text', '.source-text *');
             }
-            this._textScanner.ignoreNodes = ignoreNodes.join(',');
+            this._textScanner.excludeSelector = excludeSelectors.join(',');
         }
 
         this._updateContentScale();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -529,7 +529,7 @@ class Frontend {
     }
 
     _updateTextScannerEnabled() {
-        const enabled = (this._options.general.enable && !this._disabledOverride);
+        const enabled = (this._options !== null && this._options.general.enable && !this._disabledOverride);
         this._textScanner.setEnabled(enabled);
     }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1625,7 +1625,7 @@ class Display extends EventDispatcher {
     }
 
     _copyHostSelection() {
-        if (window.getSelection().toString()) { return false; }
+        if (this._ownerFrameId === null || window.getSelection().toString()) { return false; }
         this._copyHostSelectionInner();
         return true;
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1740,8 +1740,8 @@ class Display extends EventDispatcher {
             preventMiddleMouse: false
         });
 
-        const ignoreNodes = ['.scan-disable', '.scan-disable *', '.source-text', '.source-text *'];
-        this._definitionTextScanner.ignoreNodes = ignoreNodes.join(',');
+        const excludeSelectors = ['.scan-disable', '.scan-disable *', '.source-text', '.source-text *'];
+        this._definitionTextScanner.excludeSelector = excludeSelectors.join(',');
 
         this._definitionTextScanner.setEnabled(true);
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1043,17 +1043,17 @@ class Display extends EventDispatcher {
     }
 
     _setTitleText(text) {
-        let title = '';
+        let title = this._defaultTitle;
         if (text.length > 0) {
             // Chrome limits title to 1024 characters
             const ellipsis = '...';
             const separator = ' - ';
-            const maxLength = this._titleMaxLength - this._defaultTitle.length - separator.length;
+            const maxLength = this._titleMaxLength - title.length - separator.length;
             if (text.length > maxLength) {
                 text = `${text.substring(0, Math.max(0, maxLength - ellipsis.length))}${ellipsis}`;
             }
 
-            title = `${text}${separator}${this._defaultTitle}`;
+            title = `${text}${separator}${title}`;
         }
         document.title = title;
     }

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1740,8 +1740,8 @@ class Display extends EventDispatcher {
             preventMiddleMouse: false
         });
 
-        const excludeSelectors = ['.scan-disable', '.scan-disable *', '.source-text', '.source-text *'];
-        this._definitionTextScanner.excludeSelector = excludeSelectors.join(',');
+        const includeSelector = '.term-glossary-item,.term-glossary-item *,.tag,.tag *';
+        this._definitionTextScanner.includeSelector = includeSelector;
 
         this._definitionTextScanner.setEnabled(true);
     }

--- a/ext/mixed/js/document-util.js
+++ b/ext/mixed/js/document-util.js
@@ -261,6 +261,18 @@ class DocumentUtil {
         return false;
     }
 
+    static everyNodeMatchesSelector(nodes, selector) {
+        const ELEMENT_NODE = Node.ELEMENT_NODE;
+        for (let node of nodes) {
+            while (true) {
+                if (node === null) { return false; }
+                if (node.nodeType === ELEMENT_NODE && node.matches(selector)) { break; }
+                node = node.parentNode;
+            }
+        }
+        return true;
+    }
+
     static getModifierKeys(os) {
         switch (os) {
             case 'win':

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -44,7 +44,7 @@ class TextScanner extends EventDispatcher {
         this._searchOnClickOnly = searchOnClickOnly;
 
         this._isPrepared = false;
-        this._ignoreNodes = null;
+        this._excludeSelector = null;
 
         this._inputInfoCurrent = null;
         this._scanTimerPromise = null;
@@ -87,12 +87,12 @@ class TextScanner extends EventDispatcher {
         this._canClearSelection = value;
     }
 
-    get ignoreNodes() {
-        return this._ignoreNodes;
+    get excludeSelector() {
+        return this._excludeSelector;
     }
 
-    set ignoreNodes(value) {
-        this._ignoreNodes = value;
+    set excludeSelector(value) {
+        this._excludeSelector = value;
     }
 
     prepare() {
@@ -189,11 +189,11 @@ class TextScanner extends EventDispatcher {
 
         clonedTextSource.setEndOffset(length, layoutAwareScan);
 
-        if (this._ignoreNodes !== null) {
+        if (this._excludeSelector !== null) {
             length = clonedTextSource.text().length;
             while (
                 length > 0 &&
-                DocumentUtil.anyNodeMatchesSelector(clonedTextSource.getNodesInRange(), this._ignoreNodes)
+                DocumentUtil.anyNodeMatchesSelector(clonedTextSource.getNodesInRange(), this._excludeSelector)
             ) {
                 --length;
                 clonedTextSource.setEndOffset(length, layoutAwareScan);

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -21,13 +21,22 @@
  */
 
 class TextScanner extends EventDispatcher {
-    constructor({node, ignoreElements, ignorePoint, documentUtil, getOptionsContext, searchTerms=false, searchKanji=false, searchOnClick=false}) {
+    constructor({
+        node,
+        documentUtil,
+        getOptionsContext,
+        ignoreElements=null,
+        ignorePoint=null,
+        searchTerms=false,
+        searchKanji=false,
+        searchOnClick=false
+    }) {
         super();
         this._node = node;
-        this._ignoreElements = ignoreElements;
-        this._ignorePoint = ignorePoint;
         this._documentUtil = documentUtil;
         this._getOptionsContext = getOptionsContext;
+        this._ignoreElements = ignoreElements;
+        this._ignorePoint = ignorePoint;
         this._searchTerms = searchTerms;
         this._searchKanji = searchKanji;
         this._searchOnClick = searchOnClick;
@@ -287,7 +296,7 @@ class TextScanner extends EventDispatcher {
     }
 
     _onMouseOver(e) {
-        if (this._ignoreElements().includes(e.target)) {
+        if (this._ignoreElements !== null && this._ignoreElements().includes(e.target)) {
             this._scanTimerClear();
         }
     }

--- a/ext/mixed/js/text-scanner.js
+++ b/ext/mixed/js/text-scanner.js
@@ -29,7 +29,8 @@ class TextScanner extends EventDispatcher {
         ignorePoint=null,
         searchTerms=false,
         searchKanji=false,
-        searchOnClick=false
+        searchOnClick=false,
+        searchOnClickOnly=false
     }) {
         super();
         this._node = node;
@@ -40,6 +41,7 @@ class TextScanner extends EventDispatcher {
         this._searchTerms = searchTerms;
         this._searchKanji = searchKanji;
         this._searchOnClick = searchOnClick;
+        this._searchOnClickOnly = searchOnClickOnly;
 
         this._isPrepared = false;
         this._ignoreNodes = null;
@@ -622,7 +624,9 @@ class TextScanner extends EventDispatcher {
 
     _hookEvents() {
         let eventListenerInfos;
-        if (this._arePointerEventsSupported()) {
+        if (this._searchOnClickOnly) {
+            eventListenerInfos = this._getMouseClickOnlyEventListeners();
+        } else if (this._arePointerEventsSupported()) {
             eventListenerInfos = this._getPointerEventListeners();
         } else {
             eventListenerInfos = this._getMouseEventListeners();
@@ -661,6 +665,11 @@ class TextScanner extends EventDispatcher {
         ];
     }
 
+    _getMouseClickOnlyEventListeners() {
+        return [
+            [this._node, 'click', this._onClick.bind(this)]
+        ];
+    }
     _getTouchEventListeners() {
         return [
             [this._node, 'auxclick', this._onAuxClick.bind(this)],


### PR DESCRIPTION
* Fixed an issue where scanning selector blacklist would affect webpages rather than Yomichan pages.
* Fixed a title issue (again).
* Fixed an error caused when options weren't assigned yet.
* Fixed some duplicate searches occurring on the search page when changing settings.
* Updated popup content searching using the mouse click to use TextScanner, for improved code re-use.