### PR TITLE
Remove repeated disambiguations

### DIFF
--- a/ext/js/language/dictionary-data-util.js
+++ b/ext/js/language/dictionary-data-util.js
@@ -172,8 +172,19 @@ class DictionaryDataUtil {
         }
 
         const disambiguations = [];
-        if (!this._areSetsEqual(terms, allTermsSet)) { disambiguations.push(...this._getSetIntersection(terms, allTermsSet)); }
-        if (!this._areSetsEqual(readings, allReadingsSet)) { disambiguations.push(...this._getSetIntersection(readings, allReadingsSet)); }
+        const addTerms = !this._areSetsEqual(terms, allTermsSet);
+        const addReadings = !this._areSetsEqual(readings, allReadingsSet);
+        if (addTerms) {
+            disambiguations.push(...this._getSetIntersection(terms, allTermsSet));
+        }
+        if (addReadings) {
+            if (addTerms) {
+                for (const term of terms) {
+                    readings.delete(term);
+                }
+            }
+            disambiguations.push(...this._getSetIntersection(readings, allReadingsSet));
+        }
         return disambiguations;
     }
 


### PR DESCRIPTION
This would occur for certain words with the same reading, such as あああ. Would show up as _(あああ, あああ only)_.