### PR TITLE
Focus the current entry earlier in the generation process

### DIFF
--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -879,6 +879,7 @@ class Display extends EventDispatcher {
         }
 
         let {sentence=null, optionsContext=null, focusEntry=null, scrollX=null, scrollY=null} = state;
+        if (typeof focusEntry !== 'number') { focusEntry = 0; }
         if (!(typeof optionsContext === 'object' && optionsContext !== null)) {
             optionsContext = this.getOptionsContext();
             state.optionsContext = optionsContext;
@@ -943,9 +944,11 @@ class Display extends EventDispatcher {
             entry.dataset.index = `${i}`;
             this._addEntryEventListeners(entry);
             container.appendChild(entry);
+            if (focusEntry === i) {
+                this._focusEntry(i, false);
+            }
         }
 
-        this._focusEntry(typeof focusEntry === 'number' ? focusEntry : 0, false);
         if (typeof scrollX === 'number' || typeof scrollY === 'number') {
             let {x, y} = this._windowScroll;
             if (typeof scrollX === 'number') { x = scrollX; }


### PR DESCRIPTION
Fixes an issue mentioned in #1079:

> I think it catches the eye too much (whether it be the color or the "spread" animation when the popup displays).

> I also noticed that the blue bar indicating that the first entry is selected does some kind of "fade in" effect when first opening the popover, which is contributing to it being distracting.