### PR TITLE
Fix a poorly handled edge case of the scanning parser

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1045,7 +1045,11 @@ class Backend {
                 text.substring(0, scanningLength),
                 findTermsOptions
             );
-            if (definitions.length > 0 && sourceLength > 0) {
+            if (
+                definitions.length > 0 &&
+                sourceLength > 0 &&
+                (sourceLength !== 1 || this._japaneseUtil.isCodePointJapanese(text[0]))
+            ) {
                 const {expression, reading} = definitions[0];
                 const source = text.substring(0, sourceLength);
                 for (const {text: text2, furigana} of jp.distributeFuriganaInflected(expression, reading, source)) {


### PR DESCRIPTION
Definitions that return a single non-Japanese character are skipped.

Old:

## <div id="query-parser-content" data-term-spacing="false"><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">試</span><span class="query-parser-char">作</span></span><rt class="query-parser-segment-reading">しさく</rt></ruby></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">・</span></span><rt class="query-parser-segment-reading">なかぐろ</rt></ruby></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">開</span><span class="query-parser-char">発</span></span><rt class="query-parser-segment-reading">かいはつ</rt></ruby></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">・</span></span><rt class="query-parser-segment-reading">なかぐろ</rt></ruby></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">評</span><span class="query-parser-char">価</span></span><rt class="query-parser-segment-reading">ひょうか</rt></ruby></span></div>

New:

## <div id="query-parser-content" data-term-spacing="false"><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">試</span><span class="query-parser-char">作</span></span><rt class="query-parser-segment-reading">しさく</rt></ruby></span><span class="query-parser-term" data-type="normal"><span class="query-parser-char">・</span></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">開</span><span class="query-parser-char">発</span></span><rt class="query-parser-segment-reading">かいはつ</rt></ruby></span><span class="query-parser-term" data-type="normal"><span class="query-parser-char">・</span></span><span class="query-parser-term" data-type="normal"><ruby class="query-parser-segment"><span class="query-parser-segment-text"><span class="query-parser-char">評</span><span class="query-parser-char">価</span></span><rt class="query-parser-segment-reading">ひょうか</rt></ruby></span></div>