### PR TITLE
Change global.useSettingsV2 default value to true

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -838,7 +838,7 @@
                 },
                 "useSettingsV2": {
                     "type": "boolean",
-                    "default": false
+                    "default": true
                 }
             }
         }


### PR DESCRIPTION
The new default is used for new installations, but will not affect users who already have Yomichan installed.