### PR TITLE
Fix outer CSS being incorrectly injected

### DIFF
--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -105,8 +105,8 @@ class PopupPreviewFrame {
         return options;
     }
 
-    _onCustomOuterCssChanged({node}) {
-        if (node === null) { return; }
+    _onCustomOuterCssChanged({node, inShadow}) {
+        if (node === null || inShadow) { return; }
 
         const node2 = document.querySelector('#popup-outer-css');
         if (node2 === null) { return; }

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -195,12 +195,13 @@ class Popup extends EventDispatcher {
 
     async setCustomOuterCss(css, useWebExtensionApi) {
         let parentNode = null;
-        if (this._shadow !== null) {
+        const inShadow = (this._shadow !== null);
+        if (inShadow) {
             useWebExtensionApi = false;
             parentNode = this._shadow;
         }
         const node = await dynamicLoader.loadStyle('yomichan-popup-outer-user-stylesheet', 'code', css, useWebExtensionApi, parentNode);
-        this.trigger('customOuterCssChanged', {node, useWebExtensionApi});
+        this.trigger('customOuterCssChanged', {node, useWebExtensionApi, inShadow});
     }
 
     getFrameRect() {


### PR DESCRIPTION
`<style>` node does not need to be moved if it is inside a shadow DOM.