### PR TITLE
Search decouple

### DIFF
--- a/ext/bg/js/search-display-controller.js
+++ b/ext/bg/js/search-display-controller.js
@@ -17,7 +17,6 @@
 
 /* global
  * ClipboardMonitor
- * Display
  * api
  * wanakana
  */

--- a/ext/bg/js/search-display-controller.js
+++ b/ext/bg/js/search-display-controller.js
@@ -22,7 +22,7 @@
  * wanakana
  */
 
-class DisplaySearch {
+class SearchDisplayController {
     constructor(tabId, frameId, display, japaneseUtil) {
         this._tabId = tabId;
         this._frameId = frameId;

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -43,7 +43,7 @@
         const display = new Display(tabId, frameId, 'search', japaneseUtil, documentFocusController, hotkeyHandler);
         await display.prepare();
 
-        const displaySearch = new DisplaySearch(display, japaneseUtil);
+        const displaySearch = new DisplaySearch(tabId, frameId, display, japaneseUtil);
         await displaySearch.prepare();
 
         display.initializeState();

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -46,7 +46,10 @@
         const displaySearch = new DisplaySearch(display, japaneseUtil);
         await displaySearch.prepare();
 
+        display.initializeState();
+
         document.documentElement.dataset.loaded = 'true';
+
         yomichan.ready();
     } catch (e) {
         yomichan.logError(e);

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -17,7 +17,7 @@
 
 /* global
  * Display
- * DisplaySearch
+ * SearchDisplayController
  * DocumentFocusController
  * HotkeyHandler
  * JapaneseUtil
@@ -43,8 +43,8 @@
         const display = new Display(tabId, frameId, 'search', japaneseUtil, documentFocusController, hotkeyHandler);
         await display.prepare();
 
-        const displaySearch = new DisplaySearch(tabId, frameId, display, japaneseUtil);
-        await displaySearch.prepare();
+        const searchDisplayController = new SearchDisplayController(tabId, frameId, display, japaneseUtil);
+        await searchDisplayController.prepare();
 
         display.initializeState();
 

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * Display
  * DisplaySearch
  * DocumentFocusController
  * HotkeyHandler
@@ -39,7 +40,10 @@
         const hotkeyHandler = new HotkeyHandler();
         hotkeyHandler.prepare();
 
-        const displaySearch = new DisplaySearch(tabId, frameId, japaneseUtil, documentFocusController, hotkeyHandler);
+        const display = new Display(tabId, frameId, 'search', japaneseUtil, documentFocusController, hotkeyHandler);
+        await display.prepare();
+
+        const displaySearch = new DisplaySearch(display, japaneseUtil);
         await displaySearch.prepare();
 
         document.documentElement.dataset.loaded = 'true';

--- a/ext/bg/js/search-main.js
+++ b/ext/bg/js/search-main.js
@@ -17,10 +17,10 @@
 
 /* global
  * Display
- * SearchDisplayController
  * DocumentFocusController
  * HotkeyHandler
  * JapaneseUtil
+ * SearchDisplayController
  * api
  * wanakana
  */

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -32,7 +32,6 @@ class DisplaySearch {
         this._wanakanaEnableCheckbox = document.querySelector('#wanakana-enable');
         this._queryInputEvents = new EventListenerCollection();
         this._wanakanaEnabled = false;
-        this._isPrepared = false;
         this._introVisible = true;
         this._introAnimationTimer = null;
         this._clipboardMonitorEnabled = false;
@@ -78,8 +77,6 @@ class DisplaySearch {
 
         this._onModeChange();
         this._onDisplayOptionsUpdated({options: this._display.getOptions()});
-
-        this._isPrepared = true;
     }
 
     // Actions

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -79,8 +79,6 @@ class DisplaySearch {
         this._onModeChange();
         this._onDisplayOptionsUpdated({options: this._display.getOptions()});
 
-        this._display.initializeState();
-
         this._isPrepared = true;
     }
 

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -23,8 +23,8 @@
  */
 
 class DisplaySearch {
-    constructor(tabId, frameId, japaneseUtil, documentFocusController, hotkeyHandler) {
-        this._display = new Display(tabId, frameId, 'search', japaneseUtil, documentFocusController, hotkeyHandler);
+    constructor(display, japaneseUtil) {
+        this._display = display;
         this._searchButton = document.querySelector('#search-button');
         this._queryInput = document.querySelector('#search-textbox');
         this._introElement = document.querySelector('#intro');
@@ -42,29 +42,27 @@ class DisplaySearch {
                 getText: async () => (await api.clipboardGet())
             }
         });
-        this._display.autoPlayAudioDelay = 0;
-
-        this._display.hotkeyHandler.registerActions([
-            ['focusSearchBox', this._onActionFocusSearchBox.bind(this)]
-        ]);
     }
 
     async prepare() {
-        await this._display.prepare();
         await this._display.updateOptions();
+
         yomichan.on('optionsUpdated', this._onOptionsUpdated.bind(this));
 
         this._display.on('optionsUpdated', this._onDisplayOptionsUpdated.bind(this));
         this._display.on('contentUpdating', this._onContentUpdating.bind(this));
         this._display.on('modeChange', this._onModeChange.bind(this));
 
+        this._display.hotkeyHandler.registerActions([
+            ['focusSearchBox', this._onActionFocusSearchBox.bind(this)]
+        ]);
         this._display.registerMessageHandlers([
             ['updateSearchQuery', {async: false, handler: this._onExternalSearchUpdate.bind(this)}]
         ]);
 
+        this._display.autoPlayAudioDelay = 0;
         this._display.queryParserVisible = true;
         this._display.setHistorySettings({useBrowserHistory: true});
-
         this._display.setQueryPostProcessor(this._postProcessQuery.bind(this));
 
         const enableWanakana = !!this._display.getOptions().general.enableWanakana;

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -23,7 +23,9 @@
  */
 
 class DisplaySearch {
-    constructor(display, japaneseUtil) {
+    constructor(tabId, frameId, display, japaneseUtil) {
+        this._tabId = tabId;
+        this._frameId = frameId;
         this._display = display;
         this._searchButton = document.querySelector('#search-button');
         this._queryInput = document.querySelector('#search-textbox');
@@ -340,8 +342,8 @@ class DisplaySearch {
                 definitions: null,
                 animate,
                 contentOrigin: {
-                    tabId: this._display.tabId,
-                    frameId: this._display.frameId
+                    tabId: this.tabId,
+                    frameId: this.frameId
                 }
             }
         };

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -31,6 +31,7 @@ class DisplaySearch {
         this._clipboardMonitorEnableCheckbox = document.querySelector('#clipboard-monitor-enable');
         this._wanakanaEnableCheckbox = document.querySelector('#wanakana-enable');
         this._queryInputEvents = new EventListenerCollection();
+        this._queryInputEventsSetup = false;
         this._wanakanaEnabled = false;
         this._introVisible = true;
         this._introAnimationTimer = null;
@@ -63,10 +64,6 @@ class DisplaySearch {
         this._display.queryParserVisible = true;
         this._display.setHistorySettings({useBrowserHistory: true});
         this._display.setQueryPostProcessor(this._postProcessQuery.bind(this));
-
-        const enableWanakana = !!this._display.getOptions().general.enableWanakana;
-        this._wanakanaEnableCheckbox.checked = enableWanakana;
-        this._setWanakanaEnabled(enableWanakana);
 
         this._searchButton.addEventListener('click', this._onSearch.bind(this), false);
         this._wanakanaEnableCheckbox.addEventListener('change', this._onWanakanaEnableChange.bind(this));
@@ -112,6 +109,10 @@ class DisplaySearch {
     _onDisplayOptionsUpdated({options}) {
         this._clipboardMonitorEnabled = options.clipboard.enableSearchPageMonitor;
         this._updateClipboardMonitorEnabled();
+
+        const enableWanakana = !!this._display.getOptions().general.enableWanakana;
+        this._wanakanaEnableCheckbox.checked = enableWanakana;
+        this._setWanakanaEnabled(enableWanakana);
     }
 
     _onContentUpdating({type, content, source}) {
@@ -200,21 +201,21 @@ class DisplaySearch {
     }
 
     _setWanakanaEnabled(enabled) {
+        if (this._queryInputEventsSetup && this._wanakanaEnabled === enabled) { return; }
+
         const input = this._queryInput;
         this._queryInputEvents.removeAllEventListeners();
-
         this._queryInputEvents.addEventListener(input, 'keydown', this._onSearchKeydown.bind(this), false);
 
-        if (this._wanakanaEnabled !== enabled) {
-            this._wanakanaEnabled = enabled;
-            if (enabled) {
-                wanakana.bind(input);
-            } else {
-                wanakana.unbind(input);
-            }
+        this._wanakanaEnabled = enabled;
+        if (enabled) {
+            wanakana.bind(input);
+        } else {
+            wanakana.unbind(input);
         }
 
         this._queryInputEvents.addEventListener(input, 'input', this._onSearchInput.bind(this), false);
+        this._queryInputEventsSetup = true;
     }
 
     _setIntroVisible(visible, animate) {

--- a/ext/bg/js/search.js
+++ b/ext/bg/js/search.js
@@ -65,6 +65,8 @@ class DisplaySearch extends Display {
         this.queryParserVisible = true;
         this.setHistorySettings({useBrowserHistory: true});
 
+        this.setQueryPostProcessor(this._postProcessQuery.bind(this));
+
         const enableWanakana = !!this.getOptions().general.enableWanakana;
         this._wanakanaEnableCheckbox.checked = enableWanakana;
         this._setWanakanaEnabled(enableWanakana);
@@ -82,17 +84,6 @@ class DisplaySearch extends Display {
         this.initializeState();
 
         this._isPrepared = true;
-    }
-
-    postProcessQuery(query) {
-        if (this._wanakanaEnabled) {
-            try {
-                query = this._japaneseUtil.convertToKana(query);
-            } catch (e) {
-                // NOP
-            }
-        }
-        return query;
     }
 
     // Actions
@@ -374,5 +365,16 @@ class DisplaySearch extends Display {
         if (shrink || scrollHeight >= currentHeight - 1) {
             node.style.height = `${scrollHeight}px`;
         }
+    }
+
+    _postProcessQuery(query) {
+        if (this._wanakanaEnabled) {
+            try {
+                query = this._japaneseUtil.convertToKana(query);
+            } catch (e) {
+                // NOP
+            }
+        }
+        return query;
     }
 }

--- a/ext/bg/search.html
+++ b/ext/bg/search.html
@@ -109,7 +109,7 @@
 
 <script src="/bg/js/query-parser.js"></script>
 <script src="/bg/js/clipboard-monitor.js"></script>
-<script src="/bg/js/search.js"></script>
+<script src="/bg/js/search-display-controller.js"></script>
 
 <script src="/bg/js/search-main.js"></script>
 

--- a/ext/fg/js/float-main.js
+++ b/ext/fg/js/float-main.js
@@ -41,9 +41,13 @@
 
         const display = new Display(tabId, frameId, 'popup', japaneseUtil, documentFocusController, hotkeyHandler);
         await display.prepare();
+
         const displayProfileSelection = new DisplayProfileSelection(display);
         displayProfileSelection.prepare();
+
         display.initializeState();
+
+        document.documentElement.dataset.loaded = 'true';
 
         yomichan.ready();
     } catch (e) {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -117,6 +117,7 @@ class Display extends EventDispatcher {
         this._displayAudio = new DisplayAudio(this);
         this._ankiNoteNotification = null;
         this._ankiNoteNotificationEventListeners = null;
+        this._queryPostProcessor = null;
 
         this._hotkeyHandler.registerActions([
             ['close',             () => { this._onHotkeyClose(); }],
@@ -405,8 +406,8 @@ class Display extends EventDispatcher {
         return data.data;
     }
 
-    postProcessQuery(query) {
-        return query;
+    setQueryPostProcessor(func) {
+        this._queryPostProcessor = func;
     }
 
     close() {
@@ -573,10 +574,10 @@ class Display extends EventDispatcher {
                         this._query = query;
                         clear = false;
                         const isTerms = (type === 'terms');
-                        query = this.postProcessQuery(query);
+                        query = this._postProcessQuery(query);
                         this._rawQuery = query;
                         let queryFull = urlSearchParams.get('full');
-                        queryFull = (queryFull !== null ? this.postProcessQuery(queryFull) : query);
+                        queryFull = (queryFull !== null ? this._postProcessQuery(queryFull) : query);
                         const wildcardsEnabled = (urlSearchParams.get('wildcards') !== 'off');
                         const lookup = (urlSearchParams.get('lookup') !== 'false');
                         await this._setContentTermsOrKanji(token, isTerms, query, queryFull, lookup, wildcardsEnabled, eventArgs);
@@ -1929,5 +1930,10 @@ class Display extends EventDispatcher {
             return true;
         }
         return false;
+    }
+
+    _postProcessQuery(query) {
+        const queryPostProcessor = this._queryPostProcessor;
+        return typeof queryPostProcessor === 'function' ? queryPostProcessor(query) : query;
     }
 }


### PR DESCRIPTION
`DisplaySearch` is now decoupled from `Display`. Dependency injection is used to pass `Display` to `SearchDisplayController` instead. This should make changes and other refactoring easier.

This also fixed an issue with the WanaKana toggle, where it wouldn't turn on/off properly when the options change.