### PR TITLE
Improve search page popup detection

### DIFF
--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -821,10 +821,11 @@ class Backend {
     }
 
     async _getOrCreateSearchPopup2() {
-        // Reuse same tab
+        // Use existing tab
         const baseUrl = chrome.runtime.getURL('/search.html');
+        const urlPredicate = (url) => url !== null && url.startsWith(baseUrl);
         if (this._searchPopupTabId !== null) {
-            const tab = await this._checkTabUrl(this._searchPopupTabId, (url) => url.startsWith(baseUrl));
+            const tab = await this._checkTabUrl(this._searchPopupTabId, urlPredicate);
             if (tab !== null) {
                 return {tab, created: false};
             }

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1403,35 +1403,6 @@ class Backend {
         }
     }
 
-    async _findTab(timeout, checkUrl) {
-        // This function works around the need to have the "tabs" permission to access tab.url.
-        const tabs = await this._getAllTabs();
-        const {promise: matchPromise, resolve: matchPromiseResolve} = deferPromise();
-
-        const checkTabUrl = ({tab, url}) => {
-            if (checkUrl(url, tab)) {
-                matchPromiseResolve(tab);
-            }
-        };
-
-        const promises = [];
-        for (const tab of tabs) {
-            const promise = this._getTabUrl(tab.id);
-            promise.then((url) => checkTabUrl({url, tab}));
-            promises.push(promise);
-        }
-
-        const racePromises = [
-            matchPromise,
-            Promise.all(promises).then(() => null)
-        ];
-        if (typeof timeout === 'number') {
-            racePromises.push(new Promise((resolve) => setTimeout(() => resolve(null), timeout)));
-        }
-
-        return await Promise.race(racePromises);
-    }
-
     async _focusTab(tab) {
         await new Promise((resolve, reject) => {
             chrome.tabs.update(tab.id, {active: true}, () => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -1333,9 +1333,22 @@ class Backend {
         return null;
     }
 
+    _getAllTabs() {
+        return new Promise((resolve, reject) => {
+            chrome.tabs.query({}, (tabs) => {
+                const e = chrome.runtime.lastError;
+                if (e) {
+                    reject(new Error(e.message));
+                } else {
+                    resolve(tabs);
+                }
+            });
+        });
+    }
+
     async _findTab(timeout, checkUrl) {
         // This function works around the need to have the "tabs" permission to access tab.url.
-        const tabs = await new Promise((resolve) => chrome.tabs.query({}, resolve));
+        const tabs = await this._getAllTabs();
         const {promise: matchPromise, resolve: matchPromiseResolve} = deferPromise();
 
         const checkTabUrl = ({tab, url}) => {

--- a/ext/bg/js/backend.js
+++ b/ext/bg/js/backend.js
@@ -737,7 +737,7 @@ class Backend {
             url += `?${queryString}`;
         }
 
-        const isTabMatch = (url2) => {
+        const predicate = ({url: url2}) => {
             if (url2 === null || !url2.startsWith(baseUrl)) { return false; }
             const parsedUrl = new URL(url2);
             const baseUrl2 = `${parsedUrl.origin}${parsedUrl.pathname}`;
@@ -746,7 +746,7 @@ class Backend {
         };
 
         const openInTab = async () => {
-            const tab = await this._findTab(1000, isTabMatch);
+            const tab = await this._findTabs(1000, false, predicate, false);
             if (tab !== null) {
                 await this._focusTab(tab);
                 if (queryParams.query) {
@@ -1905,7 +1905,8 @@ class Backend {
         switch (mode) {
             case 'existingOrNewTab':
                 if (useSettingsV2) {
-                    const tab = await this._findTab(1000, (url2) => (url2 !== null && url2.startsWith(url)));
+                    const predicate = ({url: url2}) => (url2 !== null && url2.startsWith(url));
+                    const tab = await this._findTabs(1000, false, predicate, false);
                     if (tab !== null) {
                         await this._focusTab(tab);
                     } else {

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -140,7 +140,7 @@ class Display extends EventDispatcher {
         ]);
         this.registerMessageHandlers([
             ['setMode', {async: false, handler: this._onMessageSetMode.bind(this)}],
-            ['getMode', {async: false, handler: this._onMessageGetMode.bind(this)}],
+            ['getMode', {async: false, handler: this._onMessageGetMode.bind(this)}]
         ]);
         this.registerDirectMessageHandlers([
             ['setOptionsContext',  {async: false, handler: this._onMessageSetOptionsContext.bind(this)}],

--- a/ext/mixed/js/display.js
+++ b/ext/mixed/js/display.js
@@ -139,7 +139,8 @@ class Display extends EventDispatcher {
             ['previousEntryDifferentDictionary', () => { this._focusEntryWithDifferentDictionary(-1, true); }]
         ]);
         this.registerMessageHandlers([
-            ['setMode', {async: false, handler: this._onMessageSetMode.bind(this)}]
+            ['setMode', {async: false, handler: this._onMessageSetMode.bind(this)}],
+            ['getMode', {async: false, handler: this._onMessageGetMode.bind(this)}],
         ]);
         this.registerDirectMessageHandlers([
             ['setOptionsContext',  {async: false, handler: this._onMessageSetOptionsContext.bind(this)}],
@@ -491,6 +492,10 @@ class Display extends EventDispatcher {
 
     _onMessageSetMode({mode}) {
         this._setMode(mode, true);
+    }
+
+    _onMessageGetMode() {
+        return this._mode;
     }
 
     _onMessageSetOptionsContext({optionsContext}) {


### PR DESCRIPTION
This allows the search page popup to be detected without previously knowing what the tab ID is. This will be necessary when using MV3, since the service worker can be unloaded, losing state.