### PR TITLE
Fix user select all handling

### DIFF
--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -479,17 +479,18 @@ class DocumentUtil {
             return null;
         }
 
-        const range = document.createRange();
         const offset = (node.nodeType === Node.TEXT_NODE ? position.offset : 0);
+
         try {
+            const range = document.createRange();
             range.setStart(node, offset);
             range.setEnd(node, offset);
+            return range;
         } catch (e) {
             // Firefox throws new DOMException("The operation is insecure.")
             // when trying to select a node from within a ShadowRoot.
             return null;
         }
-        return range;
     }
 
     _caretRangeFromPointExt(x, y, elements) {

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -532,6 +532,10 @@ class DocumentUtil {
                         // Elements with user-select: all will return the element
                         // instead of a text point inside the element.
                         if (this._isElementUserSelectAll(node)) {
+                            if (previousStyles.has(node)) {
+                                // Recursive
+                                return null;
+                            }
                             nextElement = node;
                             continue;
                         }


### PR DESCRIPTION
On Firefox, [`caretPositionFromPoint`](https://developer.mozilla.org/en-US/docs/Web/API/DocumentOrShadowRoot/caretPositionFromPoint) will return the entire element instead of the text within the element.

Fixes #1435.