### PR TITLE
Build exclude files

### DIFF
--- a/dev/build.js
+++ b/dev/build.js
@@ -28,6 +28,7 @@ function clone(value) {
 }
 
 async function createZip(directory, excludeFiles, outputFileName, sevenZipExes=[], onUpdate=null) {
+    fs.unlinkSync(outputFileName);
     for (const exe of sevenZipExes) {
         try {
             const excludeArguments = excludeFiles.map((excludeFilePath) => `-x!${excludeFilePath}`);

--- a/dev/build.js
+++ b/dev/build.js
@@ -27,15 +27,17 @@ function clone(value) {
     return JSON.parse(JSON.stringify(value));
 }
 
-async function createZip(directory, outputFileName, sevenZipExes=[], onUpdate=null) {
+async function createZip(directory, excludeFiles, outputFileName, sevenZipExes=[], onUpdate=null) {
     for (const exe of sevenZipExes) {
         try {
+            const excludeArguments = excludeFiles.map((excludeFilePath) => `-x!${excludeFilePath}`);
             childProcess.execFileSync(
                 exe,
                 [
                     'a',
                     outputFileName,
-                    '.'
+                    '.',
+                    ...excludeArguments
                 ],
                 {
                     cwd: directory
@@ -46,12 +48,13 @@ async function createZip(directory, outputFileName, sevenZipExes=[], onUpdate=nu
             // NOP
         }
     }
-    return await createJSZip(directory, outputFileName, onUpdate);
+    return await createJSZip(directory, excludeFiles, outputFileName, onUpdate);
 }
 
-async function createJSZip(directory, outputFileName, onUpdate) {
+async function createJSZip(directory, excludeFiles, outputFileName, onUpdate) {
     const JSZip = util.JSZip;
     const files = getAllFiles(directory, directory);
+    removeItemsFromArray(files, excludeFiles);
     const zip = new JSZip();
     for (const fileName of files) {
         zip.file(
@@ -73,6 +76,27 @@ async function createJSZip(directory, outputFileName, onUpdate) {
     process.stdout.write('\n');
 
     fs.writeFileSync(outputFileName, data, {encoding: null, flag: 'w'});
+}
+
+function removeItemsFromArray(array, removeItems) {
+    for (const item of removeItems) {
+        const index = getIndexOfFilePath(array, item);
+        if (index >= 0) {
+            array.splice(index, 1);
+        }
+    }
+}
+
+function getIndexOfFilePath(array, item) {
+    const pattern = /\\/g;
+    const separator = '/';
+    item = item.replace(pattern, separator);
+    for (let i = 0, ii = array.length; i < ii; ++i) {
+        if (array[i].replace(pattern, separator) === item) {
+            return i;
+        }
+    }
+    return -1;
 }
 
 function applyModifications(manifest, modifications) {
@@ -271,6 +295,9 @@ async function build(manifest, buildDir, extDir, manifestPath, variantMap, varia
         if (typeof variant === 'undefined') { continue; }
 
         const {name, fileName, fileCopies} = variant;
+        let {excludeFiles} = variant;
+        if (!Array.isArray(excludeFiles)) { excludeFiles = []; }
+
         process.stdout.write(`Building ${name}...\n`);
 
         const modifiedManifest = createVariantManifest(manifest, variant, variantMap);
@@ -278,7 +305,7 @@ async function build(manifest, buildDir, extDir, manifestPath, variantMap, varia
         const fileNameSafe = path.basename(fileName);
         const fullFileName = path.join(buildDir, fileNameSafe);
         fs.writeFileSync(manifestPath, createManifestString(modifiedManifest));
-        await createZip(extDir, fullFileName, sevenZipExes, onUpdate);
+        await createZip(extDir, excludeFiles, fullFileName, sevenZipExes, onUpdate);
 
         if (Array.isArray(fileCopies)) {
             for (const fileName2 of fileCopies) {

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -108,7 +108,10 @@
     "variants": [
         {
             "name": "chrome",
-            "fileName": "yomichan-chrome.zip"
+            "fileName": "yomichan-chrome.zip",
+            "excludeFiles": [
+                "sw.js"
+            ]
         },
         {
             "name": "chrome-dev",
@@ -128,6 +131,9 @@
                     "patternFlags": "",
                     "replacement": "$1. This is a development build; get the stable version here: https://tinyurl.com/yaatdjmp"
                 }
+            ],
+            "excludeFiles": [
+                "sw.js"
             ]
         },
         {
@@ -179,6 +185,9 @@
                         }
                     }
                 }
+            ],
+            "excludeFiles": [
+                "sw.js"
             ]
         },
         {
@@ -205,6 +214,9 @@
                     "path": ["browser_specific_settings", "gecko", "id"],
                     "value": "alex.testing@foosoft.net"
                 }
+            ],
+            "excludeFiles": [
+                "sw.js"
             ]
         }
     ]


### PR DESCRIPTION
Allows sw.js to be excluded from non-MV3 builds, among other files in the future.