### PR TITLE
Furigana distribution improvements

### DIFF
--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -418,32 +418,34 @@ const JapaneseUtil = (() => {
                 if (isKana) {
                     if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(text))) {
                         const readingLeft = reading2.substring(text.length);
-                        const segs = segmentize(readingLeft, groups.splice(1));
-                        if (segs !== null) {
+                        const segments = segmentize(readingLeft, groups.splice(1));
+                        if (segments !== null) {
                             const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, text.length);
-                            return [this._createFuriganaSegment(text, furigana)].concat(segs);
+                            segments.unshift(this._createFuriganaSegment(text, furigana));
+                            return segments;
                         }
                     }
                     return null;
                 } else {
-                    let foundSegments = null;
+                    let result = null;
                     for (let i = reading2.length; i >= text.length; --i) {
                         const readingUsed = reading2.substring(0, i);
                         const readingLeft = reading2.substring(i);
-                        const segs = segmentize(readingLeft, groups.slice(1));
-                        if (segs !== null) {
-                            if (foundSegments !== null) {
+                        const segments = segmentize(readingLeft, groups.slice(1));
+                        if (segments !== null) {
+                            if (result !== null) {
                                 // more than one way to segmentize the tail, mark as ambiguous
                                 return null;
                             }
-                            foundSegments = [this._createFuriganaSegment(text, readingUsed)].concat(segs);
+                            segments.unshift(this._createFuriganaSegment(text, readingUsed));
+                            result = segments;
                         }
                         // there is only one way to segmentize the last non-kana group
                         if (groups.length === 1) {
                             break;
                         }
                     }
-                    return foundSegments;
+                    return result;
                 }
             };
 

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -414,20 +414,20 @@ const JapaneseUtil = (() => {
                     return [];
                 }
 
-                const group = groups[0];
-                if (group.isKana) {
-                    if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(group.text))) {
-                        const readingLeft = reading2.substring(group.text.length);
+                const {isKana, text} = groups[0];
+                if (isKana) {
+                    if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(text))) {
+                        const readingLeft = reading2.substring(text.length);
                         const segs = segmentize(readingLeft, groups.splice(1));
                         if (segs !== null) {
-                            const furigana = reading2.startsWith(group.text) ? '' : reading2.substring(0, group.text.length);
-                            return [{text: group.text, furigana}].concat(segs);
+                            const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, text.length);
+                            return [{text, furigana}].concat(segs);
                         }
                     }
                     return null;
                 } else {
                     let foundSegments = null;
-                    for (let i = reading2.length; i >= group.text.length; --i) {
+                    for (let i = reading2.length; i >= text.length; --i) {
                         const readingUsed = reading2.substring(0, i);
                         const readingLeft = reading2.substring(i);
                         const segs = segmentize(readingLeft, groups.slice(1));
@@ -436,7 +436,7 @@ const JapaneseUtil = (() => {
                                 // more than one way to segmentize the tail, mark as ambiguous
                                 return null;
                             }
-                            foundSegments = [{text: group.text, furigana: readingUsed}].concat(segs);
+                            foundSegments = [{text, furigana: readingUsed}].concat(segs);
                         }
                         // there is only one way to segmentize the last non-kana group
                         if (groups.length === 1) {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -409,9 +409,8 @@ const JapaneseUtil = (() => {
                 return [{furigana: '', text: expression}];
             }
 
-            let isAmbiguous = false;
             const segmentize = (reading2, groups) => {
-                if (groups.length === 0 || isAmbiguous) {
+                if (groups.length === 0) {
                     return [];
                 }
 
@@ -435,7 +434,6 @@ const JapaneseUtil = (() => {
                         if (segs !== null) {
                             if (foundSegments !== null) {
                                 // more than one way to segmentize the tail, mark as ambiguous
-                                isAmbiguous = true;
                                 return null;
                             }
                             foundSegments = [{text: group.text, furigana: readingUsed}].concat(segs);
@@ -465,7 +463,7 @@ const JapaneseUtil = (() => {
             }
 
             const segments = segmentize(reading, groups);
-            if (segments !== null && !isAmbiguous) {
+            if (segments !== null) {
                 return segments;
             }
 

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -410,7 +410,8 @@ const JapaneseUtil = (() => {
             }
 
             const segmentize = (reading2, groups) => {
-                if (groups.length === 0) {
+                const groupCount = groups.length;
+                if (groupCount === 0) {
                     return [];
                 }
 
@@ -441,7 +442,7 @@ const JapaneseUtil = (() => {
                             result = segments;
                         }
                         // there is only one way to segmentize the last non-kana group
-                        if (groups.length === 1) {
+                        if (groupCount === 1) {
                             break;
                         }
                     }

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -416,7 +416,7 @@ const JapaneseUtil = (() => {
                 }
 
                 const group = groups[0];
-                if (group.mode === 'kana') {
+                if (group.isKana) {
                     if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(group.text))) {
                         const readingLeft = reading2.substring(group.text.length);
                         const segs = segmentize(readingLeft, groups.splice(1));
@@ -449,15 +449,17 @@ const JapaneseUtil = (() => {
             };
 
             const groups = [];
-            let modePrev = null;
+            let groupPre = null;
+            let isKanaPre = null;
             for (const c of expression) {
                 const codePoint = c.codePointAt(0);
-                const modeCurr = this.isCodePointKanji(codePoint) || codePoint === ITERATION_MARK_CODE_POINT ? 'kanji' : 'kana';
-                if (modeCurr === modePrev) {
-                    groups[groups.length - 1].text += c;
+                const isKana = !(this.isCodePointKanji(codePoint) || codePoint === ITERATION_MARK_CODE_POINT);
+                if (isKana === isKanaPre) {
+                    groupPre.text += c;
                 } else {
-                    groups.push({mode: modeCurr, text: c});
-                    modePrev = modeCurr;
+                    groupPre = {isKana, text: c};
+                    groups.push(groupPre);
+                    isKanaPre = isKana;
                 }
             }
 

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -417,17 +417,18 @@ const JapaneseUtil = (() => {
 
                 const group = groups[groupsStart];
                 const {isKana, text} = group;
+                const textLength = text.length;
                 if (isKana) {
                     const {textNormalized} = group;
                     if (reading2Normalized.startsWith(textNormalized)) {
                         const segments = segmentize(
-                            reading2.substring(text.length),
-                            reading2Normalized.substring(text.length),
+                            reading2.substring(textLength),
+                            reading2Normalized.substring(textLength),
                             groups,
                             groupsStart + 1
                         );
                         if (segments !== null) {
-                            const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, text.length);
+                            const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, textLength);
                             segments.unshift(this._createFuriganaSegment(text, furigana));
                             return segments;
                         }
@@ -435,7 +436,7 @@ const JapaneseUtil = (() => {
                     return null;
                 } else {
                     let result = null;
-                    for (let i = reading2.length; i >= text.length; --i) {
+                    for (let i = reading2.length; i >= textLength; --i) {
                         const readingUsed = reading2.substring(0, i);
                         const segments = segmentize(
                             reading2.substring(i),

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -421,7 +421,8 @@ const JapaneseUtil = (() => {
                         const readingLeft = reading2.substring(group.text.length);
                         const segs = segmentize(readingLeft, groups.splice(1));
                         if (segs) {
-                            return [{text: group.text, furigana: ''}].concat(segs);
+                            const furigana = reading2.startsWith(group.text) ? '' : reading2.substring(0, group.text.length);
+                            return [{text: group.text, furigana}].concat(segs);
                         }
                     }
                 } else {

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -440,8 +440,6 @@ const JapaneseUtil = (() => {
         }
 
         distributeFuriganaInflected(expression, reading, source) {
-            const output = [];
-
             let stemLength = 0;
             const shortest = Math.min(source.length, expression.length);
             const sourceHiragana = this.convertKatakanaToHiragana(source);
@@ -456,15 +454,13 @@ const JapaneseUtil = (() => {
                 0,
                 offset === 0 ? reading.length : reading.length - expression.length + stemLength
             );
-            for (const segment of this.distributeFurigana(stemExpression, stemReading)) {
-                output.push(segment);
-            }
+            const result = this.distributeFurigana(stemExpression, stemReading);
 
             if (stemLength !== source.length) {
-                output.push(this._createFuriganaSegment(source.substring(stemLength), ''));
+                result.push(this._createFuriganaSegment(source.substring(stemLength), ''));
             }
 
-            return output;
+            return result;
         }
 
         // Miscellaneous

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -461,7 +461,7 @@ const JapaneseUtil = (() => {
             }
 
             if (stemLength !== source.length) {
-                output.push({text: source.substring(stemLength), furigana: ''});
+                output.push(this._createFuriganaSegment(source.substring(stemLength), ''));
             }
 
             return output;

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -437,7 +437,6 @@ const JapaneseUtil = (() => {
                 } else {
                     let result = null;
                     for (let i = reading2.length; i >= textLength; --i) {
-                        const readingUsed = reading2.substring(0, i);
                         const segments = segmentize(
                             reading2.substring(i),
                             reading2Normalized.substring(i),
@@ -449,7 +448,7 @@ const JapaneseUtil = (() => {
                                 // more than one way to segmentize the tail, mark as ambiguous
                                 return null;
                             }
-                            segments.unshift(this._createFuriganaSegment(text, readingUsed));
+                            segments.unshift(this._createFuriganaSegment(text, reading2.substring(0, i)));
                             result = segments;
                         }
                         // there is only one way to segmentize the last non-kana group

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -406,7 +406,7 @@ const JapaneseUtil = (() => {
         distributeFurigana(expression, reading) {
             if (!reading || reading === expression) {
                 // Same
-                return [{furigana: '', text: expression}];
+                return [this._createFuriganaSegment(expression, '')];
             }
 
             const segmentize = (reading2, groups) => {
@@ -421,7 +421,7 @@ const JapaneseUtil = (() => {
                         const segs = segmentize(readingLeft, groups.splice(1));
                         if (segs !== null) {
                             const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, text.length);
-                            return [{text, furigana}].concat(segs);
+                            return [this._createFuriganaSegment(text, furigana)].concat(segs);
                         }
                     }
                     return null;
@@ -436,7 +436,7 @@ const JapaneseUtil = (() => {
                                 // more than one way to segmentize the tail, mark as ambiguous
                                 return null;
                             }
-                            foundSegments = [{text, furigana: readingUsed}].concat(segs);
+                            foundSegments = [this._createFuriganaSegment(text, readingUsed)].concat(segs);
                         }
                         // there is only one way to segmentize the last non-kana group
                         if (groups.length === 1) {
@@ -468,7 +468,7 @@ const JapaneseUtil = (() => {
             }
 
             // Fallback
-            return [{furigana: reading, text: expression}];
+            return [this._createFuriganaSegment(expression, reading)];
         }
 
         distributeFuriganaInflected(expression, reading, source) {
@@ -533,6 +533,10 @@ const JapaneseUtil = (() => {
         }
 
         // Private
+
+        _createFuriganaSegment(text, furigana) {
+            return {text, furigana};
+        }
 
         _getWanakana() {
             const wanakana = this._wanakana;

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -420,18 +420,19 @@ const JapaneseUtil = (() => {
                     if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(group.text))) {
                         const readingLeft = reading2.substring(group.text.length);
                         const segs = segmentize(readingLeft, groups.splice(1));
-                        if (segs) {
+                        if (segs !== null) {
                             const furigana = reading2.startsWith(group.text) ? '' : reading2.substring(0, group.text.length);
                             return [{text: group.text, furigana}].concat(segs);
                         }
                     }
+                    return null;
                 } else {
                     let foundSegments = null;
                     for (let i = reading2.length; i >= group.text.length; --i) {
                         const readingUsed = reading2.substring(0, i);
                         const readingLeft = reading2.substring(i);
                         const segs = segmentize(readingLeft, groups.slice(1));
-                        if (segs) {
+                        if (segs !== null) {
                             if (foundSegments !== null) {
                                 // more than one way to segmentize the tail, mark as ambiguous
                                 isAmbiguous = true;
@@ -464,7 +465,7 @@ const JapaneseUtil = (() => {
             }
 
             const segments = segmentize(reading, groups);
-            if (segments && !isAmbiguous) {
+            if (segments !== null && !isAmbiguous) {
                 return segments;
             }
 

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -545,7 +545,8 @@ const JapaneseUtil = (() => {
                             // More than one way to segmentize the tail; mark as ambiguous
                             return null;
                         }
-                        segments.unshift(this._createFuriganaSegment(text, reading.substring(0, i)));
+                        const furigana = reading.substring(0, i);
+                        segments.unshift(this._createFuriganaSegment(text, furigana));
                         result = segments;
                     }
                     // There is only one way to segmentize the last non-kana group

--- a/ext/mixed/js/japanese.js
+++ b/ext/mixed/js/japanese.js
@@ -409,17 +409,17 @@ const JapaneseUtil = (() => {
                 return [this._createFuriganaSegment(expression, '')];
             }
 
-            const segmentize = (reading2, groups) => {
-                const groupCount = groups.length;
-                if (groupCount === 0) {
+            const segmentize = (reading2, groups, groupsStart) => {
+                const groupCount = groups.length - groupsStart;
+                if (groupCount <= 0) {
                     return [];
                 }
 
-                const {isKana, text} = groups[0];
+                const {isKana, text} = groups[groupsStart];
                 if (isKana) {
                     if (this.convertKatakanaToHiragana(reading2).startsWith(this.convertKatakanaToHiragana(text))) {
                         const readingLeft = reading2.substring(text.length);
-                        const segments = segmentize(readingLeft, groups.splice(1));
+                        const segments = segmentize(readingLeft, groups, groupsStart + 1);
                         if (segments !== null) {
                             const furigana = reading2.startsWith(text) ? '' : reading2.substring(0, text.length);
                             segments.unshift(this._createFuriganaSegment(text, furigana));
@@ -432,7 +432,7 @@ const JapaneseUtil = (() => {
                     for (let i = reading2.length; i >= text.length; --i) {
                         const readingUsed = reading2.substring(0, i);
                         const readingLeft = reading2.substring(i);
-                        const segments = segmentize(readingLeft, groups.slice(1));
+                        const segments = segmentize(readingLeft, groups, groupsStart + 1);
                         if (segments !== null) {
                             if (result !== null) {
                                 // more than one way to segmentize the tail, mark as ambiguous
@@ -465,7 +465,7 @@ const JapaneseUtil = (() => {
                 }
             }
 
-            const segments = segmentize(reading, groups);
+            const segments = segmentize(reading, groups, 0);
             if (segments !== null) {
                 return segments;
             }

--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -353,6 +353,22 @@ function testDistributeFurigana() {
             [
                 {text: 'かいぬ', furigana: ''}
             ]
+        ],
+        // Mismatched kana readings
+        [
+            ['有り難う', 'アリガトウ'],
+            [
+                {text: '有', furigana: 'ア'},
+                {text: 'り', furigana: 'リ'},
+                {text: '難', furigana: 'ガト'},
+                {text: 'う', furigana: 'ウ'}
+            ]
+        ],
+        [
+            ['ありがとう', 'アリガトウ'],
+            [
+                {text: 'ありがとう', furigana: 'アリガトウ'}
+            ]
         ]
     ];
 

--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -354,6 +354,19 @@ function testDistributeFurigana() {
                 {text: 'かいぬ', furigana: ''}
             ]
         ],
+        // Misc
+        [
+            ['月', 'か'],
+            [
+                {text: '月', furigana: 'か'}
+            ]
+        ],
+        [
+            ['月', 'カ'],
+            [
+                {text: '月', furigana: 'カ'}
+            ]
+        ],
         // Mismatched kana readings
         [
             ['有り難う', 'アリガトウ'],
@@ -368,6 +381,318 @@ function testDistributeFurigana() {
             ['ありがとう', 'アリガトウ'],
             [
                 {text: 'ありがとう', furigana: 'アリガトウ'}
+            ]
+        ],
+        // Mismatched kana readings (real examples)
+        [
+            ['カ月', 'かげつ'],
+            [
+                {text: 'カ', furigana: 'か'},
+                {text: '月', furigana: 'げつ'}
+            ]
+        ],
+        [
+            ['序ノ口', 'じょのくち'],
+            [
+                {text: '序', furigana: 'じょ'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '口', furigana: 'くち'}
+            ]
+        ],
+        [
+            ['スズメの涙', 'すずめのなみだ'],
+            [
+                {text: 'スズメの', furigana: 'すずめの'},
+                {text: '涙', furigana: 'なみだ'}
+            ]
+        ],
+        [
+            ['二カ所', 'にかしょ'],
+            [
+                {text: '二', furigana: 'に'},
+                {text: 'カ', furigana: 'か'},
+                {text: '所', furigana: 'しょ'}
+            ]
+        ],
+        [
+            ['八ツ橋', 'やつはし'],
+            [
+                {text: '八', furigana: 'や'},
+                {text: 'ツ', furigana: 'つ'},
+                {text: '橋', furigana: 'はし'}
+            ]
+        ],
+        [
+            ['八ツ橋', 'やつはし'],
+            [
+                {text: '八', furigana: 'や'},
+                {text: 'ツ', furigana: 'つ'},
+                {text: '橋', furigana: 'はし'}
+            ]
+        ],
+        [
+            ['一カ月', 'いっかげつ'],
+            [
+                {text: '一', furigana: 'いっ'},
+                {text: 'カ', furigana: 'か'},
+                {text: '月', furigana: 'げつ'}
+            ]
+        ],
+        [
+            ['一カ所', 'いっかしょ'],
+            [
+                {text: '一', furigana: 'いっ'},
+                {text: 'カ', furigana: 'か'},
+                {text: '所', furigana: 'しょ'}
+            ]
+        ],
+        [
+            ['カ所', 'かしょ'],
+            [
+                {text: 'カ', furigana: 'か'},
+                {text: '所', furigana: 'しょ'}
+            ]
+        ],
+        [
+            ['数カ月', 'すうかげつ'],
+            [
+                {text: '数', furigana: 'すう'},
+                {text: 'カ', furigana: 'か'},
+                {text: '月', furigana: 'げつ'}
+            ]
+        ],
+        [
+            ['くノ一', 'くのいち'],
+            [
+                {text: 'くノ', furigana: 'くの'},
+                {text: '一', furigana: 'いち'}
+            ]
+        ],
+        [
+            ['くノ一', 'くのいち'],
+            [
+                {text: 'くノ', furigana: 'くの'},
+                {text: '一', furigana: 'いち'}
+            ]
+        ],
+        [
+            ['数カ国', 'すうかこく'],
+            [
+                {text: '数', furigana: 'すう'},
+                {text: 'カ', furigana: 'か'},
+                {text: '国', furigana: 'こく'}
+            ]
+        ],
+        [
+            ['数カ所', 'すうかしょ'],
+            [
+                {text: '数', furigana: 'すう'},
+                {text: 'カ', furigana: 'か'},
+                {text: '所', furigana: 'しょ'}
+            ]
+        ],
+        [
+            ['壇ノ浦の戦い', 'だんのうらのたたかい'],
+            [
+                {text: '壇', furigana: 'だん'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '浦', furigana: 'うら'},
+                {text: 'の', furigana: ''},
+                {text: '戦', furigana: 'たたか'},
+                {text: 'い', furigana: ''}
+            ]
+        ],
+        [
+            ['壇ノ浦の戦', 'だんのうらのたたかい'],
+            [
+                {text: '壇', furigana: 'だん'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '浦', furigana: 'うら'},
+                {text: 'の', furigana: ''},
+                {text: '戦', furigana: 'たたかい'}
+            ]
+        ],
+        [
+            ['序ノ口格', 'じょのくちかく'],
+            [
+                {text: '序', furigana: 'じょ'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '口格', furigana: 'くちかく'}
+            ]
+        ],
+        [
+            ['二カ国語', 'にかこくご'],
+            [
+                {text: '二', furigana: 'に'},
+                {text: 'カ', furigana: 'か'},
+                {text: '国語', furigana: 'こくご'}
+            ]
+        ],
+        [
+            ['カ国', 'かこく'],
+            [
+                {text: 'カ', furigana: 'か'},
+                {text: '国', furigana: 'こく'}
+            ]
+        ],
+        [
+            ['カ国語', 'かこくご'],
+            [
+                {text: 'カ', furigana: 'か'},
+                {text: '国語', furigana: 'こくご'}
+            ]
+        ],
+        [
+            ['壇ノ浦の合戦', 'だんのうらのかっせん'],
+            [
+                {text: '壇', furigana: 'だん'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '浦', furigana: 'うら'},
+                {text: 'の', furigana: ''},
+                {text: '合戦', furigana: 'かっせん'}
+            ]
+        ],
+        [
+            ['一タ偏', 'いちたへん'],
+            [
+                {text: '一', furigana: 'いち'},
+                {text: 'タ', furigana: 'た'},
+                {text: '偏', furigana: 'へん'}
+            ]
+        ],
+        [
+            ['ル又', 'るまた'],
+            [
+                {text: 'ル', furigana: 'る'},
+                {text: '又', furigana: 'また'}
+            ]
+        ],
+        [
+            ['ノ木偏', 'のぎへん'],
+            [
+                {text: 'ノ', furigana: 'の'},
+                {text: '木偏', furigana: 'ぎへん'}
+            ]
+        ],
+        [
+            ['一ノ貝', 'いちのかい'],
+            [
+                {text: '一', furigana: 'いち'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '貝', furigana: 'かい'}
+            ]
+        ],
+        [
+            ['虎ノ門事件', 'とらのもんじけん'],
+            [
+                {text: '虎', furigana: 'とら'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '門事件', furigana: 'もんじけん'}
+            ]
+        ],
+        [
+            ['教育ニ関スル勅語', 'きょういくにかんするちょくご'],
+            [
+                {text: '教育', furigana: 'きょういく'},
+                {text: 'ニ', furigana: 'に'},
+                {text: '関', furigana: 'かん'},
+                {text: 'スル', furigana: 'する'},
+                {text: '勅語', furigana: 'ちょくご'}
+            ]
+        ],
+        [
+            ['二カ年', 'にかねん'],
+            [
+                {text: '二', furigana: 'に'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['三カ年', 'さんかねん'],
+            [
+                {text: '三', furigana: 'さん'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['四カ年', 'よんかねん'],
+            [
+                {text: '四', furigana: 'よん'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['五カ年', 'ごかねん'],
+            [
+                {text: '五', furigana: 'ご'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['六カ年', 'ろっかねん'],
+            [
+                {text: '六', furigana: 'ろっ'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['七カ年', 'ななかねん'],
+            [
+                {text: '七', furigana: 'なな'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['八カ年', 'はちかねん'],
+            [
+                {text: '八', furigana: 'はち'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['九カ年', 'きゅうかねん'],
+            [
+                {text: '九', furigana: 'きゅう'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['十カ年', 'じゅうかねん'],
+            [
+                {text: '十', furigana: 'じゅう'},
+                {text: 'カ', furigana: 'か'},
+                {text: '年', furigana: 'ねん'}
+            ]
+        ],
+        [
+            ['鏡ノ間', 'かがみのま'],
+            [
+                {text: '鏡', furigana: 'かがみ'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '間', furigana: 'ま'}
+            ]
+        ],
+        [
+            ['鏡ノ間', 'かがみのま'],
+            [
+                {text: '鏡', furigana: 'かがみ'},
+                {text: 'ノ', furigana: 'の'},
+                {text: '間', furigana: 'ま'}
+            ]
+        ],
+        [
+            ['ページ違反', 'ぺーじいはん'],
+            [
+                {text: 'ページ', furigana: 'ぺーじ'},
+                {text: '違反', furigana: 'いはん'}
             ]
         ]
     ];


### PR DESCRIPTION
* Improves performance by about 2x.
* Adds more tests.
* Updates furigana to be visible if the reading is different. This should be a fairly rare case. Example: <br>
  <h3><ruby>序<rt>じょ</rt></ruby><ruby>ノ<rt>の</rt></ruby><ruby>口<rt>くち</rt></ruby></h3>