### PR TITLE
Fix invalid CSS :not selector causing frequency tags to display twice

### DIFF
--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -1291,7 +1291,7 @@ button.action-button {
     display: inline;
     color: var(--light-text-color);
 }
-:root[data-glossary-layout-mode=compact] .entry:not([data-type=term][data-expression-multi=true]) .term-special-tags {
+:root[data-glossary-layout-mode=compact] .entry:not([data-expression-multi=true]) .term-special-tags {
     display: none;
 }
 :root[data-glossary-layout-mode=compact] .term-expression-details>.frequencies {


### PR DESCRIPTION
This selector appears to work in Chrome dev 89 and Firefox 84, but not in Chrome 87, hence why it was not initially detected.

Fixes #1130.