### PR TITLE
Translator regex replacements

### DIFF
--- a/ext/bg/css/settings2.css
+++ b/ext/bg/css/settings2.css
@@ -1744,7 +1744,8 @@ code.anki-field-marker {
     grid-template-rows: auto;
     grid-template-areas:
         "index pattern-label     pattern     button"
-        ".     replacement-label replacement button";
+        ".     replacement-label replacement button"
+        ".     test-label        test        .";
     column-gap: 0.25em;
     row-gap: 0.25em;
     align-items: stretch;
@@ -1787,11 +1788,10 @@ code.anki-field-marker {
     flex-flow: row nowrap;
     align-items: stretch;
 }
-input.translation-text-replacement-pattern {
-    width: 100%;
-}
+input.translation-text-replacement-pattern,
 input.translation-text-replacement-replacement {
-    width: 100%;
+    flex: 1 1 auto;
+    width: auto;
 }
 .translation-text-replacement-checkbox-container {
     white-space: nowrap;
@@ -1807,6 +1807,36 @@ input.translation-text-replacement-replacement {
     grid-area: button;
     align-self: center;
     justify-self: start;
+}
+.translation-text-replacement-test-label {
+    grid-area: test-label;
+    align-self: center;
+    justify-self: start;
+    padding-right: 0.5em;
+}
+.translation-text-replacement-test-container {
+    grid-area: test;
+    align-self: stretch;
+    justify-self: stretch;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: stretch;
+}
+input.translation-text-replacement-test-input,
+input.translation-text-replacement-test-output {
+    flex: 1 1 auto;
+    width: auto;
+}
+.translation-text-replacement-test-label-inner {
+    grid-area: button;
+    align-self: center;
+    justify-self: start;
+    flex: 0 0 auto;
+    padding: 0 0.5em;
+    white-space: nowrap;
+}
+.translation-text-replacement-entry:not([data-test-visible=true]) .translation-text-replacement-test-node {
+    display: none;
 }
 
 

--- a/ext/bg/css/settings2.css
+++ b/ext/bg/css/settings2.css
@@ -1732,6 +1732,83 @@ code.anki-field-marker {
     height: calc(0.425em * 4 + 1em * var(--line-height-default) * 3);
 }
 
+#translation-text-replacement-list-empty {
+    display: none;
+}
+#translation-text-replacement-list:empty+#translation-text-replacement-list-empty {
+    display: block;
+}
+.translation-text-replacement-entry {
+    display: grid;
+    grid-template-columns: auto auto 1fr auto;
+    grid-template-rows: auto;
+    grid-template-areas:
+        "index pattern-label     pattern     button"
+        ".     replacement-label replacement button";
+    column-gap: 0.25em;
+    row-gap: 0.25em;
+    align-items: stretch;
+    justify-items: stretch;
+}
+.translation-text-replacement-entry+.translation-text-replacement-entry {
+    margin-top: 0.5em;
+}
+.translation-text-replacement-index {
+    grid-area: index;
+    align-self: center;
+    justify-self: start;
+    padding-right: 0.5em;
+}
+.translation-text-replacement-pattern-label {
+    grid-area: pattern-label;
+    align-self: center;
+    justify-self: start;
+    padding-right: 0.5em;
+}
+.translation-text-replacement-replacement-label {
+    grid-area: replacement-label;
+    align-self: center;
+    justify-self: start;
+    padding-right: 0.5em;
+}
+.translation-text-replacement-pattern-container {
+    grid-area: pattern;
+    align-self: stretch;
+    justify-self: stretch;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: stretch;
+}
+.translation-text-replacement-replacement-container {
+    grid-area: replacement;
+    align-self: stretch;
+    justify-self: stretch;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: stretch;
+}
+input.translation-text-replacement-pattern {
+    width: 100%;
+}
+input.translation-text-replacement-replacement {
+    width: 100%;
+}
+.translation-text-replacement-checkbox-container {
+    white-space: nowrap;
+    display: flex;
+    flex-flow: row nowrap;
+    align-items: center;
+    padding-left: 0.5em;
+}
+.translation-text-replacement-checkbox-label {
+    padding-left: 0.5em;
+}
+.translation-text-replacement-button {
+    grid-area: button;
+    align-self: center;
+    justify-self: start;
+}
+
 
 /* Generic layouts */
 .margin-above {

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -592,7 +592,8 @@
                                     "convertAlphabeticCharacters",
                                     "convertHiraganaToKatakana",
                                     "convertKatakanaToHiragana",
-                                    "collapseEmphaticSequences"
+                                    "collapseEmphaticSequences",
+                                    "textReplacements"
                                 ],
                                 "properties": {
                                     "convertHalfWidthCharacters": {
@@ -624,6 +625,46 @@
                                         "type": "string",
                                         "enum": ["false", "true", "full"],
                                         "default": "false"
+                                    },
+                                    "textReplacements": {
+                                        "type": "object",
+                                        "required": [
+                                            "searchOriginal",
+                                            "groups"
+                                        ],
+                                        "properties": {
+                                            "searchOriginal": {
+                                                "type": "boolean",
+                                                "default": true
+                                            },
+                                            "groups": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "array",
+                                                    "items": {
+                                                        "required": [
+                                                            "pattern",
+                                                            "ignoreCase",
+                                                            "replacement"
+                                                        ],
+                                                        "properties": {
+                                                            "pattern": {
+                                                                "type": "string",
+                                                                "default": ""
+                                                            },
+                                                            "ignoreCase": {
+                                                                "type": "boolean",
+                                                                "default": false
+                                                            },
+                                                            "replacement": {
+                                                                "type": "string",
+                                                                "default": ""
+                                                            }
+                                                        }
+                                                    }
+                                                }
+                                            }
+                                        }
                                     }
                                 }
                             },

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1655,10 +1655,11 @@ class Backend {
                 convertAlphabeticCharacters,
                 convertHiraganaToKatakana,
                 convertKatakanaToHiragana,
-                collapseEmphaticSequences
+                collapseEmphaticSequences,
+                textReplacements: textReplacementsOptions
             }
         } = options;
-        const textReplacements = [null];
+        const textReplacements = this._getTranslatorTextReplacements(textReplacementsOptions);
         return {
             wildcard,
             mainDictionary,
@@ -1686,6 +1687,29 @@ class Backend {
             enabledDictionaryMap.set(title, {priority, allowSecondarySearches});
         }
         return enabledDictionaryMap;
+    }
+
+    _getTranslatorTextReplacements(textReplacementsOptions) {
+        const textReplacements = [];
+        for (const group of textReplacementsOptions.groups) {
+            const textReplacementsEntries = [];
+            for (let {pattern, ignoreCase, replacement} of group) {
+                try {
+                    pattern = new RegExp(pattern, ignoreCase ? 'gi' : 'g');
+                } catch (e) {
+                    // Invalid pattern
+                    continue;
+                }
+                textReplacementsEntries.push({pattern, replacement});
+            }
+            if (textReplacementsEntries.length > 0) {
+                textReplacements.push(textReplacementsEntries);
+            }
+        }
+        if (textReplacements.length === 0 || textReplacementsOptions.searchOriginal) {
+            textReplacements.unshift(null);
+        }
+        return textReplacements;
     }
 
     async _openWelcomeGuidePage() {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1658,6 +1658,7 @@ class Backend {
                 collapseEmphaticSequences
             }
         } = options;
+        const textReplacements = [null];
         return {
             wildcard,
             mainDictionary,
@@ -1668,6 +1669,7 @@ class Backend {
             convertHiraganaToKatakana,
             convertKatakanaToHiragana,
             collapseEmphaticSequences,
+            textReplacements,
             enabledDictionaryMap
         };
     }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -485,6 +485,10 @@ class OptionsUtil {
             {
                 async: false,
                 update: this._updateVersion7.bind(this)
+            },
+            {
+                async: false,
+                update: this._updateVersion8.bind(this)
             }
         ];
     }
@@ -672,6 +676,18 @@ class OptionsUtil {
             profile.options.general.popupCurrentIndicatorMode = 'triangle';
             profile.options.general.popupActionBarVisibility = 'auto';
             profile.options.general.popupActionBarLocation = 'right';
+        }
+        return options;
+    }
+
+    _updateVersion8(options) {
+        // Version 8 changes:
+        //  Added translation.textReplacements.
+        for (const profile of options.profiles) {
+            profile.options.translation.textReplacements = {
+                searchOriginal: true,
+                groups: []
+            };
         }
         return options;
     }

--- a/ext/bg/js/settings2/settings-main.js
+++ b/ext/bg/js/settings2/settings-main.js
@@ -36,6 +36,7 @@
  * SettingsDisplayController
  * StatusFooter
  * StorageController
+ * TranslationTextReplacementsController
  * api
  */
 
@@ -119,6 +120,9 @@ async function setupGenericSettingsController(genericSettingController) {
 
         const secondarySearchDictionaryController = new SecondarySearchDictionaryController(settingsController);
         secondarySearchDictionaryController.prepare();
+
+        const translationTextReplacementsController = new TranslationTextReplacementsController(settingsController);
+        translationTextReplacementsController.prepare();
 
         await Promise.all(preparePromises);
 

--- a/ext/bg/js/settings2/translation-text-replacements-controller.js
+++ b/ext/bg/js/settings2/translation-text-replacements-controller.js
@@ -1,0 +1,187 @@
+/*
+ * Copyright (C) 2021  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+class TranslationTextReplacementsController {
+    constructor(settingsController) {
+        this._settingsController = settingsController;
+        this._entryContainer = null;
+        this._entries = [];
+    }
+
+    async prepare() {
+        this._entryContainer = document.querySelector('#translation-text-replacement-list');
+        const addButton = document.querySelector('#translation-text-replacement-add');
+
+        addButton.addEventListener('click', this._onAdd.bind(this), false);
+        this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
+
+        await this._updateOptions();
+    }
+
+
+    async addGroup() {
+        const options = await this._settingsController.getOptions();
+        const {groups} = options.translation.textReplacements;
+        const newEntry = this._createNewEntry();
+        const target = (
+            (groups.length === 0) ?
+            {
+                action: 'splice',
+                path: 'translation.textReplacements.groups',
+                start: 0,
+                deleteCount: 0,
+                items: [[newEntry]]
+            } :
+            {
+                action: 'splice',
+                path: 'translation.textReplacements.groups[0]',
+                start: groups[0].length,
+                deleteCount: 0,
+                items: [newEntry]
+            }
+        );
+
+        await this._settingsController.modifyProfileSettings([target]);
+        await this._updateOptions();
+    }
+
+    async deleteGroup(index) {
+        const options = await this._settingsController.getOptions();
+        const {groups} = options.translation.textReplacements;
+        if (groups.length === 0) { return false; }
+
+        const group0 = groups[0];
+        if (index < 0 || index >= group0.length) { return false; }
+
+        const target = (
+            (group0.length > 1) ?
+            {
+                action: 'splice',
+                path: 'translation.textReplacements.groups[0]',
+                start: index,
+                deleteCount: 1,
+                items: []
+            } :
+            {
+                action: 'splice',
+                path: 'translation.textReplacements.groups',
+                start: 0,
+                deleteCount: group0.length,
+                items: []
+            }
+        );
+
+        await this._settingsController.modifyProfileSettings([target]);
+        await this._updateOptions();
+        return true;
+    }
+
+    // Private
+
+    _onOptionsChanged({options}) {
+        for (const entry of this._entries) {
+            entry.cleanup();
+        }
+        this._entries = [];
+
+        const {groups} = options.translation.textReplacements;
+        if (groups.length > 0) {
+            const group0 = groups[0];
+            for (let i = 0, ii = group0.length; i < ii; ++i) {
+                const data = group0[i];
+                const node = this._settingsController.instantiateTemplate('translation-text-replacement-entry');
+                this._entryContainer.appendChild(node);
+                const entry = new TranslationTextReplacementsEntry(this, node, i, data);
+                this._entries.push(entry);
+                entry.prepare();
+            }
+        }
+    }
+
+    _onAdd() {
+        this.addGroup();
+    }
+
+    async _updateOptions() {
+        const options = await this._settingsController.getOptions();
+        this._onOptionsChanged({options});
+    }
+
+    _createNewEntry() {
+        return {pattern: '', ignoreCase: false, replacement: ''};
+    }
+}
+
+class TranslationTextReplacementsEntry {
+    constructor(parent, node, index) {
+        this._parent = parent;
+        this._node = node;
+        this._index = index;
+        this._eventListeners = new EventListenerCollection();
+        this._patternInput = null;
+    }
+
+    prepare() {
+        const patternInput = this._node.querySelector('.translation-text-replacement-pattern');
+        const replacementInput = this._node.querySelector('.translation-text-replacement-replacement');
+        const ignoreCaseToggle = this._node.querySelector('.translation-text-replacement-pattern-ignore-case');
+        const menuButton = this._node.querySelector('.translation-text-replacement-button');
+
+        this._patternInput = patternInput;
+
+        const pathBase = `translation.textReplacements.groups[0][${this._index}]`;
+        patternInput.dataset.setting = `${pathBase}.pattern`;
+        replacementInput.dataset.setting = `${pathBase}.replacement`;
+        ignoreCaseToggle.dataset.setting = `${pathBase}.ignoreCase`;
+
+        this._eventListeners.addEventListener(menuButton, 'menuClosed', this._onMenuClosed.bind(this), false);
+        this._eventListeners.addEventListener(patternInput, 'settingChanged', this._onPatternChanged.bind(this), false);
+    }
+
+    cleanup() {
+        this._eventListeners.removeAllEventListeners();
+        if (this._node.parentNode !== null) {
+            this._node.parentNode.removeChild(this._node);
+        }
+    }
+
+    // Private
+
+    _onMenuClosed({detail: {action}}) {
+        switch (action) {
+            case 'remove':
+                this._parent.deleteGroup(this._index);
+                break;
+        }
+    }
+
+    _onPatternChanged({detail: {value}}) {
+        this._validatePattern(value);
+    }
+
+    _validatePattern(value) {
+        let okay = false;
+        try {
+            new RegExp(value, 'g');
+            okay = true;
+        } catch (e) {
+            // NOP
+        }
+
+        this._patternInput.dataset.invalid = `${!okay}`;
+    }
+}

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -1340,7 +1340,7 @@ class Translator {
             const index = match.index;
             const actualReplacement = this._applyMatchReplacement(replacement, match);
             const actualReplacementLength = actualReplacement.length;
-            const delta = actualReplacementLength - matchText.length;
+            const delta = actualReplacementLength - (matchText.length > 0 ? matchText.length : -1);
 
             text = `${text.substring(0, index)}${actualReplacement}${text.substring(index + matchText.length)}`;
             pattern.lastIndex += delta;

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -302,6 +302,7 @@ class Translator {
 
     _getAllDeinflections(text, options) {
         const textOptionVariantArray = [
+            this._getTextReplacementsFromOptions(options),
             this._getTextOptionEntryVariants(options.convertHalfWidthCharacters),
             this._getTextOptionEntryVariants(options.convertNumericCharacters),
             this._getTextOptionEntryVariants(options.convertAlphabeticCharacters),
@@ -313,9 +314,12 @@ class Translator {
         const jp = this._japaneseUtil;
         const deinflections = [];
         const used = new Set();
-        for (const [halfWidth, numeric, alphabetic, katakana, hiragana, [collapseEmphatic, collapseEmphaticFull]] of this._getArrayVariants(textOptionVariantArray)) {
+        for (const [textReplacements, halfWidth, numeric, alphabetic, katakana, hiragana, [collapseEmphatic, collapseEmphaticFull]] of this._getArrayVariants(textOptionVariantArray)) {
             let text2 = text;
             const sourceMap = new TextSourceMap(text2);
+            if (textReplacements !== null) {
+                text2 = this._applyTextReplacements(text2, sourceMap, textReplacements);
+            }
             if (halfWidth) {
                 text2 = jp.convertHalfWidthKanaToFullWidth(text2, sourceMap);
             }
@@ -879,6 +883,11 @@ class Translator {
         return collapseEmphaticOptions;
     }
 
+    _getTextReplacementsFromOptions(options) {
+        // TODO
+        return [null];
+    }
+
     _getSecondarySearchDictionaryMap(enabledDictionaryMap) {
         const secondarySearchDictionaryMap = new Map();
         for (const [dictionary, details] of enabledDictionaryMap.entries()) {
@@ -1302,6 +1311,66 @@ class Translator {
             if (i !== 0) { return i; }
 
             return stringComparer.compare(v1.notes, v2.notes);
+        });
+    }
+
+    // Regex functions
+
+    _applyTextReplacements(text, sourceMap, replacements) {
+        for (const {pattern, replacement} of replacements) {
+            text = this._applyTextReplacement(text, sourceMap, pattern, replacement);
+        }
+        return text;
+    }
+
+    _applyTextReplacement(text, sourceMap, pattern, replacement) {
+        const isGlobal = pattern.global;
+        if (isGlobal) { pattern.lastIndex = 0; }
+        for (let loop = true; loop; loop = isGlobal) {
+            const match = pattern.exec(text);
+            if (match === null) { break; }
+
+            const matchText = match[0];
+            const index = match.index;
+            const actualReplacement = this._applyMatchReplacement(replacement, match);
+            const actualReplacementLength = actualReplacement.length;
+            const delta = actualReplacementLength - matchText.length;
+
+            text = `${text.substring(0, index)}${actualReplacement}${text.substring(index + matchText.length)}`;
+            pattern.lastIndex += delta;
+
+            if (actualReplacementLength > 0) {
+                sourceMap.combine(Math.max(0, index - 1), matchText.length);
+                sourceMap.insert(index, ...(new Array(actualReplacementLength).fill(0)));
+            } else {
+                sourceMap.combine(index, matchText.length);
+            }
+        }
+        return text;
+    }
+
+    _applyMatchReplacement(replacement, match) {
+        const pattern = /\$(?:\$|&|`|'|(\d\d?)|<([^>]*)>)/g;
+        return replacement.replace(pattern, (g0, g1, g2) => {
+            if (typeof g1 !== 'undefined') {
+                const matchIndex = Number.parseInt(g1, 10);
+                if (matchIndex >= 1 && matchIndex <= match.length) {
+                    return match[matchIndex];
+                }
+            } else if (typeof g2 !== 'undefined') {
+                const {groups} = match;
+                if (typeof groups === 'object' && groups !== null && Object.prototype.hasOwnProperty.call(groups, g2)) {
+                    return groups[g2];
+                }
+            } else {
+                switch (g0) {
+                    case '$': return '$';
+                    case '&': return match[0];
+                    case '`': return replacement.substring(0, match.index);
+                    case '\'': return replacement.substring(match.index + g0.length);
+                }
+            }
+            return g0;
         });
     }
 }

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -68,6 +68,13 @@ class Translator {
      *     convertHiraganaToKatakana: (enum: 'false', 'true', 'variant'),
      *     convertKatakanaToHiragana: (enum: 'false', 'true', 'variant'),
      *     collapseEmphaticSequences: (enum: 'false', 'true', 'full'),
+     *     textReplacements: [
+     *       (null or [
+     *         {pattern: (RegExp), replacement: (string)}
+     *         ...
+     *       ])
+     *       ...
+     *     ],
      *     enabledDictionaryMap: (Map of [
      *       (string),
      *       {
@@ -884,8 +891,7 @@ class Translator {
     }
 
     _getTextReplacementsFromOptions(options) {
-        // TODO
-        return [null];
+        return options.textReplacements;
     }
 
     _getSecondarySearchDictionaryMap(enabledDictionaryMap) {

--- a/ext/bg/js/translator.js
+++ b/ext/bg/js/translator.js
@@ -309,7 +309,7 @@ class Translator {
 
     _getAllDeinflections(text, options) {
         const textOptionVariantArray = [
-            this._getTextReplacementsFromOptions(options),
+            this._getTextReplacementsVariants(options),
             this._getTextOptionEntryVariants(options.convertHalfWidthCharacters),
             this._getTextOptionEntryVariants(options.convertNumericCharacters),
             this._getTextOptionEntryVariants(options.convertAlphabeticCharacters),
@@ -890,7 +890,7 @@ class Translator {
         return collapseEmphaticOptions;
     }
 
-    _getTextReplacementsFromOptions(options) {
+    _getTextReplacementsVariants(options) {
         return options.textReplacements;
     }
 

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -2676,8 +2676,8 @@
 <!-- Translation templates -->
 <template id="translation-text-replacement-entry-template"><div class="translation-text-replacement-entry">
     <div class="translation-text-replacement-index generic-list-index-prefix"></div>
-    <div class="translation-text-replacement-pattern-label">Pattern</div>
-    <div class="translation-text-replacement-replacement-label">Replacement</div>
+    <div class="translation-text-replacement-pattern-label">Pattern:</div>
+    <div class="translation-text-replacement-replacement-label">Replacement:</div>
     <div class="translation-text-replacement-pattern-container">
         <input type="text" class="translation-text-replacement-pattern code">
         <label class="translation-text-replacement-checkbox-container">
@@ -2689,9 +2689,18 @@
         <input type="text" class="translation-text-replacement-replacement code">
     </div>
     <button class="icon-button translation-text-replacement-button" data-menu="translation-text-replacement-entry-menu" data-menu-position="below,left"><span class="icon-button-inner"><span class="icon" data-icon="kebab-menu"></span></span></button>
+
+    <div class="translation-text-replacement-test-label translation-text-replacement-test-node">Test Input:</div>
+    <div class="translation-text-replacement-test-container translation-text-replacement-test-node">
+        <input type="text" class="translation-text-replacement-test-input">
+        <div class="translation-text-replacement-test-label-inner">Output:</div>
+        <input type="text" class="translation-text-replacement-test-output" readonly>
+    </div>
 </div></template>
 
 <template id="translation-text-replacement-entry-menu-template"><div class="popup-menu-container" tabindex="-1" role="dialog"><div class="popup-menu">
+    <button class="popup-menu-item" data-menu-action="showTest">Test</button>
+    <button class="popup-menu-item" data-menu-action="hideTest">Hide test</button>
     <button class="popup-menu-item" data-menu-action="remove">Remove</button>
 </div></div></template>
 

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -1144,6 +1144,14 @@
         </div>
     </div>
     <div class="settings-group">
+        <div class="settings-item settings-item-button advanced-only" data-modal-action="show,translation-text-replacement-patterns"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Configure custom text replacement patterns&hellip;</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></div>
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Convert half width characters to full width</div>
@@ -2612,6 +2620,82 @@
 </div></div>
 
 
+<!-- Translation modals -->
+<div id="translation-text-replacement-patterns" class="modal-container" tabindex="-1" role="dialog" hidden><div class="modal-content">
+    <div class="modal-header">
+        <div class="modal-title">Custom Text Replacement Patterns</div>
+        <div class="modal-header-button-container">
+            <div class="modal-header-button-group">
+                <button class="icon-button modal-header-button" data-modal-action="expand"><span class="icon-button-inner"><span class="icon" data-icon="expand"></span></span></button>
+                <button class="icon-button modal-header-button" data-modal-action="collapse"><span class="icon-button-inner"><span class="icon" data-icon="collapse"></span></span></button>
+            </div>
+        </div>
+    </div>
+    <div class="modal-body">
+        <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
+            Text replacement patterns are used to modify or remove text that matches certain patterns.
+            Patterns are defined using
+            <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide/Regular_Expressions" target="_blank" rel="noreferrer noopener">regular expression syntax</a>,
+            and the replacement text can use certain
+            <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#Specifying_a_string_as_a_parameter" target="_blank" rel="noreferrer noopener">special replacement patterns</a>.
+        </div></div></div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">
+                    Search original text
+                </div>
+                <div class="settings-item-description">
+                    The original unmodified text will also be searched for definitions.
+                </div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" data-setting="translation.textReplacements.searchOriginal"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
+        <div class="settings-item">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Text replacement patterns</div>
+                </div>
+                <div class="settings-item-right">
+                    <button id="translation-text-replacement-add" class="low-emphasis">Add</button>
+                </div>
+            </div>
+            <div class="settings-item-children">
+                <div id="translation-text-replacement-list" class="generic-list"></div>
+                <div id="translation-text-replacement-list-empty"><em>None defined</em></div>
+            </div>
+        </div>
+    </div>
+    <div class="modal-footer">
+        <button data-modal-action="hide">Close</button>
+    </div>
+</div></div>
+
+
+<!-- Translation templates -->
+<template id="translation-text-replacement-entry-template"><div class="translation-text-replacement-entry">
+    <div class="translation-text-replacement-index generic-list-index-prefix"></div>
+    <div class="translation-text-replacement-pattern-label">Pattern</div>
+    <div class="translation-text-replacement-replacement-label">Replacement</div>
+    <div class="translation-text-replacement-pattern-container">
+        <input type="text" class="translation-text-replacement-pattern code">
+        <label class="translation-text-replacement-checkbox-container">
+            <label class="checkbox"><input type="checkbox" class="translation-text-replacement-checkbox translation-text-replacement-pattern-ignore-case"><span class="checkbox-body"><span class="checkbox-fill"></span><span class="checkbox-border"></span><span class="checkbox-check"></span></span></label>
+            <span class="translation-text-replacement-checkbox-label">Ignore case</span>
+        </label>
+    </div>
+    <div class="translation-text-replacement-replacement-container">
+        <input type="text" class="translation-text-replacement-replacement code">
+    </div>
+    <button class="icon-button translation-text-replacement-button" data-menu="translation-text-replacement-entry-menu" data-menu-position="below,left"><span class="icon-button-inner"><span class="icon" data-icon="kebab-menu"></span></span></button>
+</div></template>
+
+<template id="translation-text-replacement-entry-menu-template"><div class="popup-menu-container" tabindex="-1" role="dialog"><div class="popup-menu">
+    <button class="popup-menu-item" data-menu-action="remove">Remove</button>
+</div></div></template>
+
+
 <!-- Scripts -->
 <script src="/mixed/lib/jszip.min.js"></script>
 <script src="/mixed/lib/wanakana.min.js"></script>
@@ -2671,6 +2755,7 @@
 <script src="/bg/js/settings2/nested-popups-controller.js"></script>
 <script src="/bg/js/settings2/secondary-search-dictionary-controller.js"></script>
 <script src="/bg/js/settings2/settings-display-controller.js"></script>
+<script src="/bg/js/settings2/translation-text-replacements-controller.js"></script>
 
 <script src="/bg/js/settings2/settings-main.js"></script>
 

--- a/ext/mixed/css/material.css
+++ b/ext/mixed/css/material.css
@@ -617,6 +617,10 @@ input[type=number].input-with-suffix-button {
     border-right-style: none;
     z-index: 1;
 }
+input[type=text].code,
+input[type=number].code {
+    font-family: 'Courier New', Courier, monospace;
+}
 
 
 /* Material design button */

--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -20,6 +20,7 @@
             "convertHiraganaToKatakana": false,
             "convertKatakanaToHiragana": false,
             "collapseEmphaticSequences": false,
+            "textReplacements": [null],
             "enabledDictionaryMap": [
                 [
                     "${title}",

--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -20,7 +20,9 @@
             "convertHiraganaToKatakana": false,
             "convertKatakanaToHiragana": false,
             "collapseEmphaticSequences": false,
-            "textReplacements": [null],
+            "textReplacements": [
+                null
+            ],
             "enabledDictionaryMap": [
                 [
                     "${title}",
@@ -16875,6 +16877,52 @@
                     }
                 ]
             }
+        },
+        {
+            "comment": "Ignore text inside parentheses",
+            "func": "findTerms",
+            "mode": "split",
+            "text": "打(う)ち込(こ)む",
+            "options": [
+                "default",
+                {
+                    "alphanumeric": true,
+                    "textReplacements": [
+                        null,
+                        [
+                            {
+                                "pattern": "\\(([^)]*)(?:\\)|$)",
+                                "flags": "g",
+                                "replacement": ""
+                            }
+                        ]
+                    ]
+                }
+            ],
+            "expected": null
+        },
+        {
+            "comment": "Remove parentheses around text",
+            "func": "findTerms",
+            "mode": "split",
+            "text": "(打)(ち)(込)(む)",
+            "options": [
+                "default",
+                {
+                    "alphanumeric": true,
+                    "textReplacements": [
+                        null,
+                        [
+                            {
+                                "pattern": "\\(([^)]*)(?:\\)|$)",
+                                "flags": "g",
+                                "replacement": "$1"
+                            }
+                        ]
+                    ]
+                }
+            ],
+            "expected": null
         }
     ]
 }

--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -16899,7 +16899,1905 @@
                     ]
                 }
             ],
-            "expected": null
+            "expected": {
+                "length": 10,
+                "definitions": [
+                    {
+                        "type": "term",
+                        "id": 7,
+                        "source": "打ち込む",
+                        "rawSource": "打(う)ち込(こ)む",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 10,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "うちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": true,
+                                        "frequency": 8
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition13",
+                            "definition14"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": true,
+                                "frequency": 8
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 9,
+                        "source": "打ち込む",
+                        "rawSource": "打(う)ち込(こ)む",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 10,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "ぶちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": true,
+                                        "frequency": 9
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition17",
+                            "definition18"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": true,
+                                "frequency": 9
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 8,
+                        "source": "打ち込む",
+                        "rawSource": "打(う)ち込(こ)む",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "うちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag6",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag7",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": true,
+                                        "frequency": 8
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition15",
+                            "definition16"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag6",
+                                "category": "default",
+                                "notes": "",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag7",
+                                "category": "default",
+                                "notes": "",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": true,
+                                "frequency": 8
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 10,
+                        "source": "打ち込む",
+                        "rawSource": "打(う)ち込(こ)む",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "ぶちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": true,
+                                        "frequency": 9
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition19",
+                            "definition20"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": true,
+                                "frequency": 9
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 3,
+                        "source": "打ち",
+                        "rawSource": "打(う)ち",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 10,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "うつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": true,
+                                        "frequency": 6
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition5",
+                            "definition6"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": true,
+                                "frequency": 6
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 5,
+                        "source": "打ち",
+                        "rawSource": "打(う)ち",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 10,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "ぶつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": true,
+                                        "frequency": 7
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition9",
+                            "definition10"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": true,
+                                "frequency": 7
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 4,
+                        "source": "打ち",
+                        "rawSource": "打(う)ち",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 1,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "うつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": true,
+                                        "frequency": 6
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition7",
+                            "definition8"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": true,
+                                "frequency": 6
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 6,
+                        "source": "打ち",
+                        "rawSource": "打(う)ち",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 1,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "ぶつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": true,
+                                        "frequency": 7
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition11",
+                            "definition12"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": true,
+                                "frequency": 7
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 1,
+                        "source": "打",
+                        "rawSource": "打",
+                        "sourceTerm": "打",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 1,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打",
+                        "reading": "だ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打",
+                                "expression": "打",
+                                "reading": "だ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "だ"
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "だ",
+                                        "hasReading": false,
+                                        "frequency": 1
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "だ",
+                                        "hasReading": true,
+                                        "frequency": 4
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "だ"
+                            }
+                        ],
+                        "glossary": [
+                            "definition1",
+                            "definition2"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "だ",
+                                "hasReading": false,
+                                "frequency": 1
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "だ",
+                                "hasReading": true,
+                                "frequency": 4
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 2,
+                        "source": "打",
+                        "rawSource": "打",
+                        "sourceTerm": "打",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 2,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打",
+                        "reading": "ダース",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ダース"
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "ダース",
+                                        "hasReading": false,
+                                        "frequency": 1
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "ダース",
+                                        "hasReading": true,
+                                        "frequency": 5
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ダース"
+                            }
+                        ],
+                        "glossary": [
+                            "definition3",
+                            "definition4"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "hasReading": false,
+                                "frequency": 1
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "hasReading": true,
+                                "frequency": 5
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    }
+                ]
+            }
         },
         {
             "comment": "Remove parentheses around text",
@@ -16922,7 +18820,1905 @@
                     ]
                 }
             ],
-            "expected": null
+            "expected": {
+                "length": 12,
+                "definitions": [
+                    {
+                        "type": "term",
+                        "id": 7,
+                        "source": "打ち込む",
+                        "rawSource": "(打)(ち)(込)(む)",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 10,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "うちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": true,
+                                        "frequency": 8
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition13",
+                            "definition14"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": true,
+                                "frequency": 8
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 9,
+                        "source": "打ち込む",
+                        "rawSource": "(打)(ち)(込)(む)",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 10,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "ぶちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": true,
+                                        "frequency": 9
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition17",
+                            "definition18"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": true,
+                                "frequency": 9
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 8,
+                        "source": "打ち込む",
+                        "rawSource": "(打)(ち)(込)(む)",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "うちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag6",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag7",
+                                        "category": "default",
+                                        "notes": "",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "hasReading": true,
+                                        "frequency": 8
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "うちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition15",
+                            "definition16"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag6",
+                                "category": "default",
+                                "notes": "",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag7",
+                                "category": "default",
+                                "notes": "",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "hasReading": true,
+                                "frequency": 8
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "うちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 10,
+                        "source": "打ち込む",
+                        "rawSource": "(打)(ち)(込)(む)",
+                        "sourceTerm": "打ち込む",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 4,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打ち込む",
+                        "reading": "ぶちこむ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打ち込む",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "ち",
+                                        "furigana": ""
+                                    },
+                                    {
+                                        "text": "込",
+                                        "furigana": "こ"
+                                    },
+                                    {
+                                        "text": "む",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": false,
+                                        "frequency": 3
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "hasReading": true,
+                                        "frequency": 9
+                                    }
+                                ],
+                                "pitches": [
+                                    {
+                                        "expression": "打ち込む",
+                                        "reading": "ぶちこむ",
+                                        "dictionary": "Test Dictionary 2",
+                                        "pitches": [
+                                            {
+                                                "position": 0,
+                                                "tags": []
+                                            },
+                                            {
+                                                "position": 3,
+                                                "tags": []
+                                            }
+                                        ]
+                                    }
+                                ]
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "ち",
+                                "furigana": ""
+                            },
+                            {
+                                "text": "込",
+                                "furigana": "こ"
+                            },
+                            {
+                                "text": "む",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition19",
+                            "definition20"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": false,
+                                "frequency": 3
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "hasReading": true,
+                                "frequency": 9
+                            }
+                        ],
+                        "pitches": [
+                            {
+                                "expression": "打ち込む",
+                                "reading": "ぶちこむ",
+                                "dictionary": "Test Dictionary 2",
+                                "pitches": [
+                                    {
+                                        "position": 0,
+                                        "tags": []
+                                    },
+                                    {
+                                        "position": 3,
+                                        "tags": []
+                                    }
+                                ]
+                            }
+                        ],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 3,
+                        "source": "打ち",
+                        "rawSource": "(打)(ち)(込)",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 10,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "うつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": true,
+                                        "frequency": 6
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition5",
+                            "definition6"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": true,
+                                "frequency": 6
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 5,
+                        "source": "打ち",
+                        "rawSource": "(打)(ち)(込)",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 10,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "ぶつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": true,
+                                        "frequency": 7
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition9",
+                            "definition10"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": true,
+                                "frequency": 7
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 4,
+                        "source": "打ち",
+                        "rawSource": "(打)(ち)(込)",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 1,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "うつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "う"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "うつ",
+                                        "hasReading": true,
+                                        "frequency": 6
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "う"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition7",
+                            "definition8"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "うつ",
+                                "hasReading": true,
+                                "frequency": 6
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 6,
+                        "source": "打ち",
+                        "rawSource": "(打)(ち)(込)",
+                        "sourceTerm": "打つ",
+                        "reasons": [
+                            "masu stem"
+                        ],
+                        "score": 1,
+                        "sequence": 3,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打つ",
+                        "reading": "ぶつ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打つ",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ぶ"
+                                    },
+                                    {
+                                        "text": "つ",
+                                        "furigana": ""
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": false,
+                                        "frequency": 2
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打つ",
+                                        "reading": "ぶつ",
+                                        "hasReading": true,
+                                        "frequency": 7
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ぶ"
+                            },
+                            {
+                                "text": "つ",
+                                "furigana": ""
+                            }
+                        ],
+                        "glossary": [
+                            "definition11",
+                            "definition12"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": false,
+                                "frequency": 2
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打つ",
+                                "reading": "ぶつ",
+                                "hasReading": true,
+                                "frequency": 7
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 1,
+                        "source": "打",
+                        "rawSource": "(打)(ち)",
+                        "sourceTerm": "打",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 1,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打",
+                        "reading": "だ",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打",
+                                "expression": "打",
+                                "reading": "だ",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "だ"
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "だ",
+                                        "hasReading": false,
+                                        "frequency": 1
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "だ",
+                                        "hasReading": true,
+                                        "frequency": 4
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "だ"
+                            }
+                        ],
+                        "glossary": [
+                            "definition1",
+                            "definition2"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "だ",
+                                "hasReading": false,
+                                "frequency": 1
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "だ",
+                                "hasReading": true,
+                                "frequency": 4
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    },
+                    {
+                        "type": "term",
+                        "id": 2,
+                        "source": "打",
+                        "rawSource": "(打)(ち)",
+                        "sourceTerm": "打",
+                        "reasons": [],
+                        "score": 1,
+                        "sequence": 2,
+                        "dictionary": "Test Dictionary 2",
+                        "dictionaryPriority": 0,
+                        "dictionaryNames": [
+                            "Test Dictionary 2"
+                        ],
+                        "expression": "打",
+                        "reading": "ダース",
+                        "expressions": [
+                            {
+                                "sourceTerm": "打",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "furiganaSegments": [
+                                    {
+                                        "text": "打",
+                                        "furigana": "ダース"
+                                    }
+                                ],
+                                "termTags": [
+                                    {
+                                        "name": "tag3",
+                                        "category": "category3",
+                                        "notes": "tag3 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag4",
+                                        "category": "category4",
+                                        "notes": "tag4 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    },
+                                    {
+                                        "name": "tag5",
+                                        "category": "category5",
+                                        "notes": "tag5 notes",
+                                        "order": 0,
+                                        "score": 0,
+                                        "dictionary": "Test Dictionary 2",
+                                        "redundant": false
+                                    }
+                                ],
+                                "termFrequency": "normal",
+                                "frequencies": [
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "ダース",
+                                        "hasReading": false,
+                                        "frequency": 1
+                                    },
+                                    {
+                                        "dictionary": "Test Dictionary 2",
+                                        "expression": "打",
+                                        "reading": "ダース",
+                                        "hasReading": true,
+                                        "frequency": 5
+                                    }
+                                ],
+                                "pitches": []
+                            }
+                        ],
+                        "furiganaSegments": [
+                            {
+                                "text": "打",
+                                "furigana": "ダース"
+                            }
+                        ],
+                        "glossary": [
+                            "definition3",
+                            "definition4"
+                        ],
+                        "definitionTags": [
+                            {
+                                "name": "tag1",
+                                "category": "category1",
+                                "notes": "tag1 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag2",
+                                "category": "category2",
+                                "notes": "tag2 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "Test Dictionary 2",
+                                "category": "dictionary",
+                                "notes": "",
+                                "order": 100,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "termTags": [
+                            {
+                                "name": "tag3",
+                                "category": "category3",
+                                "notes": "tag3 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag4",
+                                "category": "category4",
+                                "notes": "tag4 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            },
+                            {
+                                "name": "tag5",
+                                "category": "category5",
+                                "notes": "tag5 notes",
+                                "order": 0,
+                                "score": 0,
+                                "dictionary": "Test Dictionary 2",
+                                "redundant": false
+                            }
+                        ],
+                        "frequencies": [
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "hasReading": false,
+                                "frequency": 1
+                            },
+                            {
+                                "dictionary": "Test Dictionary 2",
+                                "expression": "打",
+                                "reading": "ダース",
+                                "hasReading": true,
+                                "frequency": 5
+                            }
+                        ],
+                        "pitches": [],
+                        "sourceTermExactMatchCount": 1
+                    }
+                ]
+            }
         }
     ]
 }

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -394,7 +394,11 @@ function createProfileOptionsUpdatedTestData1() {
             convertAlphabeticCharacters: 'false',
             convertHiraganaToKatakana: 'false',
             convertKatakanaToHiragana: 'variant',
-            collapseEmphaticSequences: 'false'
+            collapseEmphaticSequences: 'false',
+            textReplacements: {
+                searchOriginal: true,
+                groups: []
+            }
         },
         dictionaries: {},
         parsing: {
@@ -502,7 +506,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 7,
+        version: 8,
         global: {
             database: {
                 prefixWildcardsSupported: false

--- a/test/test-translator.js
+++ b/test/test-translator.js
@@ -107,6 +107,16 @@ function buildOptions(optionsPresets, optionsArray, dictionaryTitle) {
         }
     }
 
+    // Construct regex
+    if (Array.isArray(options.textReplacements)) {
+        options.textReplacements = options.textReplacements.map((value) => {
+            if (Array.isArray(value)) {
+                value = value.map(({pattern, flags, replacement}) => ({pattern: new RegExp(pattern, flags), replacement}));
+            }
+            return value;
+        });
+    }
+
     // Update structure
     const placeholder = '${title}';
     if (options.mainDictionary === placeholder) {


### PR DESCRIPTION
Resolves #1195.

Example pattern: `[(]([^)]*)[)]`