### PR TITLE
Fix permissions changes not being supported on some browsers

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -180,9 +180,11 @@ class Backend {
         const onMessage = this._onMessageWrapper.bind(this);
         chrome.runtime.onMessage.addListener(onMessage);
 
-        const onPermissionsChanged = this._onWebExtensionEventWrapper(this._onPermissionsChanged.bind(this));
-        chrome.permissions.onAdded.addListener(onPermissionsChanged);
-        chrome.permissions.onRemoved.addListener(onPermissionsChanged);
+        if (this._canObservePermissionsChanges()) {
+            const onPermissionsChanged = this._onWebExtensionEventWrapper(this._onPermissionsChanged.bind(this));
+            chrome.permissions.onAdded.addListener(onPermissionsChanged);
+            chrome.permissions.onRemoved.addListener(onPermissionsChanged);
+        }
 
         chrome.runtime.onInstalled.addListener(this._onInstalled.bind(this));
     }
@@ -2095,7 +2097,12 @@ class Backend {
         this._updateBadge();
     }
 
+    _canObservePermissionsChanges() {
+        return isObject(chrome.permissions) && isObject(chrome.permissions.onAdded) && isObject(chrome.permissions.onRemoved);
+    }
+
     _hasRequiredPermissionsForSettings(options) {
+        if (!this._canObservePermissionsChanges()) { return true; }
         return this._permissions === null || this._permissionsUtil.hasRequiredPermissionsForOptions(this._permissions, options);
     }
 

--- a/ext/js/pages/settings/settings-controller.js
+++ b/ext/js/pages/settings/settings-controller.js
@@ -51,8 +51,10 @@ class SettingsController extends EventDispatcher {
 
     prepare() {
         yomichan.on('optionsUpdated', this._onOptionsUpdated.bind(this));
-        chrome.permissions.onAdded.addListener(this._onPermissionsChanged.bind(this));
-        chrome.permissions.onRemoved.addListener(this._onPermissionsChanged.bind(this));
+        if (this._canObservePermissionsChanges()) {
+            chrome.permissions.onAdded.addListener(this._onPermissionsChanged.bind(this));
+            chrome.permissions.onRemoved.addListener(this._onPermissionsChanged.bind(this));
+        }
     }
 
     async refresh() {
@@ -205,5 +207,9 @@ class SettingsController extends EventDispatcher {
 
         const permissions = await this._permissionsUtil.getAllPermissions();
         this.trigger(event, {permissions});
+    }
+
+    _canObservePermissionsChanges() {
+        return isObject(chrome.permissions) && isObject(chrome.permissions.onAdded) && isObject(chrome.permissions.onRemoved);
     }
 }


### PR DESCRIPTION
`chrome.permissions.onAdded/onRemoved` was not supported until Firefox 77.
https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/permissions

Fixes #1510.