### PR TITLE
Refactor translator merged mode

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -610,7 +610,7 @@ class Translator {
     _mergeByGlossary(definitions) {
         const glossaryDefinitionGroupMap = new Map();
         for (const definition of definitions) {
-            const {expression, reading, dictionary, glossary} = definition;
+            const {dictionary, glossary, expressions: [{expression, reading}]} = definition;
 
             const key = this._createMapKey([dictionary, ...glossary]);
             let group = glossaryDefinitionGroupMap.get(key);

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -500,7 +500,7 @@ class Translator {
 
         this._sortDefinitions(glossaryDefinitions);
 
-        const termDetailsList = this._createTermDetailsListFromTermInfoMap(allDefinitions);
+        const termDetailsList = this._createTermDetailsList(allDefinitions);
 
         return this._createMergedTermDefinition(
             source,
@@ -1191,7 +1191,7 @@ class Translator {
         const sourceTermExactMatchCount = this._getSourceTermMatchCountSum(definitions);
         const dictionaryNames = this._getUniqueDictionaryNames(definitions);
 
-        const termDetailsList = this._createTermDetailsListFromTermInfoMap(definitions);
+        const termDetailsList = this._createTermDetailsList(definitions);
 
         const definitionTags = this._getUniqueDefinitionTags(definitions);
         this._sortTags(definitionTags);
@@ -1227,7 +1227,7 @@ class Translator {
         };
     }
 
-    _createTermDetailsListFromTermInfoMap(definitions) {
+    _createTermDetailsList(definitions) {
         const termInfoMap = new Map();
         for (const {expression, reading, sourceTerm, furiganaSegments, termTags} of definitions) {
             let readingMap = termInfoMap.get(expression);

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -412,7 +412,7 @@ class Translator {
     }
 
     async _addSecondaryDefinitions(sequencedDefinitions, unsequencedDefinitions, enabledDictionaryMap, secondarySearchDictionaryMap) {
-        if (unsequencedDefinitions.length === 0 || secondarySearchDictionaryMap.size === 0) { return; }
+        if (unsequencedDefinitions.length === 0 && secondarySearchDictionaryMap.size === 0) { return; }
 
         const expressionList = [];
         const readingList = [];

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -371,7 +371,7 @@ class Translator {
                 if (typeof sequencedDefinition === 'undefined') {
                     sequencedDefinition = {
                         relatedDefinitions: [],
-                        relatedDefinitionIds: new Set(),
+                        definitionIds: new Set(),
                         secondaryDefinitions: []
                     };
                     sequencedDefinitionMap.set(sequence, sequencedDefinition);
@@ -379,7 +379,7 @@ class Translator {
                     sequenceList.push(sequence);
                 }
                 sequencedDefinition.relatedDefinitions.push(definition);
-                sequencedDefinition.relatedDefinitionIds.add(id);
+                sequencedDefinition.definitionIds.add(id);
             } else {
                 unsequencedDefinitions.set(id, definition);
             }
@@ -403,14 +403,14 @@ class Translator {
     async _addRelatedDefinitions(sequencedDefinitions, unsequencedDefinitions, sequenceList, mainDictionary, enabledDictionaryMap) {
         const databaseDefinitions = await this._database.findTermsBySequenceBulk(sequenceList, mainDictionary);
         for (const databaseDefinition of databaseDefinitions) {
-            const {relatedDefinitions, relatedDefinitionIds} = sequencedDefinitions[databaseDefinition.index];
+            const {relatedDefinitions, definitionIds} = sequencedDefinitions[databaseDefinition.index];
             const {id} = databaseDefinition;
-            if (relatedDefinitionIds.has(id)) { continue; }
+            if (definitionIds.has(id)) { continue; }
 
             const {source, rawSource, sourceTerm} = relatedDefinitions[0];
             const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, [], false, enabledDictionaryMap);
             relatedDefinitions.push(definition);
-            relatedDefinitionIds.add(id);
+            definitionIds.add(id);
             unsequencedDefinitions.delete(id);
         }
     }
@@ -446,12 +446,12 @@ class Translator {
             const {index, id} = databaseDefinition;
             const source = expressionList[index];
             const targets = targetsList[index];
-            for (const {relatedDefinitionIds, secondaryDefinitions} of targets) {
-                if (relatedDefinitionIds.has(id)) { continue; }
+            for (const {definitionIds, secondaryDefinitions} of targets) {
+                if (definitionIds.has(id)) { continue; }
 
                 const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, source, source, [], false, enabledDictionaryMap);
                 secondaryDefinitions.push(definition);
-                relatedDefinitionIds.add(id);
+                definitionIds.add(id);
                 unsequencedDefinitions.delete(id);
             }
         }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -444,6 +444,8 @@ class Translator {
             }
         }
 
+        if (expressionList.length === 0) { return; }
+
         const databaseDefinitions = await this._database.findTermsExactBulk(expressionList, readingList, secondarySearchDictionaryMap);
         this._sortDatabaseDefinitionsByIndex(databaseDefinitions);
 

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -457,10 +457,8 @@ class Translator {
     _getMergedDefinition(relatedDefinitions, secondaryDefinitions) {
         const {reasons, source, rawSource} = relatedDefinitions[0];
         const score = this._getMaxPrimaryDefinitionScore(relatedDefinitions);
-        const termInfoMap = new Map();
         const glossaryDefinitions = [];
         const allDefinitions = secondaryDefinitions.length > 0 ? [...relatedDefinitions, ...secondaryDefinitions] : relatedDefinitions;
-        this._addUniqueTermInfos(allDefinitions, termInfoMap);
 
         // Merge by glossary
         const allExpressions = new Set();
@@ -502,7 +500,7 @@ class Translator {
 
         this._sortDefinitions(glossaryDefinitions);
 
-        const termDetailsList = this._createTermDetailsListFromTermInfoMap(termInfoMap);
+        const termDetailsList = this._createTermDetailsListFromTermInfoMap(allDefinitions);
 
         return this._createMergedTermDefinition(
             source,
@@ -1220,9 +1218,7 @@ class Translator {
         const sourceTermExactMatchCount = this._getSourceTermMatchCountSum(definitions);
         const dictionaryNames = this._getUniqueDictionaryNames(definitions);
 
-        const termInfoMap = new Map();
-        this._addUniqueTermInfos(definitions, termInfoMap);
-        const termDetailsList = this._createTermDetailsListFromTermInfoMap(termInfoMap);
+        const termDetailsList = this._createTermDetailsListFromTermInfoMap(definitions);
 
         const definitionTags = this._getUniqueDefinitionTags(definitions);
         this._sortTags(definitionTags);
@@ -1258,7 +1254,10 @@ class Translator {
         };
     }
 
-    _createTermDetailsListFromTermInfoMap(termInfoMap) {
+    _createTermDetailsListFromTermInfoMap(definitions) {
+        const termInfoMap = new Map();
+        this._addUniqueTermInfos(definitions, termInfoMap);
+
         const termDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {
             for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -388,18 +388,7 @@ class Translator {
         }
 
         if (sequenceList.length > 0) {
-            const databaseDefinitions = await this._database.findTermsBySequenceBulk(sequenceList, mainDictionary);
-            for (const databaseDefinition of databaseDefinitions) {
-                const {relatedDefinitions, relatedDefinitionIds} = sequencedDefinitions[databaseDefinition.index];
-                const {id} = databaseDefinition;
-                if (relatedDefinitionIds.has(id)) { continue; }
-
-                const {source, rawSource, sourceTerm} = relatedDefinitions[0];
-                const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, [], false, enabledDictionaryMap);
-                relatedDefinitions.push(definition);
-                relatedDefinitionIds.add(id);
-                unsequencedDefinitions.delete(id);
-            }
+            await this._addRelatedDefinitions(sequencedDefinitions, unsequencedDefinitions, sequenceList, mainDictionary, enabledDictionaryMap);
         }
 
         for (const {relatedDefinitions} of sequencedDefinitions) {
@@ -407,6 +396,21 @@ class Translator {
         }
 
         return {sequencedDefinitions, unsequencedDefinitions: [...unsequencedDefinitions.values()]};
+    }
+
+    async _addRelatedDefinitions(sequencedDefinitions, unsequencedDefinitions, sequenceList, mainDictionary, enabledDictionaryMap) {
+        const databaseDefinitions = await this._database.findTermsBySequenceBulk(sequenceList, mainDictionary);
+        for (const databaseDefinition of databaseDefinitions) {
+            const {relatedDefinitions, relatedDefinitionIds} = sequencedDefinitions[databaseDefinition.index];
+            const {id} = databaseDefinition;
+            if (relatedDefinitionIds.has(id)) { continue; }
+
+            const {source, rawSource, sourceTerm} = relatedDefinitions[0];
+            const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, [], false, enabledDictionaryMap);
+            relatedDefinitions.push(definition);
+            relatedDefinitionIds.add(id);
+            unsequencedDefinitions.delete(id);
+        }
     }
 
     async _getMergedSecondarySearchResults(expressionsMap, secondarySearchDictionaryMap) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -185,9 +185,8 @@ class Translator {
         const definitionsMerged = [];
         const usedDefinitions = new Set();
 
-        for (const {sourceDefinitions, relatedDefinitions} of sequencedDefinitions) {
+        for (const {relatedDefinitions} of sequencedDefinitions) {
             const result = await this._getMergedDefinition(
-                sourceDefinitions,
                 relatedDefinitions,
                 unsequencedDefinitions,
                 secondarySearchDictionaryMap,
@@ -374,7 +373,6 @@ class Translator {
                 let sequencedDefinition = sequencedDefinitionMap.get(sequence);
                 if (typeof sequencedDefinition === 'undefined') {
                     sequencedDefinition = {
-                        sourceDefinitions: [],
                         relatedDefinitions: [],
                         relatedDefinitionIds: new Set()
                     };
@@ -382,7 +380,6 @@ class Translator {
                     sequencedDefinitions.push(sequencedDefinition);
                     sequenceList.push(sequence);
                 }
-                sequencedDefinition.sourceDefinitions.push(definition);
                 sequencedDefinition.relatedDefinitions.push(definition);
                 sequencedDefinition.relatedDefinitionIds.add(definition.id);
             } else {
@@ -437,9 +434,9 @@ class Translator {
         return definitions;
     }
 
-    async _getMergedDefinition(sourceDefinitions, relatedDefinitions, unsequencedDefinitions, secondarySearchDictionaryMap, usedDefinitions) {
-        const {reasons, source, rawSource} = sourceDefinitions[0];
-        const score = this._getMaxDefinitionScore(sourceDefinitions);
+    async _getMergedDefinition(relatedDefinitions, unsequencedDefinitions, secondarySearchDictionaryMap, usedDefinitions) {
+        const {reasons, source, rawSource} = relatedDefinitions[0];
+        const score = this._getMaxPrimaryDefinitionScore(relatedDefinitions);
         const termInfoMap = new Map();
         const glossaryDefinitions = [];
         const glossaryDefinitionGroupMap = new Map();
@@ -1025,6 +1022,14 @@ class Translator {
         let result = Number.MIN_SAFE_INTEGER;
         for (const {score} of definitions) {
             if (score > result) { result = score; }
+        }
+        return result;
+    }
+
+    _getMaxPrimaryDefinitionScore(definitions) {
+        let result = Number.MIN_SAFE_INTEGER;
+        for (const {isPrimary, score} of definitions) {
+            if (isPrimary && score > result) { result = score; }
         }
         return result;
     }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -456,9 +456,8 @@ class Translator {
 
     _getMergedDefinition(relatedDefinitions, secondaryDefinitions) {
         const {reasons, source, rawSource} = relatedDefinitions[0];
-        const score = this._getMaxPrimaryDefinitionScore(relatedDefinitions);
-        const glossaryDefinitions = [];
         const allDefinitions = secondaryDefinitions.length > 0 ? [...relatedDefinitions, ...secondaryDefinitions] : relatedDefinitions;
+        const score = this._getMaxPrimaryDefinitionScore(allDefinitions);
 
         // Merge by glossary
         const allExpressions = new Set();
@@ -485,6 +484,7 @@ class Translator {
             group.definitions.push(definition);
         }
 
+        const glossaryDefinitions = [];
         for (const {expressions, readings, definitions} of glossaryDefinitionGroupMap.values()) {
             const glossaryDefinition = this._createMergedGlossaryTermDefinition(
                 source,
@@ -497,7 +497,6 @@ class Translator {
             );
             glossaryDefinitions.push(glossaryDefinition);
         }
-
         this._sortDefinitions(glossaryDefinitions);
 
         const termDetailsList = this._createTermDetailsList(allDefinitions);

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -232,16 +232,19 @@ class Translator {
 
         let maxLength = 0;
         const definitions = [];
+        const definitionIds = new Set();
         for (const {databaseDefinitions, source, rawSource, term, reasons} of deinflections) {
             if (databaseDefinitions.length === 0) { continue; }
             maxLength = Math.max(maxLength, rawSource.length);
             for (const databaseDefinition of databaseDefinitions) {
+                const {id} = databaseDefinition;
+                if (definitionIds.has(id)) { continue; }
                 const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, term, reasons, true, enabledDictionaryMap);
                 definitions.push(definition);
+                definitionIds.add(id);
             }
         }
 
-        this._removeDuplicateDefinitions(definitions);
         return [definitions, maxLength];
     }
 
@@ -541,29 +544,6 @@ class Translator {
             }
         }
         return [...definitionTagsMap.values()];
-    }
-
-    _removeDuplicateDefinitions(definitions) {
-        const definitionGroups = new Map();
-        for (let i = 0, ii = definitions.length; i < ii; ++i) {
-            const definition = definitions[i];
-            const {id} = definition;
-            const existing = definitionGroups.get(id);
-            if (typeof existing === 'undefined') {
-                definitionGroups.set(id, [i, definition]);
-                continue;
-            }
-
-            let removeIndex = i;
-            if (definition.source.length > existing[1].source.length) {
-                definitionGroups.set(id, [i, definition]);
-                removeIndex = existing[0];
-            }
-
-            definitions.splice(removeIndex, 1);
-            --i;
-            --ii;
-        }
     }
 
     _flagRedundantDefinitionTags(definitions) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -385,9 +385,8 @@ class Translator {
 
         if (sequenceList.length > 0) {
             await this._addRelatedDefinitions(sequencedDefinitions, unsequencedDefinitions, sequenceList, mainDictionary, enabledDictionaryMap);
+            await this._addSecondaryDefinitions(sequencedDefinitions, unsequencedDefinitions, enabledDictionaryMap, secondarySearchDictionaryMap);
         }
-
-        await this._addSecondaryDefinitions(sequencedDefinitions, unsequencedDefinitions, enabledDictionaryMap, secondarySearchDictionaryMap);
 
         for (const {relatedDefinitions} of sequencedDefinitions) {
             this._sortDefinitionsById(relatedDefinitions);

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -622,33 +622,6 @@ class Translator {
         return results;
     }
 
-    _addUniqueTermInfos(definitions, termInfoMap) {
-        for (const {expression, reading, sourceTerm, furiganaSegments, termTags} of definitions) {
-            let readingMap = termInfoMap.get(expression);
-            if (typeof readingMap === 'undefined') {
-                readingMap = new Map();
-                termInfoMap.set(expression, readingMap);
-            }
-
-            let termInfo = readingMap.get(reading);
-            if (typeof termInfo === 'undefined') {
-                termInfo = {
-                    sourceTerm,
-                    furiganaSegments,
-                    termTagsMap: new Map()
-                };
-                readingMap.set(reading, termInfo);
-            }
-
-            const {termTagsMap} = termInfo;
-            for (const tag of termTags) {
-                const {name} = tag;
-                if (termTagsMap.has(name)) { continue; }
-                termTagsMap.set(name, this._cloneTag(tag));
-            }
-        }
-    }
-
     _convertTermDefinitionsToMergedGlossaryTermDefinitions(definitions) {
         const convertedDefinitions = [];
         for (const definition of definitions) {
@@ -1256,7 +1229,30 @@ class Translator {
 
     _createTermDetailsListFromTermInfoMap(definitions) {
         const termInfoMap = new Map();
-        this._addUniqueTermInfos(definitions, termInfoMap);
+        for (const {expression, reading, sourceTerm, furiganaSegments, termTags} of definitions) {
+            let readingMap = termInfoMap.get(expression);
+            if (typeof readingMap === 'undefined') {
+                readingMap = new Map();
+                termInfoMap.set(expression, readingMap);
+            }
+
+            let termInfo = readingMap.get(reading);
+            if (typeof termInfo === 'undefined') {
+                termInfo = {
+                    sourceTerm,
+                    furiganaSegments,
+                    termTagsMap: new Map()
+                };
+                readingMap.set(reading, termInfo);
+            }
+
+            const {termTagsMap} = termInfo;
+            for (const tag of termTags) {
+                const {name} = tag;
+                if (termTagsMap.has(name)) { continue; }
+                termTagsMap.set(name, this._cloneTag(tag));
+            }
+        }
 
         const termDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -366,9 +366,9 @@ class Translator {
         const sequenceList = [];
         const sequencedDefinitionMap = new Map();
         const sequencedDefinitions = [];
-        const unsequencedDefinitions = [];
+        const unsequencedDefinitions = new Map();
         for (const definition of definitions) {
-            const {sequence, dictionary} = definition;
+            const {sequence, dictionary, id} = definition;
             if (mainDictionary === dictionary && sequence >= 0) {
                 let sequencedDefinition = sequencedDefinitionMap.get(sequence);
                 if (typeof sequencedDefinition === 'undefined') {
@@ -381,9 +381,9 @@ class Translator {
                     sequenceList.push(sequence);
                 }
                 sequencedDefinition.relatedDefinitions.push(definition);
-                sequencedDefinition.relatedDefinitionIds.add(definition.id);
+                sequencedDefinition.relatedDefinitionIds.add(id);
             } else {
-                unsequencedDefinitions.push(definition);
+                unsequencedDefinitions.set(id, definition);
             }
         }
 
@@ -398,6 +398,7 @@ class Translator {
                 const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, [], false, enabledDictionaryMap);
                 relatedDefinitions.push(definition);
                 relatedDefinitionIds.add(id);
+                unsequencedDefinitions.delete(id);
             }
         }
 
@@ -405,7 +406,7 @@ class Translator {
             this._sortDefinitionsById(relatedDefinitions);
         }
 
-        return {sequencedDefinitions, unsequencedDefinitions};
+        return {sequencedDefinitions, unsequencedDefinitions: [...unsequencedDefinitions.values()]};
     }
 
     async _getMergedSecondarySearchResults(expressionsMap, secondarySearchDictionaryMap) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -397,6 +397,7 @@ class Translator {
                 const {source, rawSource, sourceTerm} = relatedDefinitions[0];
                 const definition = await this._createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, [], false, enabledDictionaryMap);
                 relatedDefinitions.push(definition);
+                relatedDefinitionIds.add(id);
             }
         }
 

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -181,15 +181,13 @@ class Translator {
         const [definitions, length] = await this._findTermsInternal(text, enabledDictionaryMap, options);
         const {sequencedDefinitions, unsequencedDefinitions} = await this._getSequencedDefinitions(definitions, mainDictionary, enabledDictionaryMap);
         const definitionsMerged = [];
-        const usedDefinitions = new Set();
 
         for (const {relatedDefinitions, secondaryDefinitions} of sequencedDefinitions) {
             const mergedDefinition = this._getMergedDefinition(relatedDefinitions, secondaryDefinitions);
             definitionsMerged.push(mergedDefinition);
         }
 
-        const unusedDefinitions = unsequencedDefinitions.filter((definition) => !usedDefinitions.has(definition));
-        for (const groupedDefinition of this._groupTerms(unusedDefinitions, enabledDictionaryMap)) {
+        for (const groupedDefinition of this._groupTerms(unsequencedDefinitions, enabledDictionaryMap)) {
             const {reasons, score, expression, reading, source, rawSource, sourceTerm, furiganaSegments, termTags, definitions: definitions2} = groupedDefinition;
             const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
             const compatibilityDefinition = this._createMergedTermDefinition(

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -413,6 +413,7 @@ class Translator {
     async _addSecondaryDefinitions(sequencedDefinitions, unsequencedDefinitions, enabledDictionaryMap, secondarySearchDictionaryMap) {
         if (unsequencedDefinitions.length === 0 && secondarySearchDictionaryMap.size === 0) { return; }
 
+        // Prepare grouping info
         const expressionList = [];
         const readingList = [];
         const targetList = [];
@@ -441,6 +442,7 @@ class Translator {
             }
         }
 
+        // Group unsequenced definitions with sequenced definitions that have a matching [expression, reading].
         for (const [id, definition] of unsequencedDefinitions.entries()) {
             const {expressions: [{expression, reading}]} = definition;
             const key = this._createMapKey([expression, reading]);
@@ -457,6 +459,7 @@ class Translator {
             }
         }
 
+        // Search database for additional secondary terms
         if (expressionList.length === 0 || secondarySearchDictionaryMap.size === 0) { return; }
 
         const databaseDefinitions = await this._database.findTermsExactBulk(expressionList, readingList, secondarySearchDictionaryMap);


### PR DESCRIPTION
Fetching and grouping of definitions in merge mode should now be significantly more efficient. There are less separate database queries, less redundant searches, and more early exits. The code should also be more organized and a bit easier to follow.