### PR TITLE
Deinflector refactor

### DIFF
--- a/ext/js/language/deinflector.js
+++ b/ext/js/language/deinflector.js
@@ -63,8 +63,8 @@ class Deinflector {
                 variants.push([
                     kanaIn,
                     kanaOut,
-                    Deinflector.rulesToRuleFlags(rulesIn),
-                    Deinflector.rulesToRuleFlags(rulesOut)
+                    this.rulesToRuleFlags(rulesIn),
+                    this.rulesToRuleFlags(rulesOut)
                 ]);
             }
             normalizedReasons.push([reason, variants]);
@@ -73,7 +73,7 @@ class Deinflector {
     }
 
     static rulesToRuleFlags(rules) {
-        const ruleTypes = Deinflector.ruleTypes;
+        const ruleTypes = this._ruleTypes;
         let value = 0;
         for (const rule of rules) {
             const ruleBits = ruleTypes.get(rule);
@@ -84,7 +84,8 @@ class Deinflector {
     }
 }
 
-Deinflector.ruleTypes = new Map([
+// eslint-disable-next-line no-underscore-dangle
+Deinflector._ruleTypes = new Map([
     ['v1',    0b00000001], // Verb ichidan
     ['v5',    0b00000010], // Verb godan
     ['vs',    0b00000100], // Verb suru

--- a/ext/js/language/deinflector.js
+++ b/ext/js/language/deinflector.js
@@ -20,8 +20,8 @@ class Deinflector {
         this.reasons = Deinflector.normalizeReasons(reasons);
     }
 
-    deinflect(source, rawSource) {
-        const results = [this.createDeinflection(source, rawSource, source, 0, [])];
+    deinflect(source) {
+        const results = [this._createDeinflection(source, 0, [])];
         for (let i = 0; i < results.length; ++i) {
             const {rules, term, reasons} = results[i];
             for (const [reason, variants] of this.reasons) {
@@ -34,9 +34,7 @@ class Deinflector {
                         continue;
                     }
 
-                    results.push(this.createDeinflection(
-                        source,
-                        rawSource,
+                    results.push(this._createDeinflection(
                         term.substring(0, term.length - kanaIn.length) + kanaOut,
                         rulesOut,
                         [reason, ...reasons]
@@ -47,15 +45,8 @@ class Deinflector {
         return results;
     }
 
-    createDeinflection(source, rawSource, term, rules, reasons) {
-        return {
-            source,
-            rawSource,
-            term,
-            rules,
-            reasons,
-            databaseDefinitions: []
-        };
+    _createDeinflection(term, rules, reasons) {
+        return {term, rules, reasons};
     }
 
     static normalizeReasons(reasons) {

--- a/ext/js/language/deinflector.js
+++ b/ext/js/language/deinflector.js
@@ -21,14 +21,7 @@ class Deinflector {
     }
 
     deinflect(source, rawSource) {
-        const results = [{
-            source,
-            rawSource,
-            term: source,
-            rules: 0,
-            reasons: [],
-            databaseDefinitions: []
-        }];
+        const results = [this.createDeinflection(source, rawSource, source, 0, [])];
         for (let i = 0; i < results.length; ++i) {
             const {rules, term, reasons} = results[i];
             for (const [reason, variants] of this.reasons) {
@@ -41,18 +34,28 @@ class Deinflector {
                         continue;
                     }
 
-                    results.push({
+                    results.push(this.createDeinflection(
                         source,
                         rawSource,
-                        term: term.substring(0, term.length - kanaIn.length) + kanaOut,
-                        rules: rulesOut,
-                        reasons: [reason, ...reasons],
-                        databaseDefinitions: []
-                    });
+                        term.substring(0, term.length - kanaIn.length) + kanaOut,
+                        rulesOut,
+                        [reason, ...reasons]
+                    ));
                 }
             }
         }
         return results;
+    }
+
+    createDeinflection(source, rawSource, term, rules, reasons) {
+        return {
+            source,
+            rawSource,
+            term,
+            rules,
+            reasons,
+            databaseDefinitions: []
+        };
     }
 
     static normalizeReasons(reasons) {


### PR DESCRIPTION
`Deinflector` no longer adds fields that are only used by `Translator`. `Translator` is in charge of constructing these fields.