### PR TITLE
Remove zero-width space

### DIFF
--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -462,7 +462,8 @@ class DOMTextScanner {
                 return preserveWhitespace ? 2 : 1;
             case 0x0a: // Line feed ('\n')
                 return preserveNewlines ? 3 : 1;
-            case 0x200c: // Zero-width non-joiner ('\u200c')
+            case 0x200b: // Zero-width space
+            case 0x200c: // Zero-width non-joiner
                 return 0;
             default: // Other
                 return 2;

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -138,8 +138,8 @@ class TextSourceElement {
                 break;
         }
 
-        // Remove zero-width non-joiner
-        content = content.replace(/\u200c/g, '');
+        // Remove zero-width space and zero-width non-joiner
+        content = content.replace(/[\u200b\u200c]/g, '');
 
         return content;
     }


### PR DESCRIPTION
Youtube separates certain characters in closed captions with `&ZeroWidthSpace;` (`'\u200b'`). This is similar to how Google Docs separates with `&zwnj;` (`'\u200c'`).