### PR TITLE
Improve the accent color for the dark theme

### DIFF
--- a/ext/mixed/css/display.css
+++ b/ext/mixed/css/display.css
@@ -141,7 +141,7 @@
     /* Colors */
     --background-color: #1e1e1e;
     --glossary-image-background-color: #2f2f2f;
-    --accent-color: #0275d8;
+    --accent-color: #4eacfd;
     --link-color: var(--accent-color);
 
     --default-text-color: #d4d4d4;


### PR DESCRIPTION
Addressing an issue mentioned in #1131:

> Is there an option to change the color/colour of the "popular terms" (P)? The blue on dark is a little difficult to see.