### PR TITLE
Fix autofocus sometimes not working on the search page

### DIFF
--- a/ext/js/display/search-main.js
+++ b/ext/js/display/search-main.js
@@ -26,7 +26,7 @@
 
 (async () => {
     try {
-        const documentFocusController = new DocumentFocusController();
+        const documentFocusController = new DocumentFocusController('#search-textbox');
         documentFocusController.prepare();
 
         await yomichan.prepare();

--- a/ext/js/dom/document-focus-controller.js
+++ b/ext/js/dom/document-focus-controller.js
@@ -22,13 +22,17 @@
  * focus a dummy element inside the main content, which gives keyboard scroll focus to that element.
  */
 class DocumentFocusController {
-    constructor() {
+    constructor(autofocusElementSelector=null) {
+        this._autofocusElement = (autofocusElementSelector !== null ? document.querySelector(autofocusElementSelector) : null);
         this._contentScrollFocusElement = document.querySelector('#content-scroll-focus');
     }
 
     prepare() {
         window.addEventListener('focus', this._onWindowFocus.bind(this), false);
         this._updateFocusedElement(false);
+        if (this._autofocusElement !== null && document.activeElement !== this._autofocusElement) {
+            this._autofocusElement.focus({preventScroll: true});
+        }
     }
 
     blurElement(element) {


### PR DESCRIPTION
Appears to be a race condition, as manually `.focus()`ing an element prevents autofocus. Fixes #1595.