### PR TITLE
Simplify CacheMap

### DIFF
--- a/ext/bg/js/json-schema.js
+++ b/ext/bg/js/json-schema.js
@@ -125,7 +125,7 @@ class JsonSchemaProxyHandler {
 
 class JsonSchemaValidator {
     constructor() {
-        this._regexCache = new CacheMap(100, ([pattern, flags]) => new RegExp(pattern, flags));
+        this._regexCache = new CacheMap(100);
     }
 
     createProxy(target, schema) {
@@ -705,8 +705,12 @@ class JsonSchemaValidator {
     }
 
     _getRegex(pattern, flags) {
-        const regex = this._regexCache.getOrCreate([pattern, flags]);
-        regex.lastIndex = 0;
+        const key = `${flags}:${pattern}`;
+        let regex = this._regexCache.get(key);
+        if (typeof regex === 'undefined') {
+            regex = new RegExp(pattern, flags);
+            this._regexCache.set(key, regex);
+        }
         return regex;
     }
 }

--- a/ext/mixed/js/audio-system.js
+++ b/ext/mixed/js/audio-system.js
@@ -37,7 +37,7 @@ class AudioSystem {
     }
 
     async createExpressionAudio(sources, expression, reading, details) {
-        const key = [expression, reading];
+        const key = JSON.stringify([expression, reading]);
 
         const cacheValue = this._cache.get(key);
         if (typeof cacheValue !== 'undefined') {

--- a/test/test-cache-map.js
+++ b/test/test-cache-map.js
@@ -28,14 +28,14 @@ const CacheMap = vm.get('CacheMap');
 
 function testConstructor() {
     const data = [
-        [false, () => new CacheMap(0, () => null)],
-        [false, () => new CacheMap(1, () => null)],
-        [false, () => new CacheMap(Number.MAX_VALUE, () => null)],
-        [true,  () => new CacheMap(-1, () => null)],
-        [true,  () => new CacheMap(1.5, () => null)],
-        [true,  () => new CacheMap(Number.NaN, () => null)],
-        [true,  () => new CacheMap(Number.POSITIVE_INFINITY, () => null)],
-        [true,  () => new CacheMap('a', () => null)]
+        [false, () => new CacheMap(0)],
+        [false, () => new CacheMap(1)],
+        [false, () => new CacheMap(Number.MAX_VALUE)],
+        [true,  () => new CacheMap(-1)],
+        [true,  () => new CacheMap(1.5)],
+        [true,  () => new CacheMap(Number.NaN)],
+        [true,  () => new CacheMap(Number.POSITIVE_INFINITY)],
+        [true,  () => new CacheMap('a')]
     ];
 
     for (const [throws, create] of data) {
@@ -50,155 +50,64 @@ function testConstructor() {
 function testApi() {
     const data = [
         {
-            maxCount: 1,
-            expectedCount: 0,
+            maxSize: 1,
+            expectedSize: 0,
             calls: []
         },
         {
-            maxCount: 1,
-            expectedCount: 1,
+            maxSize: 10,
+            expectedSize: 1,
             calls: [
-                {func: 'getOrCreate', args: [['a', 'b', 'c']]}
+                {func: 'get', args: ['a1-b-c'],     returnValue: void 0},
+                {func: 'has', args: ['a1-b-c'],     returnValue: false},
+                {func: 'set', args: ['a1-b-c', 32], returnValue: void 0},
+                {func: 'get', args: ['a1-b-c'],     returnValue: 32},
+                {func: 'has', args: ['a1-b-c'],     returnValue: true}
             ]
         },
         {
-            maxCount: 10,
-            expectedCount: 1,
+            maxSize: 10,
+            expectedSize: 2,
             calls: [
-                {func: 'getOrCreate', args: [['a', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c']]}
+                {func: 'set', args: ['a1-b-c', 32], returnValue: void 0},
+                {func: 'get', args: ['a1-b-c'],     returnValue: 32},
+                {func: 'set', args: ['a1-b-c', 64], returnValue: void 0},
+                {func: 'get', args: ['a1-b-c'],     returnValue: 64},
+                {func: 'set', args: ['a2-b-c', 96], returnValue: void 0},
+                {func: 'get', args: ['a2-b-c'],     returnValue: 96}
             ]
         },
         {
-            maxCount: 10,
-            expectedCount: 3,
+            maxSize: 2,
+            expectedSize: 2,
             calls: [
-                {func: 'getOrCreate', args: [['a1', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a2', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a3', 'b', 'c']]}
-            ]
-        },
-        {
-            maxCount: 10,
-            expectedCount: 3,
-            calls: [
-                {func: 'getOrCreate', args: [['a', 'b1', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b2', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b3', 'c']]}
-            ]
-        },
-        {
-            maxCount: 10,
-            expectedCount: 3,
-            calls: [
-                {func: 'getOrCreate', args: [['a', 'b', 'c1']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c2']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c3']]}
-            ]
-        },
-        {
-            maxCount: 1,
-            expectedCount: 1,
-            calls: [
-                {func: 'getOrCreate', args: [['a1', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a2', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a3', 'b', 'c']]}
-            ]
-        },
-        {
-            maxCount: 1,
-            expectedCount: 1,
-            calls: [
-                {func: 'getOrCreate', args: [['a', 'b1', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b2', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b3', 'c']]}
-            ]
-        },
-        {
-            maxCount: 1,
-            expectedCount: 1,
-            calls: [
-                {func: 'getOrCreate', args: [['a', 'b', 'c1']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c2']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c3']]}
-            ]
-        },
-        {
-            maxCount: 10,
-            expectedCount: 0,
-            calls: [
-                {func: 'getOrCreate', args: [['a', 'b', 'c1']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c2']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c3']]},
-                {func: 'clear', args: []}
-            ]
-        },
-        {
-            maxCount: 0,
-            expectedCount: 0,
-            calls: [
-                {func: 'getOrCreate', args: [['a1', 'b', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b2', 'c']]},
-                {func: 'getOrCreate', args: [['a', 'b', 'c3']]}
-            ]
-        },
-        {
-            maxCount: 10,
-            expectedCount: 1,
-            calls: [
-                {func: 'get', args: [['a1', 'b', 'c']], returnValue: void 0},
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: false},
-                {func: 'set', args: [['a1', 'b', 'c'], 32], returnValue: void 0},
-                {func: 'get', args: [['a1', 'b', 'c']], returnValue: 32},
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: true}
-            ]
-        },
-        {
-            maxCount: 10,
-            expectedCount: 2,
-            calls: [
-                {func: 'set', args: [['a1', 'b', 'c'], 32], returnValue: void 0},
-                {func: 'get', args: [['a1', 'b', 'c']], returnValue: 32},
-                {func: 'set', args: [['a1', 'b', 'c'], 64], returnValue: void 0},
-                {func: 'get', args: [['a1', 'b', 'c']], returnValue: 64},
-                {func: 'set', args: [['a2', 'b', 'c'], 96], returnValue: void 0},
-                {func: 'get', args: [['a2', 'b', 'c']], returnValue: 96}
-            ]
-        },
-        {
-            maxCount: 2,
-            expectedCount: 2,
-            calls: [
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: false},
-                {func: 'has', args: [['a2', 'b', 'c']], returnValue: false},
-                {func: 'has', args: [['a3', 'b', 'c']], returnValue: false},
-                {func: 'set', args: [['a1', 'b', 'c'], 1], returnValue: void 0},
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: true},
-                {func: 'has', args: [['a2', 'b', 'c']], returnValue: false},
-                {func: 'has', args: [['a3', 'b', 'c']], returnValue: false},
-                {func: 'set', args: [['a2', 'b', 'c'], 2], returnValue: void 0},
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: true},
-                {func: 'has', args: [['a2', 'b', 'c']], returnValue: true},
-                {func: 'has', args: [['a3', 'b', 'c']], returnValue: false},
-                {func: 'set', args: [['a3', 'b', 'c'], 3], returnValue: void 0},
-                {func: 'has', args: [['a1', 'b', 'c']], returnValue: false},
-                {func: 'has', args: [['a2', 'b', 'c']], returnValue: true},
-                {func: 'has', args: [['a3', 'b', 'c']], returnValue: true}
+                {func: 'has', args: ['a1-b-c'],    returnValue: false},
+                {func: 'has', args: ['a2-b-c'],    returnValue: false},
+                {func: 'has', args: ['a3-b-c'],    returnValue: false},
+                {func: 'set', args: ['a1-b-c', 1], returnValue: void 0},
+                {func: 'has', args: ['a1-b-c'],    returnValue: true},
+                {func: 'has', args: ['a2-b-c'],    returnValue: false},
+                {func: 'has', args: ['a3-b-c'],    returnValue: false},
+                {func: 'set', args: ['a2-b-c', 2], returnValue: void 0},
+                {func: 'has', args: ['a1-b-c'],    returnValue: true},
+                {func: 'has', args: ['a2-b-c'],    returnValue: true},
+                {func: 'has', args: ['a3-b-c'],    returnValue: false},
+                {func: 'set', args: ['a3-b-c', 3], returnValue: void 0},
+                {func: 'has', args: ['a1-b-c'],    returnValue: false},
+                {func: 'has', args: ['a2-b-c'],    returnValue: true},
+                {func: 'has', args: ['a3-b-c'],    returnValue: true}
             ]
         }
     ];
 
-    const create = (args) => args.join(',');
-    for (const {maxCount, expectedCount, calls} of data) {
-        const cache = new CacheMap(maxCount, create);
-        assert.strictEqual(cache.maxCount, maxCount);
+    for (const {maxSize, expectedSize, calls} of data) {
+        const cache = new CacheMap(maxSize);
+        assert.strictEqual(cache.maxSize, maxSize);
         for (const call of calls) {
             const {func, args} = call;
             let returnValue;
             switch (func) {
                 case 'get': returnValue = cache.get(...args); break;
-                case 'getOrCreate': returnValue = cache.getOrCreate(...args); break;
                 case 'set': returnValue = cache.set(...args); break;
                 case 'has': returnValue = cache.has(...args); break;
                 case 'clear': returnValue = cache.clear(...args); break;
@@ -208,7 +117,7 @@ function testApi() {
                 assert.deepStrictEqual(returnValue, expectedReturnValue);
             }
         }
-        assert.strictEqual(cache.count, expectedCount);
+        assert.strictEqual(cache.size, expectedSize);
     }
 }
 


### PR DESCRIPTION
Use cases don't require the added complexity of supporting array keys.