### PR TITLE
Improve empty reading handling

### DIFF
--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -70,8 +70,7 @@ class DisplayGenerator {
 
         const uniqueExpressions = new Set();
         const uniqueReadings = new Set();
-        for (let {expression, reading} of expressions) {
-            if (reading.length === 0) { reading = expression; }
+        for (const {expression, reading} of expressions) {
             uniqueExpressions.add(expression);
             uniqueReadings.add(reading);
         }
@@ -244,7 +243,7 @@ class DisplayGenerator {
         const expressionContainer = node.querySelector('.expression-text');
         const tagContainer = node.querySelector('.expression-tag-list');
 
-        node.dataset.readingIsSame = `${!reading || reading === expression}`;
+        node.dataset.readingIsSame = `${reading === expression}`;
         node.dataset.frequency = termFrequency;
 
         const pitchAccentCategories = this._getPitchAccentCategories(pitches);
@@ -252,7 +251,7 @@ class DisplayGenerator {
             node.dataset.pitchAccentCategories = pitchAccentCategories;
         }
 
-        this._setTextContent(node.querySelector('.expression-reading'), reading.length > 0 ? reading : expression);
+        this._setTextContent(node.querySelector('.expression-reading'), reading);
 
         this._appendFurigana(expressionContainer, furiganaSegments, this._appendKanjiLinks.bind(this));
         this._appendMultiple(tagContainer, this._createTag.bind(this), termTags);

--- a/ext/js/language/dictionary-data-util.js
+++ b/ext/js/language/dictionary-data-util.js
@@ -96,8 +96,7 @@ class DictionaryDataUtil {
         const allExpressions = new Set();
         const allReadings = new Set();
 
-        for (let {expression, reading, pitches: expressionPitches} of definition.expressions) {
-            if (reading.length === 0) { reading = expression; }
+        for (const {expression, reading, pitches: expressionPitches} of definition.expressions) {
             allExpressions.add(expression);
             allReadings.add(reading);
 

--- a/ext/js/language/japanese-util.js
+++ b/ext/js/language/japanese-util.js
@@ -430,7 +430,7 @@ const JapaneseUtil = (() => {
         // Furigana distribution
 
         distributeFurigana(expression, reading) {
-            if (!reading || reading === expression) {
+            if (reading === expression) {
                 // Same
                 return [this._createFuriganaSegment(expression, '')];
             }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -648,8 +648,7 @@ class Translator {
 
         for (const {expressions, frequencies: frequencies1, pitches: pitches1} of allDefinitions) {
             for (let i = 0, ii = expressions.length; i < ii; ++i) {
-                let {expression, reading, frequencies: frequencies2, pitches: pitches2} = expressions[i];
-                if (reading.length === 0) { reading = expression; }
+                const {expression, reading, frequencies: frequencies2, pitches: pitches2} = expressions[i];
                 let readingMap = expressionMap.get(expression);
                 if (typeof readingMap === 'undefined') {
                     readingMap = new Map();

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1079,7 +1079,8 @@ class Translator {
     }
 
     async _createTermDefinitionFromDatabaseDefinition(databaseDefinition, source, rawSource, sourceTerm, reasons, isPrimary, enabledDictionaryMap) {
-        const {expression, reading, definitionTags, termTags, glossary, score, dictionary, id, sequence} = databaseDefinition;
+        const {expression, reading: rawReading, definitionTags, termTags, glossary, score, dictionary, id, sequence} = databaseDefinition;
+        const reading = (rawReading.length > 0 ? rawReading : expression);
         const dictionaryOrder = this._getDictionaryOrder(dictionary, enabledDictionaryMap);
         const termTagsExpanded = await this._expandTags(termTags, dictionary);
         const definitionTagsExpanded = await this._expandTags(definitionTags, dictionary);

--- a/ext/js/media/audio-downloader.js
+++ b/ext/js/media/audio-downloader.js
@@ -131,7 +131,7 @@ class AudioDownloader {
                 if (htmlReadings.length === 0) { continue; }
 
                 const htmlReading = dom.getTextContent(htmlReadings[0]);
-                if (htmlReading && (!reading || reading === htmlReading)) {
+                if (htmlReading && (reading === expression || reading === htmlReading)) {
                     url = this._normalizeUrl(url, response.url);
                     return [{type: 'url', url}];
                 }


### PR DESCRIPTION
Empty reading means that the reading is the same as the expression. Instead of handling this edge case in many different places, only handle it once: during the conversion from database definition to a translator definition.

Mentioned in https://github.com/FooSoft/yomichan/issues/1472#issuecomment-791877947.