### PR TITLE
Add reset input to profile condition

### DIFF
--- a/ext/bg/js/settings/profile-conditions-ui.js
+++ b/ext/bg/js/settings/profile-conditions-ui.js
@@ -525,6 +525,9 @@ class ProfileConditionUI {
             case 'delete':
                 this._removeSelf();
                 break;
+            case 'resetValue':
+                this._resetValue();
+                break;
         }
     }
 
@@ -636,9 +639,11 @@ class ProfileConditionUI {
         return modifiersArray.join(', ');
     }
 
-    async _setType(type) {
+    async _setType(type, operator) {
         const operators = this._getDescriptorOperators(type);
-        const operator = operators.length > 0 ? operators[0].name : '';
+        if (typeof operator === 'undefined') {
+            operator = operators.length > 0 ? operators[0].name : '';
+        }
         const operatorDetails = this._getOperatorDetails(type, operator);
         const {defaultValue} = operatorDetails;
         this._updateSelect(this._operatorInput, this._operatorOptionContainer, operators, operator);
@@ -661,5 +666,11 @@ class ProfileConditionUI {
             }
         }
         await this.settingsController.modifyGlobalSettings(settingsModifications);
+    }
+
+    async _resetValue() {
+        const type = this._typeInput.value;
+        const operator = this._operatorInput.value;
+        await this._setType(type, operator);
     }
 }

--- a/ext/bg/js/settings/profile-conditions-ui.js
+++ b/ext/bg/js/settings/profile-conditions-ui.js
@@ -485,32 +485,13 @@ class ProfileConditionUI {
 
     _onTypeChange(e) {
         const type = e.currentTarget.value;
-        const operators = this._getDescriptorOperators(type);
-        const operator = operators.length > 0 ? operators[0].name : '';
-        const operatorDetails = this._getOperatorDetails(type, operator);
-        const {defaultValue} = operatorDetails;
-        this._updateSelect(this._operatorInput, this._operatorOptionContainer, operators, operator);
-        this._updateValueInput(defaultValue, operatorDetails);
-        this.settingsController.modifyGlobalSettings([
-            {action: 'set', path: this.getPath('type'), value: type},
-            {action: 'set', path: this.getPath('operator'), value: operator},
-            {action: 'set', path: this.getPath('value'), value: defaultValue}
-        ]);
+        this._setType(type);
     }
 
     _onOperatorChange(e) {
         const type = this._typeInput.value;
         const operator = e.currentTarget.value;
-        const operatorDetails = this._getOperatorDetails(type, operator);
-        const settingsModifications = [{action: 'set', path: this.getPath('operator'), value: operator}];
-        if (operatorDetails.resetDefaultOnChange) {
-            const {defaultValue} = operatorDetails;
-            const okay = this._updateValueInput(defaultValue, operatorDetails);
-            if (okay) {
-                settingsModifications.push({action: 'set', path: this.getPath('value'), value: defaultValue});
-            }
-        }
-        this.settingsController.modifyGlobalSettings(settingsModifications);
+        this._setOperator(type, operator);
     }
 
     _onValueInputChange({validate, normalize}, e) {
@@ -653,5 +634,32 @@ class ProfileConditionUI {
 
     _joinModifiers(modifiersArray) {
         return modifiersArray.join(', ');
+    }
+
+    async _setType(type) {
+        const operators = this._getDescriptorOperators(type);
+        const operator = operators.length > 0 ? operators[0].name : '';
+        const operatorDetails = this._getOperatorDetails(type, operator);
+        const {defaultValue} = operatorDetails;
+        this._updateSelect(this._operatorInput, this._operatorOptionContainer, operators, operator);
+        this._updateValueInput(defaultValue, operatorDetails);
+        await this.settingsController.modifyGlobalSettings([
+            {action: 'set', path: this.getPath('type'), value: type},
+            {action: 'set', path: this.getPath('operator'), value: operator},
+            {action: 'set', path: this.getPath('value'), value: defaultValue}
+        ]);
+    }
+
+    async _setOperator(type, operator) {
+        const operatorDetails = this._getOperatorDetails(type, operator);
+        const settingsModifications = [{action: 'set', path: this.getPath('operator'), value: operator}];
+        if (operatorDetails.resetDefaultOnChange) {
+            const {defaultValue} = operatorDetails;
+            const okay = this._updateValueInput(defaultValue, operatorDetails);
+            if (okay) {
+                settingsModifications.push({action: 'set', path: this.getPath('value'), value: defaultValue});
+            }
+        }
+        await this.settingsController.modifyGlobalSettings(settingsModifications);
     }
 }

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -1789,6 +1789,7 @@
 </div></div></template>
 
 <template id="profile-condition-menu-template"><div class="popup-menu-container" tabindex="-1" role="dialog"><div class="popup-menu">
+    <button class="popup-menu-item" data-menu-action="resetValue">Reset value</button>
     <button class="popup-menu-item" data-menu-action="delete">Delete</button>
 </div></div></template>
 


### PR DESCRIPTION
Fixes an issue where it would not be easy to clear keyboard inputs on devices without an escape key/backspace (touchscreen). Also for consistency with other keyboard input fields.