### PR TITLE
Fix clipboard monitor not persisting

### DIFF
--- a/ext/bg/js/options.js
+++ b/ext/bg/js/options.js
@@ -670,6 +670,7 @@ class OptionsUtil {
         //  Updated global.useSettingsV2 to be true (opt-out).
         //  Added audio.customSourceType.
         //  Added general.autoSearchClipboardContent.
+        //  Forced general.enableClipboardMonitor to false due to a bug which caused its value to not be read.
         await this._addFieldTemplatesToOptions(options, '/bg/data/anki-field-templates-upgrade-v8.handlebars');
         options.global.useSettingsV2 = true;
         for (const profile of options.profiles) {
@@ -730,6 +731,7 @@ class OptionsUtil {
             };
             profile.options.audio.customSourceType = 'audio';
             profile.options.general.autoSearchClipboardContent = true;
+            profile.options.general.enableClipboardMonitor = false;
         }
         return options;
     }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -54,6 +54,7 @@ class DisplaySearch extends Display {
         await this.updateOptions();
         yomichan.on('optionsUpdated', this._onOptionsUpdated.bind(this));
 
+        this.on('optionsUpdated', this._onDisplayOptionsUpdated.bind(this));
         this.on('contentUpdating', this._onContentUpdating.bind(this));
         this.on('modeChange', this._onModeChange.bind(this));
 
@@ -76,6 +77,7 @@ class DisplaySearch extends Display {
         this.hotkeyHandler.on('keydownNonHotkey', this._onKeyDown.bind(this));
 
         this._onModeChange();
+        this._onDisplayOptionsUpdated();
 
         this.initializeState();
 
@@ -121,6 +123,11 @@ class DisplaySearch extends Display {
         if (query) {
             this.searchLast();
         }
+    }
+
+    _onDisplayOptionsUpdated({options}) {
+        this._clipboardMonitorEnabled = options.general.enableClipboardMonitor;
+        this._updateClipboardMonitorEnabled();
     }
 
     _onContentUpdating({type, content, source}) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -313,6 +313,8 @@ class Display extends EventDispatcher {
 
         this._updateNestedFrontend(options);
         this._updateDefinitionTextScanner(options);
+
+        this.trigger('optionsUpdated', {options});
     }
 
     clearAutoPlayTimer() {


### PR DESCRIPTION
The _Clipboard monitor_ option on the search page did not persist properly. The value was written but never read.