### PR TITLE
Add info about a textarea display bug

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -51,3 +51,8 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: Chrome
 * **Date**: 2020-12-18
 * **Links**: [#455](https://github.com/FooSoft/yomichan/issues/455), [#1247](https://github.com/FooSoft/yomichan/issues/1247), [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1160302)
+
+## Textareas display incorrectly when they have an animated CSS transform
+* **Browser**: Chrome
+* **Date**: 2021-01-30
+* **Links**: [Demo](https://toasted-nutbread.github.io/chrome-textarea-transform-bug/), [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1172666)


### PR DESCRIPTION
This is a bug that primarily affects the Anki card templates textarea on the settings v2 page, during its initial "fade-in" transition, but may affect other textareas to a lesser extent, such as the custom CSS textareas.

Demo: https://toasted-nutbread.github.io/chrome-textarea-transform-bug/
Report: https://bugs.chromium.org/p/chromium/issues/detail?id=1172666