### PR TITLE
Improve popup window ownership

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1507,17 +1507,17 @@ class Backend {
         return isValidTab ? tab : null;
     }
 
-    async _getScreenshot(windowId, tabId, ownerFrameId, format, quality) {
+    async _getScreenshot(windowId, tabId, frameId, format, quality) {
         if (typeof windowId !== 'number') {
             throw new Error('Invalid window ID');
         }
 
         let token = null;
         try {
-            if (typeof tabId === 'number' && typeof ownerFrameId === 'number') {
+            if (typeof tabId === 'number' && typeof frameId === 'number') {
                 const action = 'setAllVisibleOverride';
                 const params = {value: false, priority: 0, awaitFrame: true};
-                token = await this._sendMessageTabPromise(tabId, {action, params}, {frameId: ownerFrameId});
+                token = await this._sendMessageTabPromise(tabId, {action, params}, {frameId});
             }
 
             return await new Promise((resolve, reject) => {
@@ -1535,7 +1535,7 @@ class Backend {
                 const action = 'clearAllVisibleOverride';
                 const params = {token};
                 try {
-                    await this._sendMessageTabPromise(tabId, {action, params}, {frameId: ownerFrameId});
+                    await this._sendMessageTabPromise(tabId, {action, params}, {frameId});
                 } catch (e) {
                     // NOP
                 }
@@ -1636,8 +1636,8 @@ class Backend {
     }
 
     async _injectAnkNoteScreenshot(ankiConnect, timestamp, definitionDetails, details) {
-        const {windowId, tabId, ownerFrameId, format, quality} = details;
-        const dataUrl = await this._getScreenshot(windowId, tabId, ownerFrameId, format, quality);
+        const {windowId, tabId, frameId, format, quality} = details;
+        const dataUrl = await this._getScreenshot(windowId, tabId, frameId, format, quality);
 
         const {mediaType, data} = this._getDataUrlInfo(dataUrl);
         const extension = this._mediaUtility.getFileExtensionFromImageMediaType(mediaType);

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -525,8 +525,10 @@ class Backend {
     }
 
     _onApiFrameInformationGet(params, sender) {
+        const tab = sender.tab;
+        const tabId = tab ? tab.id : void 0;
         const frameId = sender.frameId;
-        return Promise.resolve({frameId});
+        return Promise.resolve({tabId, frameId});
     }
 
     _onApiInjectStylesheet({type, value}, sender) {

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -32,12 +32,14 @@
         api.forwardLogsToBackend();
         await yomichan.backendReady();
 
+        const {tabId, frameId} = await api.frameInformationGet();
+
         const japaneseUtil = new JapaneseUtil(wanakana);
 
         const hotkeyHandler = new HotkeyHandler();
         hotkeyHandler.prepare();
 
-        const displaySearch = new DisplaySearch(japaneseUtil, documentFocusController, hotkeyHandler);
+        const displaySearch = new DisplaySearch(tabId, frameId, japaneseUtil, documentFocusController, hotkeyHandler);
         await displaySearch.prepare();
 
         document.documentElement.dataset.loaded = 'true';

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -354,7 +354,7 @@ class DisplaySearch extends Display {
             content: {
                 definitions: null,
                 animate,
-                owner: {
+                contentOrigin: {
                     tabId: this.tabId,
                     frameId: this.frameId
                 }

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -23,8 +23,8 @@
  */
 
 class DisplaySearch extends Display {
-    constructor(japaneseUtil, documentFocusController, hotkeyHandler) {
-        super('search', japaneseUtil, documentFocusController, hotkeyHandler);
+    constructor(tabId, frameId, japaneseUtil, documentFocusController, hotkeyHandler) {
+        super('search', tabId, frameId, japaneseUtil, documentFocusController, hotkeyHandler);
         this._searchButton = document.querySelector('#search-button');
         this._queryInput = document.querySelector('#search-textbox');
         this._introElement = document.querySelector('#intro');

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -353,7 +353,11 @@ class DisplaySearch extends Display {
             },
             content: {
                 definitions: null,
-                animate
+                animate,
+                owner: {
+                    tabId: this.tabId,
+                    frameId: this.frameId
+                }
             }
         };
         if (!lookup) { details.params.lookup = 'false'; }

--- a/ext/bg/js/settings/popup-preview-frame-main.js
+++ b/ext/bg/js/settings/popup-preview-frame-main.js
@@ -26,7 +26,7 @@
     try {
         api.forwardLogsToBackend();
 
-        const {frameId} = await api.frameInformationGet();
+        const {tabId, frameId} = await api.frameInformationGet();
 
         const hotkeyHandler = new HotkeyHandler();
         hotkeyHandler.prepare();
@@ -34,7 +34,7 @@
         const popupFactory = new PopupFactory(frameId);
         popupFactory.prepare();
 
-        const preview = new PopupPreviewFrame(frameId, popupFactory, hotkeyHandler);
+        const preview = new PopupPreviewFrame(tabId, frameId, popupFactory, hotkeyHandler);
         await preview.prepare();
 
         document.documentElement.dataset.loaded = 'true';

--- a/ext/bg/js/settings/popup-preview-frame.js
+++ b/ext/bg/js/settings/popup-preview-frame.js
@@ -23,7 +23,8 @@
  */
 
 class PopupPreviewFrame {
-    constructor(frameId, popupFactory, hotkeyHandler) {
+    constructor(tabId, frameId, popupFactory, hotkeyHandler) {
+        this._tabId = tabId;
         this._frameId = frameId;
         this._popupFactory = popupFactory;
         this._hotkeyHandler = hotkeyHandler;
@@ -67,6 +68,7 @@ class PopupPreviewFrame {
 
         // Overwrite frontend
         this._frontend = new Frontend({
+            tabId: this._tabId,
             frameId: this._frameId,
             popupFactory: this._popupFactory,
             depth: 0,

--- a/ext/fg/js/content-script-main.js
+++ b/ext/fg/js/content-script-main.js
@@ -27,7 +27,7 @@
         api.forwardLogsToBackend();
         await yomichan.backendReady();
 
-        const {frameId} = await api.frameInformationGet();
+        const {tabId, frameId} = await api.frameInformationGet();
         if (typeof frameId !== 'number') {
             throw new Error('Failed to get frameId');
         }
@@ -39,6 +39,7 @@
         popupFactory.prepare();
 
         const frontend = new Frontend({
+            tabId,
             frameId,
             popupFactory,
             depth: 0,

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -32,12 +32,14 @@
         api.forwardLogsToBackend();
         await yomichan.backendReady();
 
+        const {tabId, frameId} = await api.frameInformationGet();
+
         const japaneseUtil = new JapaneseUtil(null);
 
         const hotkeyHandler = new HotkeyHandler();
         hotkeyHandler.prepare();
 
-        const display = new Display('popup', japaneseUtil, documentFocusController, hotkeyHandler);
+        const display = new Display(tabId, frameId, 'popup', japaneseUtil, documentFocusController, hotkeyHandler);
         await display.prepare();
         const displayProfileSelection = new DisplayProfileSelection(display);
         displayProfileSelection.prepare();

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -539,7 +539,11 @@ class Frontend {
                 documentTitle
             },
             content: {
-                definitions
+                definitions,
+                owner: {
+                    tabId: this._tabId,
+                    frameId: this._frameId
+                }
             }
         };
         if (textSource instanceof TextSourceElement && textSource.fullContent !== query) {

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -28,6 +28,7 @@ class Frontend {
         pageType,
         popupFactory,
         depth,
+        tabId,
         frameId,
         parentPopupId,
         parentFrameId,
@@ -40,6 +41,7 @@ class Frontend {
         this._pageType = pageType;
         this._popupFactory = popupFactory;
         this._depth = depth;
+        this._tabId = tabId;
         this._frameId = frameId;
         this._parentPopupId = parentPopupId;
         this._parentFrameId = parentFrameId;

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -439,7 +439,6 @@ class Frontend {
 
         return await this._popupFactory.getOrCreatePopup({
             frameId: this._frameId,
-            ownerFrameId: this._frameId,
             depth: this._depth,
             childrenSupported: this._childrenSupported
         });
@@ -448,7 +447,6 @@ class Frontend {
     async _getProxyPopup() {
         return await this._popupFactory.getOrCreatePopup({
             frameId: this._parentFrameId,
-            ownerFrameId: this._frameId,
             depth: this._depth,
             parentPopupId: this._parentPopupId,
             childrenSupported: this._childrenSupported
@@ -471,7 +469,6 @@ class Frontend {
 
         const popup = await this._popupFactory.getOrCreatePopup({
             frameId: targetFrameId,
-            ownerFrameId: this._frameId,
             id: popupId,
             childrenSupported: this._childrenSupported
         });
@@ -484,7 +481,6 @@ class Frontend {
 
     async _getPopupWindow() {
         return await this._popupFactory.getOrCreatePopup({
-            ownerFrameId: this._frameId,
             depth: this._depth,
             popupWindow: true,
             childrenSupported: this._childrenSupported

--- a/ext/fg/js/frontend.js
+++ b/ext/fg/js/frontend.js
@@ -536,7 +536,7 @@ class Frontend {
             },
             content: {
                 definitions,
-                owner: {
+                contentOrigin: {
                     tabId: this._tabId,
                     frameId: this._frameId
                 }

--- a/ext/fg/js/popup-factory.js
+++ b/ext/fg/js/popup-factory.js
@@ -56,7 +56,6 @@ class PopupFactory {
 
     async getOrCreatePopup({
         frameId=null,
-        ownerFrameId=null,
         id=null,
         parentPopupId=null,
         depth=null,
@@ -103,8 +102,7 @@ class PopupFactory {
             const popup = new PopupWindow({
                 id,
                 depth,
-                frameId: this._frameId,
-                ownerFrameId
+                frameId: this._frameId
             });
             this._popups.set(id, popup);
             return popup;
@@ -117,7 +115,6 @@ class PopupFactory {
                 id,
                 depth,
                 frameId: this._frameId,
-                ownerFrameId,
                 childrenSupported
             });
             if (parent !== null) {
@@ -139,14 +136,12 @@ class PopupFactory {
                 id,
                 parentPopupId,
                 frameId,
-                ownerFrameId,
                 childrenSupported
             }));
             const popup = new PopupProxy({
                 id,
                 depth,
                 frameId,
-                ownerFrameId,
                 frameOffsetForwarder: useFrameOffsetForwarder ? this._frameOffsetForwarder : null
             });
             this._popups.set(id, popup);

--- a/ext/fg/js/popup-proxy.js
+++ b/ext/fg/js/popup-proxy.js
@@ -24,14 +24,12 @@ class PopupProxy extends EventDispatcher {
         id,
         depth,
         frameId,
-        ownerFrameId,
         frameOffsetForwarder
     }) {
         super();
         this._id = id;
         this._depth = depth;
         this._frameId = frameId;
-        this._ownerFrameId = ownerFrameId;
         this._frameOffsetForwarder = frameOffsetForwarder;
 
         this._frameOffset = [0, 0];

--- a/ext/fg/js/popup-window.js
+++ b/ext/fg/js/popup-window.js
@@ -23,14 +23,12 @@ class PopupWindow extends EventDispatcher {
     constructor({
         id,
         depth,
-        frameId,
-        ownerFrameId
+        frameId
     }) {
         super();
         this._id = id;
         this._depth = depth;
         this._frameId = frameId;
-        this._ownerFrameId = ownerFrameId;
         this._popupTabId = null;
     }
 

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -275,7 +275,6 @@ class Popup extends EventDispatcher {
             depth: this._depth,
             parentPopupId: this._id,
             parentFrameId: this._frameId,
-            ownerFrameId: this._ownerFrameId,
             childrenSupported: this._childrenSupported,
             scale: this._contentScale,
             optionsContext: this._optionsContext

--- a/ext/fg/js/popup.js
+++ b/ext/fg/js/popup.js
@@ -27,14 +27,12 @@ class Popup extends EventDispatcher {
         id,
         depth,
         frameId,
-        ownerFrameId,
         childrenSupported
     }) {
         super();
         this._id = id;
         this._depth = depth;
         this._frameId = frameId;
-        this._ownerFrameId = ownerFrameId;
         this._childrenSupported = childrenSupported;
         this._parent = null;
         this._child = null;

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1539,10 +1539,10 @@ class Display extends EventDispatcher {
         } = options;
 
         const timestamp = Date.now();
-        const ownerFrameId = this._ownerFrameId;
+        const screenshotFrameId = this._ownerFrameId;
         const definitionDetails = this._getDefinitionDetailsForNote(definition);
         const audioDetails = (mode !== 'kanji' && this._ankiNoteBuilder.containsMarker(fields, 'audio') ? {sources, customSourceUrl, customSourceType} : null);
-        const screenshotDetails = (this._ankiNoteBuilder.containsMarker(fields, 'screenshot') ? {ownerFrameId, format, quality} : null);
+        const screenshotDetails = (this._ankiNoteBuilder.containsMarker(fields, 'screenshot') ? {frameId: screenshotFrameId, format, quality} : null);
         const clipboardDetails = {
             image: this._ankiNoteBuilder.containsMarker(fields, 'clipboard-image'),
             text: this._ankiNoteBuilder.containsMarker(fields, 'clipboard-text')

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -1655,10 +1655,10 @@ class Display extends EventDispatcher {
     }
 
     async _invokeContentOrigin(action, params={}) {
-        if (this._contentOriginFrameId === null) {
-            throw new Error('No content origin');
+        if (this._contentOriginTabId === this._tabId && this._contentOriginFrameId === this._frameId) {
+            throw new Error('Content origin is same page');
         }
-        return await api.crossFrame.invoke(this._contentOriginFrameId, action, params);
+        return await api.crossFrame.invokeTab(this._contentOriginTabId, this._contentOriginFrameId, action, params);
     }
 
     _copyHostSelection() {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -36,8 +36,10 @@
  */
 
 class Display extends EventDispatcher {
-    constructor(pageType, japaneseUtil, documentFocusController, hotkeyHandler) {
+    constructor(tabId, frameId, pageType, japaneseUtil, documentFocusController, hotkeyHandler) {
         super();
+        this._tabId = tabId;
+        this._frameId = frameId;
         this._pageType = pageType;
         this._japaneseUtil = japaneseUtil;
         this._documentFocusController = documentFocusController;
@@ -197,6 +199,14 @@ class Display extends EventDispatcher {
 
     get progressIndicatorVisible() {
         return this._progressIndicatorVisible;
+    }
+
+    get tabId() {
+        return this._tabId;
+    }
+
+    get frameId() {
+        return this._frameId;
     }
 
     async prepare() {
@@ -1583,8 +1593,6 @@ class Display extends EventDispatcher {
             parentFrameId: this._parentFrameId
         };
 
-        const {frameId} = await api.frameInformationGet();
-
         await dynamicLoader.loadScripts([
             '/mixed/js/text-scanner.js',
             '/mixed/js/frame-client.js',
@@ -1597,12 +1605,13 @@ class Display extends EventDispatcher {
             '/fg/js/frontend.js'
         ]);
 
-        const popupFactory = new PopupFactory(frameId);
+        const popupFactory = new PopupFactory(this._frameId);
         popupFactory.prepare();
 
         Object.assign(setupNestedPopupsOptions, {
             depth: this._depth + 1,
-            frameId,
+            tabId: this._tabId,
+            frameId: this._frameId,
             popupFactory,
             pageType: this._pageType,
             allowRootFramePopupProxy: true,


### PR DESCRIPTION
Ownership terminology is changed to "content origin", and this value is updated whenever the content is assigned, rather than on the `'configure'` initialization event. This should make the origin more accurately track where the content is coming from, particularly for popups which target the same frame.