### PR TITLE
Fix Display._definitionTextScanner not ignoring certain elements

### DIFF
--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1772,6 +1772,8 @@ class Display extends EventDispatcher {
                 searchOnClick: true,
                 searchOnClickOnly: true
             });
+            const excludeSelectors = ['.scan-disable', '.scan-disable *'];
+            this._definitionTextScanner.excludeSelector = excludeSelectors.join(',');
             this._definitionTextScanner.prepare();
             this._definitionTextScanner.on('searched', this._onDefinitionTextScannerSearched.bind(this));
         }


### PR DESCRIPTION
Issue was causing this scanner to not ignore the query parser, which would result in the query parser being overwritten.

Fixes #1152.