### PR TITLE
Fix description of scanning.autoHideResults setting

### DIFF
--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -894,7 +894,7 @@
             <div class="settings-item-inner">
                 <div class="settings-item-left">
                     <div class="settings-item-label">Auto-hide search popup</div>
-                    <div class="settings-item-description">When no key or button is required for scanning, the popup will hide automatically.</div>
+                    <div class="settings-item-description">When no text or definitions are found, the popup will automatically hide.</div>
                 </div>
                 <div class="settings-item-right">
                     <label class="toggle"><input type="checkbox" data-setting="scanning.autoHideResults" data-transform="setVisibility" data-ancestor-distance="-1" data-relative-selector="#auto-hide-search-popup-options" data-visbility-condition='{"op":"===","value":true}'><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>

--- a/ext/bg/welcome.html
+++ b/ext/bg/welcome.html
@@ -128,7 +128,7 @@
             <div class="settings-item-inner">
                 <div class="settings-item-left">
                     <div class="settings-item-label">Auto-hide search popup</div>
-                    <div class="settings-item-description">When no key or button is required for scanning, the popup will hide automatically.</div>
+                    <div class="settings-item-description">When no text or definitions are found, the popup will automatically hide.</div>
                 </div>
                 <div class="settings-item-right">
                     <label class="toggle"><input type="checkbox" data-setting="scanning.autoHideResults" data-transform="setVisibility" data-ancestor-distance="-1" data-relative-selector="#auto-hide-search-popup-options" data-visbility-condition='{"op":"===","value":true}'><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>


### PR DESCRIPTION
This option should apply even when modifier keys are in use.