### PR TITLE
Optimize template renderer

### DIFF
--- a/ext/js/templates/template-renderer-frame-api.js
+++ b/ext/js/templates/template-renderer-frame-api.js
@@ -20,6 +20,7 @@ class TemplateRendererFrameApi {
         this._templateRenderer = templateRenderer;
         this._windowMessageHandlers = new Map([
             ['render', {async: false, handler: this._onRender.bind(this)}],
+            ['renderMulti', {async: false, handler: this._onRenderMulti.bind(this)}],
             ['getModifiedData', {async: false, handler: this._onGetModifiedData.bind(this)}]
         ]);
     }
@@ -58,6 +59,10 @@ class TemplateRendererFrameApi {
         return this._templateRenderer.render(template, data, type);
     }
 
+    _onRenderMulti({items}) {
+        return this._serializeMulti(this._templateRenderer.renderMulti(items));
+    }
+
     _onGetModifiedData({data, type}) {
         const result = this._templateRenderer.getModifiedData(data, type);
         return this._clone(result);
@@ -80,6 +85,17 @@ class TemplateRendererFrameApi {
             value: error,
             hasValue: true
         };
+    }
+
+    _serializeMulti(array) {
+        for (let i = 0, ii = array.length; i < ii; ++i) {
+            const value = array[i];
+            const {error} = value;
+            if (typeof error !== 'undefined') {
+                value.error = this._serializeError(error);
+            }
+        }
+        return array;
     }
 
     _clone(value) {

--- a/ext/js/templates/template-renderer-frame-main.js
+++ b/ext/js/templates/template-renderer-frame-main.js
@@ -27,7 +27,8 @@
     const templateRenderer = new TemplateRenderer(japaneseUtil);
     const ankiNoteDataCreator = new AnkiNoteDataCreator(japaneseUtil);
     templateRenderer.registerDataType('ankiNote', {
-        modifier: ({marker, commonData}) => ankiNoteDataCreator.create(marker, commonData)
+        modifier: ({marker, commonData}) => ankiNoteDataCreator.create(marker, commonData),
+        composeData: (marker, commonData) => ({marker, commonData})
     });
     const templateRendererFrameApi = new TemplateRendererFrameApi(templateRenderer);
     templateRendererFrameApi.prepare();

--- a/ext/js/templates/template-renderer-proxy.js
+++ b/ext/js/templates/template-renderer-proxy.js
@@ -30,6 +30,11 @@ class TemplateRendererProxy {
         return await this._invoke('render', {template, data, type});
     }
 
+    async renderMulti(items) {
+        await this._prepareFrame();
+        return await this._invoke('renderMulti', {items});
+    }
+
     async getModifiedData(data, type) {
         await this._prepareFrame();
         return await this._invoke('getModifiedData', {data, type});

--- a/test/test-anki-note-builder.js
+++ b/test/test-anki-note-builder.js
@@ -55,12 +55,28 @@ async function createVM() {
             const japaneseUtil = new JapaneseUtil(null);
             this._templateRenderer = new TemplateRenderer(japaneseUtil);
             this._templateRenderer.registerDataType('ankiNote', {
-                modifier: ({marker, commonData}) => ankiNoteDataCreator.create(marker, commonData)
+                modifier: ({marker, commonData}) => ankiNoteDataCreator.create(marker, commonData),
+                composeData: (marker, commonData) => ({marker, commonData})
             });
         }
 
         async render(template, data, type) {
-            return await this._templateRenderer.render(template, data, type);
+            return this._templateRenderer.render(template, data, type);
+        }
+
+        async renderMulti(items) {
+            return this._serializeMulti(this._templateRenderer.renderMulti(items));
+        }
+
+        _serializeMulti(array) {
+            for (let i = 0, ii = array.length; i < ii; ++i) {
+                const value = array[i];
+                const {error} = value;
+                if (typeof error !== 'undefined') {
+                    value.error = this._serializeError(error);
+                }
+            }
+            return array;
         }
     }
     vm.set({TemplateRendererProxy});


### PR DESCRIPTION
This change optimizes the template rendering process by batching data together before sending to the rendering frame. This can result in an improvement of nearly 100x reduction of total data transmission. Metrics based on a test with many dictionaries installed and many Anki card fields:

* 21.2.28.2 - 53,317,095 (prior to Translator data refactoring)
* 21.3.31.0 - 23,957,117
* After this change - 240,763

The value is the sum of the lengths of all `JSON.stringify(data)` passed to the rendering frame, for a single lookup of 日本語. The values were calculated from this patch:

```patch
diff --git a/ext/js/templates/template-renderer-frame-api.js b/ext/js/templates/template-renderer-frame-api.js
index dd6be5173..b80c3a264 100644
--- a/ext/js/templates/template-renderer-frame-api.js
+++ b/ext/js/templates/template-renderer-frame-api.js
@@ -17,6 +17,7 @@
 
 class TemplateRendererFrameApi {
     constructor(templateRenderer) {
+        this._totalSize = 0;
         this._templateRenderer = templateRenderer;
         this._windowMessageHandlers = new Map([
             ['render', {async: false, handler: this._onRender.bind(this)}],
@@ -36,6 +37,8 @@ class TemplateRendererFrameApi {
         const messageHandler = this._windowMessageHandlers.get(action);
         if (typeof messageHandler === 'undefined') { return; }
 
+        this._totalSize += JSON.stringify(e.data).length;
+        console.log(`totalSize = ${this._totalSize.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')}`);
         this._onWindowMessageInner(messageHandler, action, params, source, id);
     }
```