### PR TITLE
Change popupCurrentIndicatorMode default to triangle

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -272,7 +272,7 @@
                                     "popupCurrentIndicatorMode": {
                                         "type": "string",
                                         "enum": ["none", "asterisk", "triangle", "bar-left", "bar-right", "dot-left", "dot-right"],
-                                        "default": "bar-left"
+                                        "default": "triangle"
                                     },
                                     "popupActionBarVisibility": {
                                         "type": "string",

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -669,7 +669,7 @@ class OptionsUtil {
         delete options.global.showPopupPreview;
         for (const profile of options.profiles) {
             profile.options.general.maximumClipboardSearchLength = 1000;
-            profile.options.general.popupCurrentIndicatorMode = 'bar-left';
+            profile.options.general.popupCurrentIndicatorMode = 'triangle';
             profile.options.general.popupActionBarVisibility = 'auto';
             profile.options.general.popupActionBarLocation = 'right';
         }

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -294,7 +294,7 @@ function createProfileOptionsUpdatedTestData1() {
             usePopupShadowDom: true,
             usePopupWindow: false,
             maximumClipboardSearchLength: 1000,
-            popupCurrentIndicatorMode: 'bar-left',
+            popupCurrentIndicatorMode: 'triangle',
             popupActionBarVisibility: 'auto',
             popupActionBarLocation: 'right'
         },


### PR DESCRIPTION
Based on feedback in #1079, the default indicator is now smaller, has a more subtle animation, and still does not affect layout when visible.