### PR TITLE
Fix missing data-setting target for scanning.enablePopupSearch

### DIFF
--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -326,7 +326,7 @@
                 <div class="settings-item-label">Search terms when clicking text from the results list</div>
             </div>
             <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                <label class="toggle"><input type="checkbox" data-setting="scanning.enablePopupSearch"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <div class="settings-item advanced-only">


### PR DESCRIPTION
Fixes another issue mentioned in #1152.