### PR TITLE
Update termTags for termGrouped mode to include all definition tags

### DIFF
--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -7957,6 +7957,24 @@
                                         "score": 0,
                                         "dictionary": "Test Dictionary 2",
                                         "redundant": false
+                                    },
+                                    {
+                                        "name": "tag6",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag7",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
                                     }
                                 ],
                                 "termFrequency": "normal",
@@ -8034,6 +8052,24 @@
                                 "name": "tag5",
                                 "category": "category5",
                                 "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag6",
+                                "category": "default",
+                                "notes": "",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag7",
+                                "category": "default",
+                                "notes": "",
                                 "order": 0,
                                 "score": 0,
                                 "dictionary": "Test Dictionary 2",


### PR DESCRIPTION
Fixes part 2 of #1130:

> I don't know if this is a bug or not (or if it's even new), but it seems tags don't show up unless they are in the top dictionary entry.