### PR TITLE
Fix TextSourceElement.getNodesInRange not including the element

### DIFF
--- a/ext/fg/js/text-source-element.js
+++ b/ext/fg/js/text-source-element.js
@@ -114,7 +114,7 @@ class TextSourceElement {
     }
 
     getNodesInRange() {
-        return [];
+        return [this._element];
     }
 
     static getElementContent(element) {


### PR DESCRIPTION
This fixes an issue where `TextScanner.excludeSelector` would not properly ignore images, buttons, etc.