### PR TITLE
Fix dictionary image support

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -114,7 +114,7 @@
             "popup.html",
             "template-renderer.html"
         ],
-        "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+        "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
     },
     "variants": [
         {
@@ -194,7 +194,7 @@
                 {
                     "action": "set",
                     "path": ["content_security_policy"],
-                    "value": "default-src 'self'; script-src 'self' 'unsafe-eval'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+                    "value": "default-src 'self'; script-src 'self' 'unsafe-eval'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
                 },
                 {
                     "action": "set",

--- a/dev/database-vm.js
+++ b/dev/database-vm.js
@@ -76,6 +76,13 @@ class Image {
     }
 }
 
+class Blob {
+    constructor(array, options) {
+        this._array = array;
+        this._options = options;
+    }
+}
+
 async function fetch(url2) {
     const filePath = url.fileURLToPath(url2);
     await Promise.resolve();
@@ -89,15 +96,21 @@ async function fetch(url2) {
     };
 }
 
+function atob(data) {
+    return Buffer.from(data, 'base64').toString('ascii');
+}
+
 class DatabaseVM extends VM {
     constructor() {
         super({
             chrome,
             Image,
+            Blob,
             fetch,
             indexedDB: global.indexedDB,
             IDBKeyRange: global.IDBKeyRange,
-            JSZip
+            JSZip,
+            atob
         });
         this.context.window = this.context;
         this.indexedDB = global.indexedDB;

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -400,7 +400,9 @@ class DictionaryImporter {
                 eventListeners.removeAllEventListeners();
                 reject(new Error('Image failed to load'));
             }, false);
-            image.src = `data:${mediaType};base64,${content}`;
+            const blob = MediaUtil.createBlobFromBase64Content(content, mediaType);
+            const url = URL.createObjectURL(blob);
+            image.src = url;
         });
     }
 }

--- a/ext/js/media/media-loader.js
+++ b/ext/js/media/media-loader.js
@@ -15,6 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* global
+ * MediaUtil
+ */
+
 class MediaLoader {
     constructor() {
         this._token = {};
@@ -82,22 +86,11 @@ class MediaLoader {
         const token = this._token;
         const data = (await yomichan.api.getMedia([{path, dictionaryName}]))[0];
         if (token === this._token && data !== null) {
-            const contentArrayBuffer = this._base64ToArrayBuffer(data.content);
-            const blob = new Blob([contentArrayBuffer], {type: data.mediaType});
+            const blob = MediaUtil.createBlobFromBase64Content(data.content, data.mediaType);
             const url = URL.createObjectURL(blob);
             cachedData.data = data;
             cachedData.url = url;
         }
         return cachedData;
-    }
-
-    _base64ToArrayBuffer(content) {
-        const binaryContent = window.atob(content);
-        const length = binaryContent.length;
-        const array = new Uint8Array(length);
-        for (let i = 0; i < length; ++i) {
-            array[i] = binaryContent.charCodeAt(i);
-        }
-        return array.buffer;
     }
 }

--- a/ext/js/media/media-util.js
+++ b/ext/js/media/media-util.js
@@ -129,4 +129,20 @@ class MediaUtil {
                 return null;
         }
     }
+
+    /**
+     * Creates a new `Blob` object from a base64 string of content.
+     * @param content The binary content string encoded in base64.
+     * @param mediaType The type of the media.
+     * @returns A new `Blob` object corresponding to the specified content.
+     */
+    static createBlobFromBase64Content(content, mediaType) {
+        const binaryContent = atob(content);
+        const length = binaryContent.length;
+        const array = new Uint8Array(length);
+        for (let i = 0; i < length; ++i) {
+            array[i] = binaryContent.charCodeAt(i);
+        }
+        return new Blob([array.buffer], {type: mediaType});
+    }
 }

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -113,5 +113,5 @@
         "popup.html",
         "template-renderer.html"
     ],
-    "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
+    "content_security_policy": "default-src 'self'; img-src blob: 'self'; style-src 'self' 'unsafe-inline'; media-src *; connect-src *"
 }

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -123,6 +123,7 @@
 <script src="/js/language/text-scanner.js"></script>
 <script src="/js/media/audio-system.js"></script>
 <script src="/js/media/media-loader.js"></script>
+<script src="/js/media/media-util.js"></script>
 <script src="/js/media/text-to-speech-audio.js"></script>
 <script src="/js/script/dynamic-loader.js"></script>
 <script src="/js/templates/template-renderer-proxy.js"></script>

--- a/ext/search.html
+++ b/ext/search.html
@@ -107,6 +107,7 @@
 <script src="/js/language/text-scanner.js"></script>
 <script src="/js/media/audio-system.js"></script>
 <script src="/js/media/media-loader.js"></script>
+<script src="/js/media/media-util.js"></script>
 <script src="/js/media/text-to-speech-audio.js"></script>
 <script src="/js/script/dynamic-loader.js"></script>
 <script src="/js/templates/template-renderer-proxy.js"></script>


### PR DESCRIPTION
Content security policy was blocking `data:` images from being validated during initial import. `blob:` is now consistently used for all images and has been added to the CSP.