### PR TITLE
Enable automatic updates for the firefox-dev release

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -235,6 +235,11 @@
                     "action": "set",
                     "path": ["browser_specific_settings", "gecko", "id"],
                     "value": "alex.testing@foosoft.net"
+                },
+                {
+                    "action": "set",
+                    "path": ["browser_specific_settings", "gecko", "update_url"],
+                    "value": "https://foosoft.net/projects/yomichan/dl/updates.json"
                 }
             ],
             "excludeFiles": [


### PR DESCRIPTION
@FooSoft Let me know if you think we should add this field to the standard `firefox` build target. I assume it won't affect the store deployment since the [Firefox information page](https://extensionworkshop.com/documentation/manage/updating-your-extension/) states:

> Firefox supports automated updates to add-ons using JSON update manifests. Add-ons hosted on addons.mozilla.org (AMO) automatically receive updates to new versions posted there. Other add-ons must specify the location of their update manifests.

Resolves #830.