### PR TITLE
Add information about communication port bugs

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -56,3 +56,13 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: Chrome
 * **Date**: 2021-01-30
 * **Links**: [Demo](https://toasted-nutbread.github.io/chrome-textarea-transform-bug/), [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1172666)
+
+## Chrome extensions using port connections can crash the browser using manifest version 3
+* **Browser**: Chrome
+* **Date**: 2021-02-13
+* **Links**: [Demo](https://github.com/toasted-nutbread/chrome-extension-port-connect-crash), [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1178179)
+
+## Chrome extension Port.onDisconnect event does not always fire in content scripts
+* **Browser**: Chrome
+* **Date**: 2021-02-13
+* **Links**: [Demo](https://github.com/toasted-nutbread/chrome-extension-port-disconnect-bug), [Report 1](https://bugs.chromium.org/p/chromium/issues/detail?id=1178188) (MV2), [Report 2](https://bugs.chromium.org/p/chromium/issues/detail?id=1178189) (MV3)


### PR DESCRIPTION
The following bugs have the potential to affect the extension, primarily in MV3 mode:

1. https://bugs.chromium.org/p/chromium/issues/detail?id=1178179
   This bug can cause the browser to crash when using ports; discovered while looking into the port disconnection issues below.
2. https://bugs.chromium.org/p/chromium/issues/detail?id=1178188 (MV2)
   https://bugs.chromium.org/p/chromium/issues/detail?id=1178189 (MV3)
   These are bugs related to `Port.onDisconnect` not firing properly. Separate issues for both manifest versions 2 and 3 since they exhibit different behaviour.

These issues cause the cross-frame/cross-tab communication system to break if the background page or service worker is reloaded or stopped, since the `Port.onDisconnect` event is not fired.