### PR TITLE
Build fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,6 @@ jobs:
         node-version: '12.x'
     - name: Install dependencies
       run: npm ci
-    - name: Build
-      run: npm run build --if-present
     - name: Lint
       run: npm run test-lint
       env:
@@ -33,3 +31,5 @@ jobs:
       run: npm run test-manifest
       env:
         CI: true
+    - name: Build
+      run: npm run test-build

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -94,7 +94,7 @@
                 "description": "Toggle text scanning on/off"
             },
             "openInfoPage": {
-                "description": "Open the help page"
+                "description": "Open the info page"
             },
             "openSettingsPage": {
                 "description": "Open the settings page"


### PR DESCRIPTION
CI build before other tasks was polluting the workarea, causing manifest mismatches to go undetected.