### PR TITLE
Native messaging optional permission

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -79,12 +79,12 @@
             "storage",
             "clipboardWrite",
             "unlimitedStorage",
-            "nativeMessaging",
             "webRequest",
             "webRequestBlocking"
         ],
         "optional_permissions": [
-            "clipboardRead"
+            "clipboardRead",
+            "nativeMessaging"
         ],
         "commands": {
             "toggleTextScanning": {
@@ -204,6 +204,16 @@
                             "strict_min_version": "57.0"
                         }
                     }
+                },
+                {
+                    "action": "remove",
+                    "path": ["optional_permissions"],
+                    "item": "nativeMessaging"
+                },
+                {
+                    "action": "add",
+                    "path": ["permissions"],
+                    "items": ["nativeMessaging"]
                 }
             ],
             "excludeFiles": [

--- a/docs/permissions.md
+++ b/docs/permissions.md
@@ -23,12 +23,6 @@
   Yomichan will sometimes need to inject stylesheets into webpages in order to
   properly display the search popup.
 
-* `nativeMessaging` <br>
-  Yomichan has the ability to communicate with an optional native messaging component in order to support
-  parsing large blocks of Japanese text using
-  [MeCab](https://en.wikipedia.org/wiki/MeCab).
-  The installation of this component is optional and is not included by default.
-
 * `clipboardWrite` <br>
   Yomichan supports simulating the `Ctrl+C` (copy to clipboard) keyboard shortcut
   when a definitions popup is open and focused.
@@ -38,3 +32,10 @@
   while the browser is running, depending on how certain settings are configured.
   This allows Yomichan to support scanning text from external applications, provided there is a way
   to copy text from those applications to the clipboard.
+
+* `nativeMessaging` (optional on Chrome) <br>
+  Yomichan has the ability to communicate with an optional native messaging component in order to support
+  parsing large blocks of Japanese text using
+  [MeCab](https://en.wikipedia.org/wiki/MeCab).
+  The installation of this component is optional and is not included by default.
+  This permission is optional on Chrome, but required on Firefox, because Firefox does not permit it to be optional.

--- a/ext/bg/js/permissions-main.js
+++ b/ext/bg/js/permissions-main.js
@@ -38,10 +38,32 @@ async function isAllowedFileSchemeAccess() {
     return await new Promise((resolve) => chrome.extension.isAllowedFileSchemeAccess(resolve));
 }
 
+function setupPermissionsToggles() {
+    const manifest = chrome.runtime.getManifest();
+    let optionalPermissions = manifest.optional_permissions;
+    if (!Array.isArray(optionalPermissions)) { optionalPermissions = []; }
+    optionalPermissions = new Set(optionalPermissions);
+
+    const hasAllPermisions = (set, values) => {
+        for (const value of values) {
+            if (!set.has(value)) { return false; }
+        }
+        return true;
+    };
+
+    for (const toggle of document.querySelectorAll('.permissions-toggle')) {
+        let permissions = toggle.dataset.requiredPermissions;
+        permissions = (typeof permissions === 'string' && permissions.length > 0 ? permissions.split(' ') : []);
+        toggle.disabled = !hasAllPermisions(optionalPermissions, permissions);
+    }
+}
+
 (async () => {
     try {
         const documentFocusController = new DocumentFocusController();
         documentFocusController.prepare();
+
+        setupPermissionsToggles();
 
         for (const node of document.querySelectorAll('.extension-id-example')) {
             node.textContent = chrome.runtime.getURL('/');

--- a/ext/bg/permissions.html
+++ b/ext/bg/permissions.html
@@ -86,17 +86,6 @@
         </div></div>
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
-                <div class="settings-item-label"><code>nativeMessaging</code></div>
-                <div class="settings-item-description">
-                    Yomichan has the ability to communicate with an optional native messaging component in order to support
-                    parsing large blocks of Japanese text using
-                    <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener noreferrer">MeCab</a>.
-                    The installation of this component is optional and is not included by default.
-                </div>
-            </div>
-        </div></div>
-        <div class="settings-item"><div class="settings-item-inner">
-            <div class="settings-item-left">
                 <div class="settings-item-label"><code>clipboardWrite</code></div>
                 <div class="settings-item-description">
                     Yomichan supports simulating the <code>Ctrl+C</code> (copy to clipboard) keyboard shortcut
@@ -115,7 +104,21 @@
                 </div>
             </div>
             <div class="settings-item-right">
-                <label class="toggle"><input type="checkbox" id="permission-checkbox-clipboard-read"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="clipboardRead"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
+        <div class="settings-item"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label"><code>nativeMessaging</code> <span class="light" data-show-for-browser="chrome edge">(optional)</span></div>
+                <div class="settings-item-description">
+                    Yomichan has the ability to communicate with an optional native messaging component in order to support
+                    parsing large blocks of Japanese text using
+                    <a href="https://en.wikipedia.org/wiki/MeCab" target="_blank" rel="noopener noreferrer">MeCab</a>.
+                    The installation of this component is optional and is not included by default.
+                </div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="nativeMessaging"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
         <div class="settings-item"><div class="settings-item-inner">
@@ -164,6 +167,10 @@
 <script src="/mixed/js/api.js"></script>
 
 <script src="/mixed/js/document-focus-controller.js"></script>
+<script src="/mixed/js/html-template-collection.js"></script>
+
+<script src="/bg/js/settings/permissions-toggle-controller.js"></script>
+<script src="/bg/js/settings/settings-controller.js"></script>
 
 <script src="/bg/js/permissions-main.js"></script>
 

--- a/ext/bg/settings.html
+++ b/ext/bg/settings.html
@@ -682,7 +682,7 @@
                 </div>
 
                 <div class="checkbox">
-                    <label><input type="checkbox" id="parsing-mecab-enable" data-setting="parsing.enableMecabParser"> Enable text parsing using MeCab</label>
+                    <label><input type="checkbox" id="parsing-mecab-enable" class="permissions-toggle" data-permissions-setting="parsing.enableMecabParser" data-required-permissions="nativeMessaging"> Enable text parsing using MeCab</label>
                 </div>
 
                 <div class="checkbox">

--- a/ext/bg/settings2.html
+++ b/ext/bg/settings2.html
@@ -1151,7 +1151,7 @@
                     </div>
                 </div>
                 <div class="settings-item-right">
-                    <label class="toggle"><input type="checkbox" data-setting="parsing.enableMecabParser"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                    <label class="toggle"><input type="checkbox" class="permissions-toggle" data-permissions-setting="parsing.enableMecabParser" data-required-permissions="nativeMessaging"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
                 </div>
             </div>
             <div class="settings-item-children more" hidden>

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -78,12 +78,12 @@
         "storage",
         "clipboardWrite",
         "unlimitedStorage",
-        "nativeMessaging",
         "webRequest",
         "webRequestBlocking"
     ],
     "optional_permissions": [
-        "clipboardRead"
+        "clipboardRead",
+        "nativeMessaging"
     ],
     "commands": {
         "toggleTextScanning": {


### PR DESCRIPTION
This change has two effects:
* The `nativeMessaging` permission is now optional on Chrome. On Firefox, it is still required because it cannot be optional.
* The permissions page will now automatically update toggles if permissions are changed from another source.