### PR TITLE
Multiple custom audio sources

### DIFF
--- a/ext/bg/data/custom-audio-list-schema.json
+++ b/ext/bg/data/custom-audio-list-schema.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "type": "object",
+    "required": [
+        "type",
+        "audioSources"
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "type": {
+            "type": "string",
+            "const": "audioSourceList"
+        },
+        "audioSources": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "url"
+                ],
+                "additionalProperties": false,
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "url": {
+                        "type": "string"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -348,6 +348,7 @@
                                     "volume",
                                     "autoPlay",
                                     "customSourceUrl",
+                                    "customSourceType",
                                     "textToSpeechVoice"
                                 ],
                                 "properties": {
@@ -386,6 +387,11 @@
                                     "customSourceUrl": {
                                         "type": "string",
                                         "default": ""
+                                    },
+                                    "customSourceType": {
+                                        "type": "string",
+                                        "enum": ["audio", "json"],
+                                        "default": "audio"
                                     },
                                     "textToSpeechVoice": {
                                         "type": "string",

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1581,7 +1581,7 @@ class Backend {
             throw new Error('Invalid reading and expression');
         }
 
-        const {sources, customSourceUrl} = details;
+        const {sources, customSourceUrl, customSourceType} = details;
         const data = await this._downloadDefinitionAudio(
             sources,
             expression,
@@ -1589,6 +1589,7 @@ class Backend {
             {
                 textToSpeechVoice: null,
                 customSourceUrl,
+                customSourceType,
                 binary: true,
                 disableCache: true
             }

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -726,6 +726,7 @@ class OptionsUtil {
                 windowType: 'popup',
                 windowState: 'normal'
             };
+            profile.options.audio.customSourceType = 'audio';
         }
         return options;
     }

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -2205,15 +2205,41 @@
                     </div>
                 </div>
                 <div class="settings-item-right">
-                    <input type="text" spellcheck="false" autocomplete="off" data-setting="audio.customSourceUrl" placeholder="None">
+                    <div class="settings-item-group">
+                        <div class="settings-item-group-item">
+                            <div class="settings-item-group-item-label">Type</div>
+                            <select class="short-width short-height" data-setting="audio.customSourceType">
+                                <option value="audio">Audio</option>
+                                <option value="json">JSON</option>
+                            </select>
+                        </div>
+                        <div class="settings-item-group-item">
+                            <div class="settings-item-group-item-label">URL</div>
+                            <input class="short-height" type="text" spellcheck="false" autocomplete="off" data-setting="audio.customSourceUrl" placeholder="None">
+                        </div>
+                    </div>
                 </div>
             </div>
             <div class="settings-item-children more" hidden>
                 <p>
-                    URL format used for fetching audio clips in <em>Custom</em> mode.
+                    The <em>URL</em> property specifies the URL format used for fetching audio clips in <em>Custom</em> mode.
                     The replacement tags <code data-select-on-click="">{expression}</code> and <code data-select-on-click="">{reading}</code> can be used to specify which
                     expression and reading is being looked up.<br>
-                    Example: <a data-select-on-click="">http://localhost/audio.mp3?expression={expression}&reading={reading}</a>
+                </p>
+                <p>
+                    The <em>Type</em> property specifies how the URL is handled when looking up audio:
+                </p>
+                <ul>
+                    <li>
+                        <strong>Audio</strong> - The link is treated as a direct link to an audio file that the browser can play.
+                    </li>
+                    <li>
+                        <strong>JSON</strong> - The link is interpreted as a link to a JSON file, which is downloaded and parsed for audio URLs.
+                        The format of the JSON file is specified in <a href="/bg/data/custom-audio-list-schema.json" target="_blank" rel="noopener noreferrer">this schema file</a>.
+                    </li>
+                </ul>
+                <p>
+                    Example URL: <a data-select-on-click="">http://localhost/audio.mp3?expression={expression}&reading={reading}</a>
                 </p>
                 <p>
                     <a class="more-toggle" data-parent-distance="3">Less&hellip;</a>

--- a/ext/mixed/css/material.css
+++ b/ext/mixed/css/material.css
@@ -970,6 +970,7 @@ button.popup-menu-item:disabled {
     height: calc(16em / 14);
     background-color: var(--text-color);
     margin-right: 0.5em;
+    flex: 0 0 auto;
 }
 .popup-menu-item-icon:not([hidden]) {
     display: block;

--- a/ext/mixed/js/display-audio.js
+++ b/ext/mixed/js/display-audio.js
@@ -112,7 +112,7 @@ class DisplayAudio {
 
         const {expression, reading} = expressionReading;
         const audioOptions = this._getAudioOptions();
-        const {textToSpeechVoice, customSourceUrl, volume} = audioOptions;
+        const {textToSpeechVoice, customSourceUrl, customSourceType, volume} = audioOptions;
         if (!Array.isArray(sources)) {
             ({sources} = audioOptions);
         }
@@ -126,7 +126,7 @@ class DisplayAudio {
             // Create audio
             let audio;
             let title;
-            const info = await this._createExpressionAudio(sources, sourceDetailsMap, expression, reading, {textToSpeechVoice, customSourceUrl});
+            const info = await this._createExpressionAudio(sources, sourceDetailsMap, expression, reading, {textToSpeechVoice, customSourceUrl, customSourceType});
             if (info !== null) {
                 let source;
                 ({audio, source} = info);

--- a/ext/mixed/js/display-audio.js
+++ b/ext/mixed/js/display-audio.js
@@ -520,13 +520,13 @@ class DisplayAudio {
             // Entry info
             entry.index = i;
 
-            const {audio, audioResolved, title} = infoList[i];
+            const {audio, audioResolved, info: {name}} = infoList[i];
             if (audioResolved) { entry.valid = (audio !== null); }
 
             const labelNode = entry.node.querySelector('.popup-menu-item-label');
             let label = defaultLabel;
             if (ii > 1) { label = `${label} ${i + 1}`; }
-            if (typeof title === 'string' && title.length > 0) { label += `: ${title}`; }
+            if (typeof name === 'string' && name.length > 0) { label += `: ${name}`; }
             labelNode.textContent = label;
         }
 

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1432,13 +1432,13 @@ class Display extends EventDispatcher {
     async _injectAnkiNoteMedia(definition, mode, options, fields) {
         const {
             anki: {screenshot: {format, quality}},
-            audio: {sources, customSourceUrl}
+            audio: {sources, customSourceUrl, customSourceType}
         } = options;
 
         const timestamp = Date.now();
         const ownerFrameId = this._ownerFrameId;
         const definitionDetails = this._getDefinitionDetailsForNote(definition);
-        const audioDetails = (mode !== 'kanji' && this._ankiNoteBuilder.containsMarker(fields, 'audio') ? {sources, customSourceUrl} : null);
+        const audioDetails = (mode !== 'kanji' && this._ankiNoteBuilder.containsMarker(fields, 'audio') ? {sources, customSourceUrl, customSourceType} : null);
         const screenshotDetails = (this._ankiNoteBuilder.containsMarker(fields, 'screenshot') ? {ownerFrameId, format, quality} : null);
         const clipboardDetails = {
             image: this._ankiNoteBuilder.containsMarker(fields, 'clipboard-image'),

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -304,6 +304,7 @@ function createProfileOptionsUpdatedTestData1() {
             volume: 100,
             autoPlay: false,
             customSourceUrl: '',
+            customSourceType: 'audio',
             textToSpeechVoice: ''
         },
         scanning: {


### PR DESCRIPTION
The custom audio URL can now point towards a JSON file, which is parsed for multiple audio URLs. The format of the JSON file is specified in this schema: [custom-audio-list-schema.json](https://github.com/FooSoft/yomichan/blob/master/ext/bg/data/custom-audio-list-schema.json).

Resolves #544.