### PR TITLE
Fix incorrect furigana distribution

### DIFF
--- a/test/test-japanese.js
+++ b/test/test-japanese.js
@@ -729,16 +729,26 @@ function testDistributeFuriganaInflected() {
             ['美味しい', 'おいしい', '美味しかた'],
             [
                 {text: '美味', furigana: 'おい'},
-                {text: 'し', furigana: ''},
-                {text: 'かた', furigana: ''}
+                {text: 'しかた', furigana: ''}
             ]
         ],
         [
             ['食べる', 'たべる', '食べた'],
             [
                 {text: '食', furigana: 'た'},
-                {text: 'べ', furigana: ''},
-                {text: 'た', furigana: ''}
+                {text: 'べた', furigana: ''}
+            ]
+        ],
+        [
+            ['迄に', 'までに', 'までに'],
+            [
+                {text: 'までに', furigana: ''}
+            ]
+        ],
+        [
+            ['行う', 'おこなう', 'おこなわなかった'],
+            [
+                {text: 'おこなわなかった', furigana: ''}
             ]
         ]
     ];


### PR DESCRIPTION
Fixes #1509. `distributeFuriganaInflected` did not properly handle cases where the source matches the reading instead of the expression.

Prior to #1496, this only incidentally seemed to work. The bug that was fixed in that commit was causing an _apparently_ correct,  but still broken, behaviour of this function.