### PR TITLE
Fix storage stats update error during dictionary deletion

### DIFF
--- a/ext/bg/js/settings/dictionary-controller.js
+++ b/ext/bg/js/settings/dictionary-controller.js
@@ -184,7 +184,7 @@ class DictionaryEntry {
 }
 
 class DictionaryController {
-    constructor(settingsController, modalController, storageController, statusFooter=null) {
+    constructor(settingsController, modalController, storageController, statusFooter) {
         this._settingsController = settingsController;
         this._modalController = modalController;
         this._storageController = storageController;

--- a/ext/bg/js/settings/dictionary-import-controller.js
+++ b/ext/bg/js/settings/dictionary-import-controller.js
@@ -23,7 +23,7 @@
  */
 
 class DictionaryImportController {
-    constructor(settingsController, modalController, storageController, statusFooter=null) {
+    constructor(settingsController, modalController, storageController, statusFooter) {
         this._settingsController = settingsController;
         this._modalController = modalController;
         this._storageController = storageController;

--- a/ext/bg/js/settings/main.js
+++ b/ext/bg/js/settings/main.js
@@ -83,10 +83,10 @@ async function setupEnvironmentInfo() {
         const profileController = new ProfileController(settingsController, modalController);
         profileController.prepare();
 
-        const dictionaryController = new DictionaryController(settingsController, modalController, storageController);
+        const dictionaryController = new DictionaryController(settingsController, modalController, storageController, null);
         dictionaryController.prepare();
 
-        const dictionaryImportController = new DictionaryImportController(settingsController, modalController, storageController);
+        const dictionaryImportController = new DictionaryImportController(settingsController, modalController, storageController, null);
         dictionaryImportController.prepare();
 
         const ankiController = new AnkiController(settingsController);

--- a/ext/bg/js/settings2/settings-main.js
+++ b/ext/bg/js/settings2/settings-main.js
@@ -74,7 +74,7 @@ async function setupGenericSettingsController(genericSettingController) {
         const storageController = new StorageController();
         storageController.prepare();
 
-        const dictionaryController = new DictionaryController(settingsController, modalController, statusFooter);
+        const dictionaryController = new DictionaryController(settingsController, modalController, storageController, statusFooter);
         dictionaryController.prepare();
 
         const dictionaryImportController = new DictionaryImportController(settingsController, modalController, storageController, statusFooter);


### PR DESCRIPTION
`DictionaryController` was missing the `storageController` constructor argument.