### PR TITLE
Fix furigana distribution when reading starts with expression, but has remainder characters

### DIFF
--- a/ext/js/language/japanese-util.js
+++ b/ext/js/language/japanese-util.js
@@ -531,7 +531,7 @@ const JapaneseUtil = (() => {
         _segmentizeFurigana(reading, readingNormalized, groups, groupsStart) {
             const groupCount = groups.length - groupsStart;
             if (groupCount <= 0) {
-                return [];
+                return reading.length === 0 ? [] : null;
             }
 
             const group = groups[groupsStart];

--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -707,6 +707,13 @@ function testDistributeFurigana() {
                 {text: 'サボ', furigana: ''},
                 {text: 'る', furigana: 'ル'}
             ]
+        ],
+        // Reading starts with expression, but has remainder characters
+        [
+            ['シック', 'シック・ビルしょうこうぐん'],
+            [
+                {text: 'シック', furigana: 'シック・ビルしょうこうぐん'}
+            ]
         ]
     ];
 


### PR DESCRIPTION
Fixes case where `reading.startsWith(expression) && reading.length > expression.length`. Spotted in some definitions from Kenkyuusha.