### PR TITLE
Split dictionary order and index sorting

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1898,29 +1898,17 @@ class Backend {
     }
 
     _getTranslatorEnabledDictionaryMap(options) {
-        const dictionaries = [];
-        const {dictionaries: optionsDictionaries} = options;
-        for (const title in optionsDictionaries) {
-            if (!Object.prototype.hasOwnProperty.call(optionsDictionaries, title)) { continue; }
-            const dictionary = optionsDictionaries[title];
+        const enabledDictionaryMap = new Map();
+        const {dictionaries} = options;
+        for (const title in dictionaries) {
+            if (!Object.prototype.hasOwnProperty.call(dictionaries, title)) { continue; }
+            const dictionary = dictionaries[title];
             if (!dictionary.enabled) { continue; }
-            dictionaries.push({
-                title,
-                index: dictionaries.length,
+            enabledDictionaryMap.set(title, {
+                index: enabledDictionaryMap.size,
                 priority: dictionary.priority,
                 allowSecondarySearches: dictionary.allowSecondarySearches
             });
-        }
-
-        dictionaries.sort((v1, v2) => {
-            const i = v2.priority - v1.priority;
-            return i !== 0 ? i : v1.index - v2.index;
-        });
-
-        const enabledDictionaryMap = new Map();
-        for (let i = 0, ii = dictionaries.length; i < ii; ++i) {
-            const {title, allowSecondarySearches} = dictionaries[i];
-            enabledDictionaryMap.set(title, {order: i, allowSecondarySearches});
         }
         return enabledDictionaryMap;
     }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1011,7 +1011,7 @@ class Translator {
         return result;
     }
 
-    _getMinDictionaryOrder(definitions) {
+    _getBestDictionaryOrder(definitions) {
         let result = Number.MAX_SAFE_INTEGER;
         for (const {dictionaryOrder} of definitions) {
             if (dictionaryOrder < result) { result = dictionaryOrder; }
@@ -1117,7 +1117,7 @@ class Translator {
     _createGroupedTermDefinition(definitions) {
         const {expression, reading, furiganaSegments, reasons, source, rawSource, sourceTerm} = definitions[0];
         const score = this._getMaxDefinitionScore(definitions);
-        const dictionaryOrder = this._getMinDictionaryOrder(definitions);
+        const dictionaryOrder = this._getBestDictionaryOrder(definitions);
         const dictionaryNames = this._getUniqueDictionaryNames(definitions);
         const termTags = this._getUniqueTermTags(definitions);
         const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
@@ -1151,7 +1151,7 @@ class Translator {
     }
 
     _createMergedTermDefinition(source, rawSource, definitions, expressions, readings, termDetailsList, reasons, score) {
-        const dictionaryOrder = this._getMinDictionaryOrder(definitions);
+        const dictionaryOrder = this._getBestDictionaryOrder(definitions);
         const sourceTermExactMatchCount = this._getSourceTermMatchCountSum(definitions);
         const dictionaryNames = this._getUniqueDictionaryNames(definitions);
         return {
@@ -1201,7 +1201,7 @@ class Translator {
 
         const {glossary} = definitions[0];
         const score = this._getMaxDefinitionScore(definitions);
-        const dictionaryOrder = this._getMinDictionaryOrder(definitions);
+        const dictionaryOrder = this._getBestDictionaryOrder(definitions);
         return {
             type: 'termMergedByGlossary',
             // id

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1314,14 +1314,18 @@ class Translator {
             i = v2.score - v1.score;
             if (i !== 0) { return i; }
 
+            // Skip if either expression is not a string (array)
             const expression1 = v1.expression;
             const expression2 = v2.expression;
-            if (typeof expression1 !== 'string' || typeof expression2 !== 'string') { return 0; } // Skip if either is not a string (array)
+            if (typeof expression1 === 'string' && typeof expression2 === 'string') {
+                i = expression2.length - expression1.length;
+                if (i !== 0) { return i; }
 
-            i = expression2.length - expression1.length;
-            if (i !== 0) { return i; }
+                i = stringComparer.compare(expression1, expression2);
+                if (i !== 0) { return i; }
+            }
 
-            return stringComparer.compare(expression1, expression2);
+            return 0;
         };
         definitions.sort(compareFunction);
     }

--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -5,7 +5,8 @@
                 [
                     "${title}",
                     {
-                        "order": 0
+                        "index": 0,
+                        "priority": 0
                     }
                 ]
             ]
@@ -27,7 +28,8 @@
                 [
                     "${title}",
                     {
-                        "order": 0,
+                        "index": 0,
+                        "priority": 0,
                         "allowSecondarySearches": false
                     }
                 ]
@@ -143,7 +145,10 @@
                             {
                                 "index": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "character": "打",
                                 "frequency": 1
                             }
@@ -259,7 +264,10 @@
                             {
                                 "index": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "character": "込",
                                 "frequency": 2
                             }
@@ -297,7 +305,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -349,7 +360,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -359,7 +373,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -433,7 +450,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -443,7 +463,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -464,7 +487,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -516,7 +542,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -526,7 +555,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -600,7 +632,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -610,7 +645,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -643,7 +681,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -699,7 +740,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -709,7 +753,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -787,7 +834,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -797,7 +847,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -818,7 +871,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -874,7 +930,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -884,7 +943,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -962,7 +1024,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -972,7 +1037,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -993,7 +1061,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1049,7 +1120,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -1059,7 +1133,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -1137,7 +1214,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -1147,7 +1227,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -1168,7 +1251,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1224,7 +1310,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -1234,7 +1323,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -1312,7 +1404,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -1322,7 +1417,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -1343,7 +1441,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1395,7 +1496,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -1405,7 +1509,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -1479,7 +1586,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -1489,7 +1599,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -1510,7 +1623,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1562,7 +1678,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -1572,7 +1691,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -1646,7 +1768,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -1656,7 +1781,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -1689,7 +1817,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1753,7 +1884,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -1763,7 +1897,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -1775,7 +1912,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -1868,7 +2008,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -1878,7 +2021,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -1890,7 +2036,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -1918,7 +2067,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -1982,7 +2134,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -1992,7 +2147,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -2004,7 +2162,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -2097,7 +2258,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -2107,7 +2271,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -2119,7 +2286,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -2147,7 +2317,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -2211,7 +2384,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -2221,7 +2397,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -2233,7 +2412,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -2326,7 +2508,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -2336,7 +2521,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -2348,7 +2536,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -2376,7 +2567,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -2440,7 +2634,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -2450,7 +2647,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -2462,7 +2662,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -2555,7 +2758,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -2565,7 +2771,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -2577,7 +2786,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -2607,7 +2819,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -2663,7 +2878,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -2673,7 +2891,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -2751,7 +2972,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -2761,7 +2985,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -2784,7 +3011,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -2840,7 +3070,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -2850,7 +3083,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -2928,7 +3164,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -2938,7 +3177,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -2961,7 +3203,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3017,7 +3262,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -3027,7 +3275,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -3105,7 +3356,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -3115,7 +3369,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -3138,7 +3395,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3194,7 +3454,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -3204,7 +3467,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -3282,7 +3548,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -3292,7 +3561,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -3313,7 +3585,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3365,7 +3640,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -3375,7 +3653,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -3449,7 +3730,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -3459,7 +3743,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -3480,7 +3767,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3532,7 +3822,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -3542,7 +3835,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -3616,7 +3912,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -3626,7 +3925,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -3659,7 +3961,10 @@
                         "isPrimary": true,
                         "sequence": 5,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3805,7 +4110,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -3857,7 +4165,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -3867,7 +4178,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -3941,7 +4255,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -3951,7 +4268,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -3984,7 +4304,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4036,7 +4359,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -4046,7 +4372,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -4120,7 +4449,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -4130,7 +4462,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -4163,7 +4498,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4219,7 +4557,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -4229,7 +4570,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -4307,7 +4651,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -4317,7 +4664,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -4338,7 +4688,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4394,7 +4747,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -4404,7 +4760,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -4482,7 +4841,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -4492,7 +4854,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -4525,7 +4890,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4581,7 +4949,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -4591,7 +4962,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -4669,7 +5043,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -4679,7 +5056,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -4700,7 +5080,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4756,7 +5139,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -4766,7 +5152,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -4844,7 +5233,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -4854,7 +5246,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -4887,7 +5282,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -4951,7 +5349,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -4961,7 +5362,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -4973,7 +5377,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -5066,7 +5473,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -5076,7 +5486,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -5088,7 +5501,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -5116,7 +5532,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -5180,7 +5599,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -5190,7 +5612,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -5202,7 +5627,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -5295,7 +5723,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -5305,7 +5736,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -5317,7 +5751,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -5347,7 +5784,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -5403,7 +5843,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -5413,7 +5856,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -5491,7 +5937,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -5501,7 +5950,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -5524,7 +5976,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -5580,7 +6035,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -5590,7 +6048,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -5668,7 +6129,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -5678,7 +6142,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -5711,7 +6178,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -5775,7 +6245,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -5785,7 +6258,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -5797,7 +6273,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -5890,7 +6369,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -5900,7 +6382,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -5912,7 +6397,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -5940,7 +6428,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -6004,7 +6495,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -6014,7 +6508,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -6026,7 +6523,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -6119,7 +6619,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -6129,7 +6632,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -6141,7 +6647,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -6171,7 +6680,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -6227,7 +6739,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -6237,7 +6752,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -6315,7 +6833,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -6325,7 +6846,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -6348,7 +6872,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -6404,7 +6931,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -6414,7 +6944,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -6492,7 +7025,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -6502,7 +7038,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -6535,7 +7074,10 @@
                         "isPrimary": true,
                         "sequence": 5,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -6703,7 +7245,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -6852,7 +7397,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7001,7 +7549,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7150,7 +7701,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7301,7 +7855,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7436,7 +7993,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7571,7 +8131,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7706,7 +8269,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7839,7 +8405,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -7964,7 +8533,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -8098,7 +8670,10 @@
                         "reasons": [],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -8180,7 +8755,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -8190,7 +8768,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -8202,7 +8783,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -8296,7 +8880,10 @@
                                 "isPrimary": true,
                                 "sequence": 4,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -8360,7 +8947,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -8370,7 +8960,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -8382,7 +8975,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -8475,7 +9071,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -8485,7 +9084,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -8497,7 +9099,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -8525,7 +9130,10 @@
                                 "isPrimary": true,
                                 "sequence": 4,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -8589,7 +9197,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -8599,7 +9210,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -8611,7 +9225,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -8704,7 +9321,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -8714,7 +9334,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -8726,7 +9349,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -8749,7 +9375,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -8759,7 +9388,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -8771,7 +9403,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -8796,7 +9431,10 @@
                         "reasons": [],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -8860,7 +9498,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -8870,7 +9511,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -8882,7 +9526,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -8958,7 +9605,10 @@
                                 "isPrimary": true,
                                 "sequence": 4,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -9022,7 +9672,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -9032,7 +9685,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -9044,7 +9700,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -9137,7 +9796,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -9147,7 +9809,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -9159,7 +9824,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -9187,7 +9855,10 @@
                                 "isPrimary": true,
                                 "sequence": 4,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -9251,7 +9922,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -9261,7 +9935,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -9273,7 +9950,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -9366,7 +10046,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -9376,7 +10059,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -9388,7 +10074,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -9411,7 +10100,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -9421,7 +10113,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -9433,7 +10128,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -9460,7 +10158,10 @@
                         ],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -9516,7 +10217,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -9526,7 +10230,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -9589,7 +10296,10 @@
                                 "isPrimary": true,
                                 "sequence": 3,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -9645,7 +10355,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -9655,7 +10368,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -9733,7 +10449,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -9743,7 +10462,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -9766,7 +10488,10 @@
                                 "isPrimary": true,
                                 "sequence": 3,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -9822,7 +10547,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -9832,7 +10560,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -9910,7 +10641,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -9920,7 +10654,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -9936,7 +10673,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -9946,7 +10686,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -9966,7 +10709,10 @@
                         ],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -10022,7 +10768,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -10032,7 +10781,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -10095,7 +10847,10 @@
                                 "isPrimary": true,
                                 "sequence": 3,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -10151,7 +10906,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -10161,7 +10919,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -10239,7 +11000,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -10249,7 +11013,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -10272,7 +11039,10 @@
                                 "isPrimary": true,
                                 "sequence": 3,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -10328,7 +11098,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -10338,7 +11111,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -10416,7 +11192,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -10426,7 +11205,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -10442,7 +11224,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -10452,7 +11237,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -10470,7 +11258,10 @@
                         "reasons": [],
                         "score": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -10522,7 +11313,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -10532,7 +11326,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -10589,7 +11386,10 @@
                                 "isPrimary": true,
                                 "sequence": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -10641,7 +11441,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": false,
@@ -10651,7 +11454,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": true,
@@ -10725,7 +11531,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -10735,7 +11544,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -10751,7 +11563,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -10761,7 +11576,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -10779,7 +11597,10 @@
                         "reasons": [],
                         "score": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -10831,7 +11652,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -10841,7 +11665,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -10898,7 +11725,10 @@
                                 "isPrimary": true,
                                 "sequence": 2,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -10950,7 +11780,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": false,
@@ -10960,7 +11793,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": true,
@@ -11034,7 +11870,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -11044,7 +11883,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -11060,7 +11902,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -11070,7 +11915,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -11099,7 +11947,10 @@
                         "reasons": [],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -11186,7 +12037,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -11196,7 +12050,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -11208,7 +12065,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -11281,7 +12141,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -11291,7 +12154,10 @@
                                         "index": 1,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -11303,7 +12169,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -11328,7 +12197,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -11396,7 +12268,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -11406,7 +12281,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -11418,7 +12296,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -11471,7 +12352,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -11535,7 +12419,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": false,
@@ -11545,7 +12432,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": true,
@@ -11557,7 +12447,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "pitches": [
@@ -11650,7 +12543,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -11660,7 +12556,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -11672,7 +12571,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -11695,7 +12597,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -11705,7 +12610,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -11717,7 +12625,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -11744,7 +12655,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -11812,7 +12726,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -11822,7 +12739,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -11834,7 +12754,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -11887,7 +12810,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -11951,7 +12877,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": false,
@@ -11961,7 +12890,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": true,
@@ -11973,7 +12905,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "pitches": [
@@ -12066,7 +13001,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -12076,7 +13014,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -12088,7 +13029,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -12111,7 +13055,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -12121,7 +13068,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -12133,7 +13083,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -12160,7 +13113,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -12228,7 +13184,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -12238,7 +13197,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -12250,7 +13212,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -12303,7 +13268,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -12367,7 +13335,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": false,
@@ -12377,7 +13348,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": true,
@@ -12389,7 +13363,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "pitches": [
@@ -12482,7 +13459,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -12492,7 +13472,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -12504,7 +13487,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -12527,7 +13513,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -12537,7 +13526,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -12549,7 +13541,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -12576,7 +13571,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -12644,7 +13642,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -12654,7 +13655,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -12666,7 +13670,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -12719,7 +13726,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -12783,7 +13793,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": false,
@@ -12793,7 +13806,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": true,
@@ -12805,7 +13821,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "pitches": [
@@ -12898,7 +13917,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -12908,7 +13930,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -12920,7 +13945,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -12943,7 +13971,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -12953,7 +13984,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -12965,7 +13999,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -12991,7 +14028,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -13001,7 +14041,10 @@
                                 "index": 2,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -13011,7 +14054,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -13021,7 +14067,10 @@
                                 "index": 3,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -13033,7 +14082,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -13051,7 +14103,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -13077,7 +14132,10 @@
                         ],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -13138,7 +14196,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -13148,7 +14209,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -13206,7 +14270,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -13216,7 +14283,10 @@
                                         "index": 1,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -13234,7 +14304,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -13294,7 +14367,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -13304,7 +14380,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -13352,7 +14431,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -13408,7 +14490,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": false,
@@ -13418,7 +14503,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": true,
@@ -13496,7 +14584,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -13506,7 +14597,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -13522,7 +14616,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -13532,7 +14629,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -13552,7 +14652,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -13612,7 +14715,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -13622,7 +14728,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -13670,7 +14779,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -13726,7 +14838,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": false,
@@ -13736,7 +14851,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": true,
@@ -13814,7 +14932,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -13824,7 +14945,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -13840,7 +14964,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -13850,7 +14977,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -13870,7 +15000,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -13930,7 +15063,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -13940,7 +15076,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -13988,7 +15127,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -14044,7 +15186,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": false,
@@ -14054,7 +15199,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": true,
@@ -14132,7 +15280,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -14142,7 +15293,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -14158,7 +15312,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -14168,7 +15325,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -14188,7 +15348,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -14248,7 +15411,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -14258,7 +15424,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -14306,7 +15475,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -14362,7 +15534,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": false,
@@ -14372,7 +15547,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": true,
@@ -14450,7 +15628,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -14460,7 +15641,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -14476,7 +15660,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -14486,7 +15673,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -14505,7 +15695,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -14515,7 +15708,10 @@
                                 "index": 2,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -14525,7 +15721,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -14535,7 +15734,10 @@
                                 "index": 3,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -14552,7 +15754,10 @@
                         "reasons": [],
                         "score": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -14608,7 +15813,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -14618,7 +15826,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -14636,7 +15847,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -14692,7 +15906,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": false,
@@ -14702,7 +15919,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": true,
@@ -14748,7 +15968,10 @@
                                         "isPrimary": true,
                                         "sequence": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -14800,7 +16023,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打",
                                                         "reading": "だ",
                                                         "hasReading": false,
@@ -14810,7 +16036,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打",
                                                         "reading": "だ",
                                                         "hasReading": true,
@@ -14884,7 +16113,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": false,
@@ -14894,7 +16126,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "だ",
                                                 "hasReading": true,
@@ -14910,7 +16145,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -14920,7 +16158,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -14937,7 +16178,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -14947,7 +16191,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -14964,7 +16211,10 @@
                         "reasons": [],
                         "score": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -15020,7 +16270,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -15030,7 +16283,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -15048,7 +16304,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -15104,7 +16363,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": false,
@@ -15114,7 +16376,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": true,
@@ -15160,7 +16425,10 @@
                                         "isPrimary": true,
                                         "sequence": 2,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -15212,7 +16480,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打",
                                                         "reading": "ダース",
                                                         "hasReading": false,
@@ -15222,7 +16493,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打",
                                                         "reading": "ダース",
                                                         "hasReading": true,
@@ -15296,7 +16570,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": false,
@@ -15306,7 +16583,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打",
                                                 "reading": "ダース",
                                                 "hasReading": true,
@@ -15322,7 +16602,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -15332,7 +16615,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -15349,7 +16635,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -15359,7 +16648,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -15396,7 +16688,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -15460,7 +16755,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -15470,7 +16768,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -15482,7 +16783,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -15575,7 +16879,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -15585,7 +16892,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -15597,7 +16907,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -15629,7 +16942,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -15693,7 +17009,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -15703,7 +17022,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -15715,7 +17037,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -15808,7 +17133,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -15818,7 +17146,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -15830,7 +17161,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -15862,7 +17196,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -15926,7 +17263,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -15936,7 +17276,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -15948,7 +17291,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -16041,7 +17387,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -16051,7 +17400,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -16063,7 +17415,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -16095,7 +17450,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -16159,7 +17517,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -16169,7 +17530,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -16181,7 +17545,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -16274,7 +17641,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -16284,7 +17654,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -16296,7 +17669,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -16326,7 +17702,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -16382,7 +17761,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -16392,7 +17774,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -16470,7 +17855,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -16480,7 +17868,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -16503,7 +17894,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -16559,7 +17953,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -16569,7 +17966,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -16647,7 +18047,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -16657,7 +18060,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -16680,7 +18086,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -16736,7 +18145,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -16746,7 +18158,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -16824,7 +18239,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -16834,7 +18252,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -16857,7 +18278,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -16913,7 +18337,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -16923,7 +18350,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -17001,7 +18431,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -17011,7 +18444,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -17032,7 +18468,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -17084,7 +18523,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -17094,7 +18536,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -17168,7 +18613,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -17178,7 +18626,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -17199,7 +18650,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -17251,7 +18705,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -17261,7 +18718,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -17335,7 +18795,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -17345,7 +18808,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -17393,7 +18859,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -17457,7 +18926,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -17467,7 +18939,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -17479,7 +18954,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -17572,7 +19050,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -17582,7 +19063,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -17594,7 +19078,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -17622,7 +19109,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -17686,7 +19176,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -17696,7 +19189,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -17708,7 +19204,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -17801,7 +19300,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -17811,7 +19313,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -17823,7 +19328,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -17851,7 +19359,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -17915,7 +19426,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -17925,7 +19439,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -17937,7 +19454,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -18030,7 +19550,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -18040,7 +19563,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -18052,7 +19578,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -18080,7 +19609,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -18144,7 +19676,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -18154,7 +19689,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -18166,7 +19704,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -18259,7 +19800,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -18269,7 +19813,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -18281,7 +19828,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -18311,7 +19861,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -18367,7 +19920,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -18377,7 +19933,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -18455,7 +20014,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -18465,7 +20027,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -18488,7 +20053,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -18544,7 +20112,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -18554,7 +20125,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -18632,7 +20206,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -18642,7 +20219,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -18665,7 +20245,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -18721,7 +20304,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -18731,7 +20317,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -18809,7 +20398,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -18819,7 +20411,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -18842,7 +20437,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -18898,7 +20496,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -18908,7 +20509,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -18986,7 +20590,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -18996,7 +20603,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -19017,7 +20627,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -19069,7 +20682,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -19079,7 +20695,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -19153,7 +20772,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -19163,7 +20785,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -19184,7 +20809,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -19236,7 +20864,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -19246,7 +20877,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -19320,7 +20954,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -19330,7 +20967,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -19378,7 +21018,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -19442,7 +21085,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -19452,7 +21098,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -19464,7 +21113,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -19557,7 +21209,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -19567,7 +21222,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -19579,7 +21237,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -19607,7 +21268,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -19671,7 +21335,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -19681,7 +21348,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -19693,7 +21363,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -19786,7 +21459,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -19796,7 +21472,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -19808,7 +21487,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -19836,7 +21518,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -19900,7 +21585,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -19910,7 +21598,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -19922,7 +21613,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -20015,7 +21709,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -20025,7 +21722,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -20037,7 +21737,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -20065,7 +21768,10 @@
                         "isPrimary": true,
                         "sequence": 4,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -20129,7 +21835,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -20139,7 +21848,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -20151,7 +21863,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -20244,7 +21959,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -20254,7 +21972,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -20266,7 +21987,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -20296,7 +22020,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -20352,7 +22079,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -20362,7 +22092,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -20440,7 +22173,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -20450,7 +22186,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -20473,7 +22212,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -20529,7 +22271,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -20539,7 +22284,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -20617,7 +22365,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -20627,7 +22378,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -20650,7 +22404,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -20706,7 +22463,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -20716,7 +22476,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -20794,7 +22557,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -20804,7 +22570,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -20827,7 +22596,10 @@
                         "isPrimary": true,
                         "sequence": 3,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -20883,7 +22655,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -20893,7 +22668,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -20971,7 +22749,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -20981,7 +22762,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,
@@ -21002,7 +22786,10 @@
                         "isPrimary": true,
                         "sequence": 1,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21054,7 +22841,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": false,
@@ -21064,7 +22854,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "だ",
                                         "hasReading": true,
@@ -21138,7 +22931,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": false,
@@ -21148,7 +22944,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "だ",
                                 "hasReading": true,
@@ -21169,7 +22968,10 @@
                         "isPrimary": true,
                         "sequence": 2,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21221,7 +23023,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": false,
@@ -21231,7 +23036,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打",
                                         "reading": "ダース",
                                         "hasReading": true,
@@ -21305,7 +23113,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": false,
@@ -21315,7 +23126,10 @@
                                 "index": 1,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打",
                                 "reading": "ダース",
                                 "hasReading": true,
@@ -21365,7 +23179,10 @@
                         "isPrimary": true,
                         "sequence": 6,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21479,7 +23296,10 @@
                         "isPrimary": true,
                         "sequence": 7,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21575,7 +23395,10 @@
                         "isPrimary": true,
                         "sequence": 6,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21670,7 +23493,10 @@
                         "reasons": [],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -21757,7 +23583,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -21767,7 +23596,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -21779,7 +23611,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -21852,7 +23687,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -21862,7 +23700,10 @@
                                         "index": 1,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -21874,7 +23715,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -21899,7 +23743,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -21967,7 +23814,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -21977,7 +23827,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -21989,7 +23842,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -22042,7 +23898,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -22106,7 +23965,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": false,
@@ -22116,7 +23978,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": true,
@@ -22128,7 +23993,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "pitches": [
@@ -22221,7 +24089,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -22231,7 +24102,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -22243,7 +24117,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -22266,7 +24143,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -22276,7 +24156,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -22288,7 +24171,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -22315,7 +24201,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -22383,7 +24272,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -22393,7 +24285,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -22405,7 +24300,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -22458,7 +24356,10 @@
                                         "isPrimary": false,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -22522,7 +24423,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": false,
@@ -22532,7 +24436,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": true,
@@ -22544,7 +24451,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "pitches": [
@@ -22637,7 +24547,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -22647,7 +24560,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -22659,7 +24575,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -22682,7 +24601,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -22692,7 +24614,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -22704,7 +24629,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -22731,7 +24659,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -22799,7 +24730,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -22809,7 +24743,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -22821,7 +24758,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -22874,7 +24814,10 @@
                                         "isPrimary": true,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -22938,7 +24881,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": false,
@@ -22948,7 +24894,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "hasReading": true,
@@ -22960,7 +24909,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "うちこむ",
                                                         "pitches": [
@@ -23053,7 +25005,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": false,
@@ -23063,7 +25018,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "hasReading": true,
@@ -23075,7 +25033,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
                                                 "pitches": [
@@ -23098,7 +25059,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": false,
@@ -23108,7 +25072,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "hasReading": true,
@@ -23120,7 +25087,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
                                         "pitches": [
@@ -23147,7 +25117,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -23215,7 +25188,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -23225,7 +25201,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -23237,7 +25216,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -23290,7 +25272,10 @@
                                         "isPrimary": false,
                                         "sequence": 4,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -23354,7 +25339,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": false,
@@ -23364,7 +25352,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "hasReading": true,
@@ -23376,7 +25367,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打ち込む",
                                                         "reading": "ぶちこむ",
                                                         "pitches": [
@@ -23469,7 +25463,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": false,
@@ -23479,7 +25476,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "hasReading": true,
@@ -23491,7 +25491,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
                                                 "pitches": [
@@ -23514,7 +25517,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": false,
@@ -23524,7 +25530,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "hasReading": true,
@@ -23536,7 +25545,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
                                         "pitches": [
@@ -23562,7 +25574,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": false,
@@ -23572,7 +25587,10 @@
                                 "index": 2,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "hasReading": true,
@@ -23582,7 +25600,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": false,
@@ -23592,7 +25613,10 @@
                                 "index": 3,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "hasReading": true,
@@ -23604,7 +25628,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
                                 "pitches": [
@@ -23622,7 +25649,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
                                 "pitches": [
@@ -23648,7 +25678,10 @@
                         ],
                         "score": 10,
                         "dictionary": "Test Dictionary 2",
-                        "dictionaryOrder": 0,
+                        "dictionaryOrder": {
+                            "index": 0,
+                            "priority": 0
+                        },
                         "dictionaryNames": [
                             "Test Dictionary 2"
                         ],
@@ -23709,7 +25742,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -23719,7 +25755,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -23777,7 +25816,10 @@
                                         "index": 0,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -23787,7 +25829,10 @@
                                         "index": 1,
                                         "expressionIndex": 1,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -23805,7 +25850,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -23865,7 +25913,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -23875,7 +25926,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -23923,7 +25977,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -23979,7 +26036,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": false,
@@ -23989,7 +26049,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": true,
@@ -24067,7 +26130,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -24077,7 +26143,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -24093,7 +26162,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -24103,7 +26175,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -24123,7 +26198,10 @@
                                 "reasons": [],
                                 "score": 10,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -24183,7 +26261,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -24193,7 +26274,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -24239,7 +26323,10 @@
                                         "isPrimary": false,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -24295,7 +26382,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": false,
@@ -24305,7 +26395,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": true,
@@ -24383,7 +26476,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -24393,7 +26489,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -24409,7 +26508,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -24419,7 +26521,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -24439,7 +26544,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -24499,7 +26607,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -24509,7 +26620,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -24557,7 +26671,10 @@
                                         "isPrimary": true,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -24613,7 +26730,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": false,
@@ -24623,7 +26743,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "うつ",
                                                         "hasReading": true,
@@ -24701,7 +26824,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": false,
@@ -24711,7 +26837,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "うつ",
                                                 "hasReading": true,
@@ -24727,7 +26856,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": false,
@@ -24737,7 +26869,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "うつ",
                                         "hasReading": true,
@@ -24757,7 +26892,10 @@
                                 "reasons": [],
                                 "score": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "dictionaryNames": [
                                     "Test Dictionary 2"
                                 ],
@@ -24817,7 +26955,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -24827,7 +26968,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -24873,7 +27017,10 @@
                                         "isPrimary": false,
                                         "sequence": 3,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "dictionaryNames": [
                                             "Test Dictionary 2"
                                         ],
@@ -24929,7 +27076,10 @@
                                                         "index": 0,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": false,
@@ -24939,7 +27089,10 @@
                                                         "index": 1,
                                                         "expressionIndex": 0,
                                                         "dictionary": "Test Dictionary 2",
-                                                        "dictionaryOrder": 0,
+                                                        "dictionaryOrder": {
+                                                            "index": 0,
+                                                            "priority": 0
+                                                        },
                                                         "expression": "打つ",
                                                         "reading": "ぶつ",
                                                         "hasReading": true,
@@ -25017,7 +27170,10 @@
                                                 "index": 0,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": false,
@@ -25027,7 +27183,10 @@
                                                 "index": 1,
                                                 "expressionIndex": 0,
                                                 "dictionary": "Test Dictionary 2",
-                                                "dictionaryOrder": 0,
+                                                "dictionaryOrder": {
+                                                    "index": 0,
+                                                    "priority": 0
+                                                },
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
                                                 "hasReading": true,
@@ -25043,7 +27202,10 @@
                                         "index": 0,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": false,
@@ -25053,7 +27215,10 @@
                                         "index": 1,
                                         "expressionIndex": 0,
                                         "dictionary": "Test Dictionary 2",
-                                        "dictionaryOrder": 0,
+                                        "dictionaryOrder": {
+                                            "index": 0,
+                                            "priority": 0
+                                        },
                                         "expression": "打つ",
                                         "reading": "ぶつ",
                                         "hasReading": true,
@@ -25072,7 +27237,10 @@
                                 "index": 0,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": false,
@@ -25082,7 +27250,10 @@
                                 "index": 2,
                                 "expressionIndex": 0,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "うつ",
                                 "hasReading": true,
@@ -25092,7 +27263,10 @@
                                 "index": 1,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": false,
@@ -25102,7 +27276,10 @@
                                 "index": 3,
                                 "expressionIndex": 1,
                                 "dictionary": "Test Dictionary 2",
-                                "dictionaryOrder": 0,
+                                "dictionaryOrder": {
+                                    "index": 0,
+                                    "priority": 0
+                                },
                                 "expression": "打つ",
                                 "reading": "ぶつ",
                                 "hasReading": true,


### PR DESCRIPTION
Corrects a slight change in behaviour introduced in #1456. The issue is that dictionary index and priority can't be used as part of the same comparison; index comparison should come (nearly) last.