### PR TITLE
Clipboard lookup skip option

### DIFF
--- a/ext/bg/data/options-schema.json
+++ b/ext/bg/data/options-schema.json
@@ -115,7 +115,8 @@
                                     "maximumClipboardSearchLength",
                                     "popupCurrentIndicatorMode",
                                     "popupActionBarVisibility",
-                                    "popupActionBarLocation"
+                                    "popupActionBarLocation",
+                                    "autoSearchClipboardContent"
                                 ],
                                 "properties": {
                                     "enable": {
@@ -286,6 +287,10 @@
                                         "type": "string",
                                         "enum": ["left", "right", "top", "bottom"],
                                         "default": "top"
+                                    },
+                                    "autoSearchClipboardContent": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             },

--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -668,6 +668,8 @@ class OptionsUtil {
         //  Added popupWindow.
         //  Updated handlebars templates to include "stroke-count" definition.
         //  Updated global.useSettingsV2 to be true (opt-out).
+        //  Added audio.customSourceType.
+        //  Added general.autoSearchClipboardContent.
         await this._addFieldTemplatesToOptions(options, '/bg/data/anki-field-templates-upgrade-v8.handlebars');
         options.global.useSettingsV2 = true;
         for (const profile of options.profiles) {
@@ -727,6 +729,7 @@ class OptionsUtil {
                 windowState: 'normal'
             };
             profile.options.audio.customSourceType = 'audio';
+            profile.options.general.autoSearchClipboardContent = true;
         }
         return options;
     }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -159,12 +159,12 @@ class DisplaySearch extends Display {
         e.preventDefault();
         e.stopImmediatePropagation();
         this.blurElement(e.currentTarget);
-        this._search(true, true);
+        this._search(true, true, true);
     }
 
     _onSearch(e) {
         e.preventDefault();
-        this._search(true, true);
+        this._search(true, true, true);
     }
 
     _onCopy() {
@@ -173,12 +173,12 @@ class DisplaySearch extends Display {
     }
 
     _onExternalSearchUpdate({text, animate=true}) {
-        const {general: {maximumClipboardSearchLength}} = this.getOptions();
+        const {general: {maximumClipboardSearchLength, autoSearchClipboardContent}} = this.getOptions();
         if (text.length > maximumClipboardSearchLength) {
             text = text.substring(0, maximumClipboardSearchLength);
         }
         this._queryInput.value = text;
-        this._search(animate, false);
+        this._search(animate, false, autoSearchClipboardContent);
     }
 
     _onWanakanaEnableChange(e) {
@@ -323,7 +323,7 @@ class DisplaySearch extends Display {
         });
     }
 
-    _search(animate, history) {
+    _search(animate, history, lookup) {
         const query = this._queryInput.value;
         const depth = this.depth;
         const url = window.location.href;
@@ -346,6 +346,7 @@ class DisplaySearch extends Display {
                 animate
             }
         };
+        if (!lookup) { details.params.lookup = 'false'; }
         this.setContent(details);
     }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -130,7 +130,7 @@ class DisplaySearch extends Display {
             case 'terms':
             case 'kanji':
                 animate = !!content.animate;
-                valid = content.definitions.length > 0;
+                valid = (typeof source === 'string' && source.length > 0);
                 this.blurElement(this._queryInput);
                 break;
             case 'clear':

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -993,6 +993,29 @@
         </div></div>
         <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
+                <div class="settings-item-label">Clipboard text search mode</div>
+                <div class="settings-item-description">Change how the search page reacts to new text in the clipboard.</div>
+            </div>
+            <div class="settings-item-right">
+                <select data-setting="general.autoSearchClipboardContent"
+                    data-transform='[
+                        {
+                            "step": "pre",
+                            "type": "toBoolean"
+                        },
+                        {
+                            "step": "post",
+                            "type": "toString"
+                        }
+                    ]'
+                >
+                    <option value="true">Search for definitions</option>
+                    <option value="false">Update search query only</option>
+                </select>
+            </div>
+        </div></div>
+        <div class="settings-item"><div class="settings-item-inner settings-item-inner-wrappable">
+            <div class="settings-item-left">
                 <div class="settings-item-label">Size</div>
                 <div class="settings-item-description">Control the size of the window, in pixels.</div>
             </div>

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -558,7 +558,8 @@ class Display extends EventDispatcher {
                         let queryFull = urlSearchParams.get('full');
                         queryFull = (queryFull !== null ? this.postProcessQuery(queryFull) : query);
                         const wildcardsEnabled = (urlSearchParams.get('wildcards') !== 'off');
-                        await this._setContentTermsOrKanji(token, isTerms, query, queryFull, wildcardsEnabled, eventArgs);
+                        const lookup = (urlSearchParams.get('lookup') !== 'false');
+                        await this._setContentTermsOrKanji(token, isTerms, query, queryFull, lookup, wildcardsEnabled, eventArgs);
                     }
                     break;
                 case 'unloaded':
@@ -844,7 +845,7 @@ class Display extends EventDispatcher {
         }
     }
 
-    async _setContentTermsOrKanji(token, isTerms, query, queryFull, wildcardsEnabled, eventArgs) {
+    async _setContentTermsOrKanji(token, isTerms, query, queryFull, lookup, wildcardsEnabled, eventArgs) {
         let {state, content} = this._history;
         let changeHistory = false;
         if (!isObject(content)) {
@@ -874,7 +875,7 @@ class Display extends EventDispatcher {
 
         let {definitions} = content;
         if (!Array.isArray(definitions)) {
-            definitions = await this._findDefinitions(isTerms, query, wildcardsEnabled, optionsContext);
+            definitions = lookup ? await this._findDefinitions(isTerms, query, wildcardsEnabled, optionsContext) : [];
             if (this._setContentToken !== token) { return; }
             content.definitions = definitions;
             changeHistory = true;
@@ -899,7 +900,7 @@ class Display extends EventDispatcher {
         this._definitions = definitions;
 
         this._updateNavigation(this._history.hasPrevious(), this._history.hasNext());
-        this._setNoContentVisible(definitions.length === 0);
+        this._setNoContentVisible(definitions.length === 0 && lookup);
 
         const container = this._container;
         container.textContent = '';

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -296,7 +296,8 @@ function createProfileOptionsUpdatedTestData1() {
             maximumClipboardSearchLength: 1000,
             popupCurrentIndicatorMode: 'triangle',
             popupActionBarVisibility: 'auto',
-            popupActionBarLocation: 'top'
+            popupActionBarLocation: 'top',
+            autoSearchClipboardContent: true
         },
         audio: {
             enabled: true,


### PR DESCRIPTION
Adds an option `autoSearchClipboardContent` which can be used to disable the immediate lookup of text copied from the clipboard. The query parser is still updated.

Resolves #1311.