### PR TITLE
Refactor furigana segment data

### DIFF
--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -31,7 +31,7 @@
     <div class="debug-info"><a class="debug-log-link">Log debug info to console</a></div>
 </div></template>
 <template id="expression-template" data-remove-whitespace-text="true"><div class="expression">
-    <div class="expression-text-container" lang="ja">
+    <div class="expression-text-container">
         <span class="expression-text-outer source-text">
             <span class="expression-current-indicator"></span>
             <span class="expression-text"></span>

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -651,7 +651,6 @@ class DisplayGenerator {
     }
 
     _appendKanjiLinks(container, text) {
-        container.lang = 'ja';
         const jp = this._japaneseUtil;
         let part = '';
         for (const c of text) {

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -190,11 +190,9 @@ class DisplayGenerator {
                 disambiguationContainer.dataset[attribute] = value;
             }
             for (const {expression, reading} of disambiguation) {
-                const segments = this._japaneseUtil.distributeFurigana(expression, reading);
                 const disambiguationItem = document.createElement('span');
                 disambiguationItem.className = 'tag-details-disambiguation';
-                disambiguationItem.lang = 'ja';
-                this._appendFurigana(disambiguationItem, segments, (container, text) => {
+                this._appendFurigana(disambiguationItem, expression, reading, (container, text) => {
                     container.appendChild(document.createTextNode(text));
                 });
                 disambiguationContainer.appendChild(disambiguationItem);
@@ -232,7 +230,7 @@ class DisplayGenerator {
     // Private
 
     _createTermExpression(details) {
-        const {termFrequency, furiganaSegments, expression, reading, termTags, pitches} = details;
+        const {termFrequency, expression, reading, termTags, pitches} = details;
 
         const searchQueries = [];
         if (expression) { searchQueries.push(expression); }
@@ -253,7 +251,7 @@ class DisplayGenerator {
 
         this._setTextContent(node.querySelector('.expression-reading'), reading);
 
-        this._appendFurigana(expressionContainer, furiganaSegments, this._appendKanjiLinks.bind(this));
+        this._appendFurigana(expressionContainer, expression, reading, this._appendKanjiLinks.bind(this));
         this._appendMultiple(tagContainer, this._createTag.bind(this), termTags);
         this._appendMultiple(tagContainer, this._createSearchTag.bind(this), searchQueries);
 
@@ -691,7 +689,9 @@ class DisplayGenerator {
         return count;
     }
 
-    _appendFurigana(container, segments, addText) {
+    _appendFurigana(container, expression, reading, addText) {
+        container.lang = 'ja';
+        const segments = this._japaneseUtil.distributeFurigana(expression, reading);
         for (const {text, furigana} of segments) {
             if (furigana) {
                 const ruby = document.createElement('ruby');

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1080,8 +1080,7 @@ class Translator {
         this._sortTags(definitionTagsExpanded);
         this._sortTags(termTagsExpanded);
 
-        const furiganaSegments = this._japaneseUtil.distributeFurigana(expression, reading);
-        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTagsExpanded)];
+        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, termTagsExpanded)];
         const sourceTermExactMatchCount = (sourceTerm === expression ? 1 : 0);
 
         return {
@@ -1100,7 +1099,6 @@ class Translator {
             expression,
             reading,
             expressions: termDetailsList,
-            furiganaSegments,
             glossary,
             definitionTags: definitionTagsExpanded,
             termTags: termTagsExpanded,
@@ -1118,12 +1116,12 @@ class Translator {
      * @returns A single 'termGrouped' definition.
      */
     _createGroupedTermDefinition(definitions) {
-        const {reasons, source, rawSource, sourceTerm, expressions: [{expression, reading, furiganaSegments}]} = definitions[0];
+        const {reasons, source, rawSource, sourceTerm, expressions: [{expression, reading}]} = definitions[0];
         const score = this._getMaxDefinitionScore(definitions);
         const dictionaryOrder = this._getBestDictionaryOrder(definitions);
         const dictionaryNames = this._getUniqueDictionaryNames(definitions);
         const termTags = this._getUniqueTermTags(definitions);
-        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags)];
+        const termDetailsList = [this._createTermDetails(sourceTerm, expression, reading, termTags)];
         const sourceTermExactMatchCount = (sourceTerm === expression ? 1 : 0);
         return {
             type: 'termGrouped',
@@ -1141,7 +1139,6 @@ class Translator {
             expression,
             reading,
             expressions: termDetailsList,
-            furiganaSegments, // Contains duplicate data
             // glossary
             // definitionTags
             termTags,
@@ -1173,7 +1170,6 @@ class Translator {
             expression: expressions,
             reading: readings,
             expressions: termDetailsList,
-            // furiganaSegments
             // glossary
             // definitionTags
             // termTags
@@ -1221,7 +1217,6 @@ class Translator {
             expression: [...expressions],
             reading: [...readings],
             expressions: termDetailsList,
-            // furiganaSegments
             glossary: [...glossary],
             definitionTags,
             // termTags
@@ -1240,7 +1235,7 @@ class Translator {
      */
     _createTermDetailsList(definitions) {
         const termInfoMap = new Map();
-        for (const {expression, reading, sourceTerm, furiganaSegments, termTags} of definitions) {
+        for (const {expression, reading, sourceTerm, termTags} of definitions) {
             let readingMap = termInfoMap.get(expression);
             if (typeof readingMap === 'undefined') {
                 readingMap = new Map();
@@ -1251,7 +1246,6 @@ class Translator {
             if (typeof termInfo === 'undefined') {
                 termInfo = {
                     sourceTerm,
-                    furiganaSegments,
                     termTagsMap: new Map()
                 };
                 readingMap.set(reading, termInfo);
@@ -1267,22 +1261,21 @@ class Translator {
 
         const termDetailsList = [];
         for (const [expression, readingMap] of termInfoMap.entries()) {
-            for (const [reading, {termTagsMap, sourceTerm, furiganaSegments}] of readingMap.entries()) {
+            for (const [reading, {termTagsMap, sourceTerm}] of readingMap.entries()) {
                 const termTags = [...termTagsMap.values()];
                 this._sortTags(termTags);
-                termDetailsList.push(this._createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags));
+                termDetailsList.push(this._createTermDetails(sourceTerm, expression, reading, termTags));
             }
         }
         return termDetailsList;
     }
 
-    _createTermDetails(sourceTerm, expression, reading, furiganaSegments, termTags) {
+    _createTermDetails(sourceTerm, expression, reading, termTags) {
         const termFrequency = this._scoreToTermFrequency(this._getTermTagsScoreSum(termTags));
         return {
             sourceTerm,
             expression,
             reading,
-            furiganaSegments, // Contains duplicate data
             termTags,
             termFrequency,
             frequencies: [],

--- a/ext/js/templates/template-renderer-frame-main.js
+++ b/ext/js/templates/template-renderer-frame-main.js
@@ -26,7 +26,7 @@
     const japaneseUtil = new JapaneseUtil(null);
     const templateRenderer = new TemplateRenderer(japaneseUtil);
     templateRenderer.registerDataType('ankiNote', {
-        modifier: ({data, marker}) => new AnkiNoteData(data, marker).createPublic()
+        modifier: ({data, marker}) => new AnkiNoteData(japaneseUtil, marker, data).createPublic()
     });
     const templateRendererFrameApi = new TemplateRendererFrameApi(templateRenderer);
     templateRendererFrameApi.prepare();

--- a/test/data/test-translator-data.json
+++ b/test/data/test-translator-data.json
@@ -319,12 +319,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -384,12 +378,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -501,12 +489,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -566,12 +548,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -695,16 +671,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -764,16 +730,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -885,16 +841,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -954,16 +900,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -1075,16 +1011,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -1144,16 +1070,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -1265,16 +1181,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -1334,16 +1240,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -1455,12 +1351,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -1520,12 +1410,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -1637,12 +1521,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -1702,12 +1580,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -1831,24 +1703,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -1930,24 +1784,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -2081,24 +1917,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -2180,24 +1998,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -2331,24 +2131,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -2430,24 +2212,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -2581,24 +2345,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -2680,24 +2426,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -2833,16 +2561,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -2902,16 +2620,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -3025,16 +2733,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -3094,16 +2792,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -3217,16 +2905,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -3286,16 +2964,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -3409,16 +3077,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -3478,16 +3136,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -3599,12 +3247,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -3664,12 +3306,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -3781,12 +3417,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -3846,12 +3476,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -3975,12 +3599,6 @@
                                 "sourceTerm": "画像",
                                 "expression": "画像",
                                 "reading": "がぞう",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "画像",
-                                        "furigana": "がぞう"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4013,12 +3631,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "画像",
-                                "furigana": "がぞう"
                             }
                         ],
                         "glossary": [
@@ -4124,12 +3736,6 @@
                                 "sourceTerm": "だ",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4189,12 +3795,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -4318,12 +3918,6 @@
                                 "sourceTerm": "ダース",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4383,12 +3977,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -4512,16 +4100,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4581,16 +4159,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -4702,16 +4270,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4771,16 +4329,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -4904,16 +4452,6 @@
                                 "sourceTerm": "ぶつ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -4973,16 +4511,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -5094,16 +4622,6 @@
                                 "sourceTerm": "ぶつ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -5163,16 +4681,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -5296,24 +4804,6 @@
                                 "sourceTerm": "うちこむ",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -5395,24 +4885,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -5546,24 +5018,6 @@
                                 "sourceTerm": "うちこむ",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -5645,24 +5099,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -5798,16 +5234,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -5867,16 +5293,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -5990,16 +5406,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -6059,16 +5465,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -6192,24 +5588,6 @@
                                 "sourceTerm": "ぶちこむ",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -6291,24 +5669,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -6442,24 +5802,6 @@
                                 "sourceTerm": "ぶちこむ",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -6541,24 +5883,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -6694,16 +6018,6 @@
                                 "sourceTerm": "ぶつ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -6763,16 +6077,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -6886,16 +6190,6 @@
                                 "sourceTerm": "ぶつ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -6955,16 +6249,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -7088,12 +6372,6 @@
                                 "sourceTerm": "がぞう",
                                 "expression": "画像",
                                 "reading": "がぞう",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "画像",
-                                        "furigana": "がぞう"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -7126,12 +6404,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "画像",
-                                "furigana": "がぞう"
                             }
                         ],
                         "glossary": [
@@ -7259,24 +6531,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -7309,24 +6563,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -7411,24 +6647,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -7461,24 +6679,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -7563,24 +6763,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -7613,24 +6795,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -7715,24 +6879,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -7765,24 +6911,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -7869,16 +6997,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -7911,16 +7029,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -8007,16 +7115,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8049,16 +7147,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -8145,16 +7233,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8187,16 +7265,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -8283,16 +7351,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8325,16 +7383,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -8419,12 +7467,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8457,12 +7499,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -8547,12 +7583,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8585,12 +7615,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -8684,24 +7708,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -8803,24 +7809,6 @@
                                 ]
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -8894,24 +7882,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -8993,24 +7963,6 @@
                                                 ]
                                             }
                                         ]
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -9144,24 +8096,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag5",
@@ -9243,24 +8177,6 @@
                                                 ]
                                             }
                                         ]
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -9445,24 +8361,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -9546,24 +8444,6 @@
                                 ]
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -9619,24 +8499,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -9718,24 +8580,6 @@
                                                 ]
                                             }
                                         ]
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -9869,24 +8713,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -9968,24 +8794,6 @@
                                                 ]
                                             }
                                         ]
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -10172,16 +8980,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -10243,16 +9041,6 @@
                                 "pitches": []
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -10310,16 +9098,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -10379,16 +9157,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -10502,16 +9270,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -10571,16 +9329,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -10723,16 +9471,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -10794,16 +9532,6 @@
                                 "pitches": []
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -10861,16 +9589,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -10930,16 +9648,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -11053,16 +9761,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -11122,16 +9820,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
                                     }
                                 ],
                                 "glossary": [
@@ -11272,12 +9960,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -11339,12 +10021,6 @@
                                 "pitches": []
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -11400,12 +10076,6 @@
                                         "sourceTerm": "打",
                                         "expression": "打",
                                         "reading": "だ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "だ"
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -11465,12 +10135,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
                                     }
                                 ],
                                 "glossary": [
@@ -11611,12 +10275,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -11678,12 +10336,6 @@
                                 "pitches": []
                             }
                         ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
-                            }
-                        ],
                         "termTags": [
                             {
                                 "name": "tag3",
@@ -11739,12 +10391,6 @@
                                         "sourceTerm": "打",
                                         "expression": "打",
                                         "reading": "ダース",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ダース"
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -11804,12 +10450,6 @@
                                             }
                                         ],
                                         "pitches": []
-                                    }
-                                ],
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
                                     }
                                 ],
                                 "glossary": [
@@ -11966,24 +10606,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -12088,24 +10710,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -12215,24 +10819,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -12366,24 +10952,6 @@
                                                 "sourceTerm": "打ち込む",
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -12465,24 +11033,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -12673,24 +11223,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -12824,24 +11356,6 @@
                                                 "sourceTerm": "打ち込む",
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -12923,24 +11437,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -13131,24 +11627,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag5",
@@ -13282,24 +11760,6 @@
                                                 "sourceTerm": "打ち込む",
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag5",
@@ -13381,24 +11841,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -13589,24 +12031,6 @@
                                         "sourceTerm": "打ち込む",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -13740,24 +12164,6 @@
                                                 "sourceTerm": "打ち込む",
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -13839,24 +12245,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -14151,16 +12539,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -14225,16 +12603,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -14322,16 +12690,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -14445,16 +12803,6 @@
                                                 "sourceTerm": "打つ",
                                                 "expression": "打つ",
                                                 "reading": "うつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -14514,16 +12862,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -14670,16 +13008,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -14793,16 +13121,6 @@
                                                 "sourceTerm": "打つ",
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -14862,16 +13180,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -15018,16 +13326,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -15141,16 +13439,6 @@
                                                 "sourceTerm": "打つ",
                                                 "expression": "打つ",
                                                 "reading": "うつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -15210,16 +13498,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -15366,16 +13644,6 @@
                                         "sourceTerm": "打つ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -15489,16 +13757,6 @@
                                                 "sourceTerm": "打つ",
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -15558,16 +13816,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -15772,12 +14020,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -15865,12 +14107,6 @@
                                         "sourceTerm": "打",
                                         "expression": "打",
                                         "reading": "だ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "だ"
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -15982,12 +14218,6 @@
                                                 "sourceTerm": "打",
                                                 "expression": "打",
                                                 "reading": "だ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "だ"
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -16047,12 +14277,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "だ"
                                             }
                                         ],
                                         "glossary": [
@@ -16229,12 +14453,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -16322,12 +14540,6 @@
                                         "sourceTerm": "打",
                                         "expression": "打",
                                         "reading": "ダース",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ダース"
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -16439,12 +14651,6 @@
                                                 "sourceTerm": "打",
                                                 "expression": "打",
                                                 "reading": "ダース",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ダース"
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -16504,12 +14710,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ダース"
                                             }
                                         ],
                                         "glossary": [
@@ -16702,24 +14902,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -16801,24 +14983,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -16956,24 +15120,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -17055,24 +15201,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -17210,24 +15338,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -17309,24 +15419,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -17464,24 +15556,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -17563,24 +15637,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -17716,16 +15772,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -17785,16 +15831,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -17908,16 +15944,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -17977,16 +16003,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -18100,16 +16116,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -18169,16 +16175,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -18292,16 +16288,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -18361,16 +16347,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -18482,12 +16458,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -18547,12 +16517,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -18664,12 +16628,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -18729,12 +16687,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -18873,24 +16825,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -18972,24 +16906,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -19123,24 +17039,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -19222,24 +17120,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -19373,24 +17253,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -19472,24 +17334,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -19623,24 +17467,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -19722,24 +17548,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -19875,16 +17683,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -19944,16 +17742,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -20067,16 +17855,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -20136,16 +17914,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -20259,16 +18027,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -20328,16 +18086,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -20451,16 +18199,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -20520,16 +18258,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -20641,12 +18369,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -20706,12 +18428,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -20823,12 +18539,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -20888,12 +18598,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -21032,24 +18736,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -21131,24 +18817,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -21282,24 +18950,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -21381,24 +19031,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -21532,24 +19164,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag5",
@@ -21631,24 +19245,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -21782,24 +19378,6 @@
                                 "sourceTerm": "打ち込む",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -21881,24 +19459,6 @@
                                         ]
                                     }
                                 ]
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "ち",
-                                "furigana": ""
-                            },
-                            {
-                                "text": "込",
-                                "furigana": "こ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -22034,16 +19594,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -22103,16 +19653,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -22226,16 +19766,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -22295,16 +19825,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -22418,16 +19938,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -22487,16 +19997,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "う"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -22610,16 +20110,6 @@
                                 "sourceTerm": "打つ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -22679,16 +20169,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ぶ"
-                            },
-                            {
-                                "text": "つ",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -22800,12 +20280,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "だ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "だ"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -22865,12 +20339,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "だ"
                             }
                         ],
                         "glossary": [
@@ -22982,12 +20450,6 @@
                                 "sourceTerm": "打",
                                 "expression": "打",
                                 "reading": "ダース",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ダース"
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -23047,12 +20509,6 @@
                                     }
                                 ],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "打",
-                                "furigana": "ダース"
                             }
                         ],
                         "glossary": [
@@ -23193,16 +20649,6 @@
                                 "sourceTerm": "よむ",
                                 "expression": "読む",
                                 "reading": "よむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "読",
-                                        "furigana": "よ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "vt",
@@ -23217,16 +20663,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "読",
-                                "furigana": "よ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -23310,30 +20746,10 @@
                                 "sourceTerm": "つよみ",
                                 "expression": "強み",
                                 "reading": "つよみ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "強",
-                                        "furigana": "つよ"
-                                    },
-                                    {
-                                        "text": "み",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [],
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "強",
-                                "furigana": "つよ"
-                            },
-                            {
-                                "text": "み",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -23409,16 +20825,6 @@
                                 "sourceTerm": "よむ",
                                 "expression": "読む",
                                 "reading": "よむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "読",
-                                        "furigana": "よ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "vt",
@@ -23433,16 +20839,6 @@
                                 "termFrequency": "normal",
                                 "frequencies": [],
                                 "pitches": []
-                            }
-                        ],
-                        "furiganaSegments": [
-                            {
-                                "text": "読",
-                                "furigana": "よ"
-                            },
-                            {
-                                "text": "む",
-                                "furigana": ""
                             }
                         ],
                         "glossary": [
@@ -23512,24 +20908,6 @@
                                 "sourceTerm": "うちこむ",
                                 "expression": "打ち込む",
                                 "reading": "うちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -23634,24 +21012,6 @@
                                 "sourceTerm": "うちこむ",
                                 "expression": "打ち込む",
                                 "reading": "ぶちこむ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "ち",
-                                        "furigana": ""
-                                    },
-                                    {
-                                        "text": "込",
-                                        "furigana": "こ"
-                                    },
-                                    {
-                                        "text": "む",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -23761,24 +21121,6 @@
                                         "sourceTerm": "うちこむ",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -23912,24 +21254,6 @@
                                                 "sourceTerm": "うちこむ",
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -24011,24 +21335,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -24219,24 +21525,6 @@
                                         "sourceTerm": "うちこむ",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -24370,24 +21658,6 @@
                                                 "sourceTerm": "うちこむ",
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -24469,24 +21739,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -24677,24 +21929,6 @@
                                         "sourceTerm": "うちこむ",
                                         "expression": "打ち込む",
                                         "reading": "うちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag5",
@@ -24828,24 +22062,6 @@
                                                 "sourceTerm": "うちこむ",
                                                 "expression": "打ち込む",
                                                 "reading": "うちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag5",
@@ -24927,24 +22143,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -25135,24 +22333,6 @@
                                         "sourceTerm": "うちこむ",
                                         "expression": "打ち込む",
                                         "reading": "ぶちこむ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -25286,24 +22466,6 @@
                                                 "sourceTerm": "うちこむ",
                                                 "expression": "打ち込む",
                                                 "reading": "ぶちこむ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "ち",
-                                                        "furigana": ""
-                                                    },
-                                                    {
-                                                        "text": "込",
-                                                        "furigana": "こ"
-                                                    },
-                                                    {
-                                                        "text": "む",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -25385,24 +22547,6 @@
                                                         ]
                                                     }
                                                 ]
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "ち",
-                                                "furigana": ""
-                                            },
-                                            {
-                                                "text": "込",
-                                                "furigana": "こ"
-                                            },
-                                            {
-                                                "text": "む",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -25697,16 +22841,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "うつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "う"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -25771,16 +22905,6 @@
                                 "sourceTerm": "うつ",
                                 "expression": "打つ",
                                 "reading": "ぶつ",
-                                "furiganaSegments": [
-                                    {
-                                        "text": "打",
-                                        "furigana": "ぶ"
-                                    },
-                                    {
-                                        "text": "つ",
-                                        "furigana": ""
-                                    }
-                                ],
                                 "termTags": [
                                     {
                                         "name": "tag3",
@@ -25868,16 +22992,6 @@
                                         "sourceTerm": "うつ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -25991,16 +23105,6 @@
                                                 "sourceTerm": "うつ",
                                                 "expression": "打つ",
                                                 "reading": "うつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -26060,16 +23164,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -26216,16 +23310,6 @@
                                         "sourceTerm": "うつ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -26337,16 +23421,6 @@
                                                 "sourceTerm": "うつ",
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -26406,16 +23480,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -26562,16 +23626,6 @@
                                         "sourceTerm": "うつ",
                                         "expression": "打つ",
                                         "reading": "うつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -26685,16 +23739,6 @@
                                                 "sourceTerm": "うつ",
                                                 "expression": "打つ",
                                                 "reading": "うつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "う"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -26754,16 +23798,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "う"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [
@@ -26910,16 +23944,6 @@
                                         "sourceTerm": "うつ",
                                         "expression": "打つ",
                                         "reading": "ぶつ",
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
-                                            }
-                                        ],
                                         "termTags": [
                                             {
                                                 "name": "tag3",
@@ -27031,16 +24055,6 @@
                                                 "sourceTerm": "うつ",
                                                 "expression": "打つ",
                                                 "reading": "ぶつ",
-                                                "furiganaSegments": [
-                                                    {
-                                                        "text": "打",
-                                                        "furigana": "ぶ"
-                                                    },
-                                                    {
-                                                        "text": "つ",
-                                                        "furigana": ""
-                                                    }
-                                                ],
                                                 "termTags": [
                                                     {
                                                         "name": "tag3",
@@ -27100,16 +24114,6 @@
                                                     }
                                                 ],
                                                 "pitches": []
-                                            }
-                                        ],
-                                        "furiganaSegments": [
-                                            {
-                                                "text": "打",
-                                                "furigana": "ぶ"
-                                            },
-                                            {
-                                                "text": "つ",
-                                                "furigana": ""
                                             }
                                         ],
                                         "glossary": [


### PR DESCRIPTION
Removes some fields that are derived from other fields. This should help reduce the amount of data that needs to sent via the messaging system when looking up definitions.

As an example of the difference, `test/data/test-translator-data.json` was reduced by ~3000 lines.