### PR TITLE
Update browser bug list

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -66,3 +66,8 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: Chrome
 * **Date**: 2021-02-13
 * **Links**: [Demo](https://github.com/toasted-nutbread/chrome-extension-port-disconnect-bug), [Report 1](https://bugs.chromium.org/p/chromium/issues/detail?id=1178188) (MV2), [Report 2](https://bugs.chromium.org/p/chromium/issues/detail?id=1178189) (MV3)
+
+## Ruby elements with padding have incorrect layout
+* **Browser**: Firefox
+* **Date**: 2021-03-05
+* **Links**: [Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1696721)


### PR DESCRIPTION
The new issue is exhibited with the new layout for frequency tags on Firefox when using the `inline-list` format and the following custom CSS is enabled:

```css
.frequency-disambiguation::before,
.frequency-disambiguation::after {
    content: none;
}
```

The result is tags wrapping incorrectly and a "jumping" behaviour when they are hovered using the dev tools inspector.