### PR TITLE
Show any custom tags on words that have anki cards created

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -691,6 +691,9 @@ button.action-button[data-icon=play-audio]::before {
 button.action-button[data-icon=source-term]::before {
     background-image: url('/images/source-term.svg');
 }
+button.action-button[data-icon=magnifying-glass]::before {
+    background-image: url('/images/magnifying-glass.svg');
+}
 :root[data-result-output-mode=merge] .entry[data-type=term] .actions>button.action-button.action-play-audio {
     display: none;
 }

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -644,7 +644,7 @@ button.action-button[hidden] {
         -webkit-filter var(--animation-duration) linear,
         background-color var(--animation-duration) linear;
 }
-button.collapsable-action-button[hidden] {
+button.collapsible-action-button[hidden] {
     display: none;
 }
 button.action-button:disabled {

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -667,7 +667,7 @@ button.action-button:active {
     background-color: var(--action-button-active-color);
     box-shadow: none;
 }
-button.action-button::before {
+button.action-button[data-icon]::before {
     content: '';
     width: var(--action-button-size);
     height: var(--action-button-size);
@@ -693,6 +693,12 @@ button.action-button[data-icon=source-term]::before {
 }
 button.action-button[data-icon=magnifying-glass]::before {
     background-image: url('/images/magnifying-glass.svg');
+}
+.action-view-tags>.icon {
+    display: block;
+    width: var(--action-button-size);
+    height: var(--action-button-size);
+    background-color: var(--text-color);
 }
 :root[data-result-output-mode=merge] .entry[data-type=term] .actions>button.action-button.action-play-audio {
     display: none;

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -691,9 +691,6 @@ button.action-button[data-icon=play-audio]::before {
 button.action-button[data-icon=source-term]::before {
     background-image: url('/images/source-term.svg');
 }
-button.action-button[data-icon=magnifying-glass]::before {
-    background-image: url('/images/magnifying-glass.svg');
-}
 .action-view-tags>.icon {
     display: block;
     width: var(--action-button-size);

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -644,6 +644,9 @@ button.action-button[hidden] {
         -webkit-filter var(--animation-duration) linear,
         background-color var(--animation-duration) linear;
 }
+button.collapsable-action-button[hidden] {
+    display: none;
+}
 button.action-button:disabled {
     pointer-events: none;
     cursor: default;

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -806,7 +806,8 @@
                                     "duplicateScope",
                                     "checkForDuplicates",
                                     "fieldTemplates",
-                                    "suspendNewCards"
+                                    "suspendNewCards",
+                                    "displayTags"
                                 ],
                                 "properties": {
                                     "enable": {
@@ -912,6 +913,11 @@
                                     "suspendNewCards": {
                                         "type": "boolean",
                                         "default": false
+                                    },
+                                    "displayTags": {
+                                        "type": "string",
+                                        "enum": ["never", "always", "non-standard"],
+                                        "default": "never"
                                     }
                                 }
                             },

--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -5,7 +5,7 @@
     <div class="entry-current-indicator" title="Current entry"><span class="entry-current-indicator-inner"></span></div>
     <div class="entry-header">
         <div class="actions">
-            <button class="action-button action-view-tags" hidden disabled data-icon="magnifying-glass" title="Note has tags"></button>
+            <button class="action-button action-view-tags" hidden disabled><span class="icon" data-icon="tag"></span></button>
             <button class="action-button action-view-note" hidden disabled data-icon="view-note" title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kanji" data-mode="term-kanji" title="Add expression" data-hotkey='["addNoteTermKanji","title","Add expression ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kana" data-mode="term-kana" title="Add reading" data-hotkey='["addNoteTermKana","title","Add reading ({0})"]'></button>

--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -5,6 +5,7 @@
     <div class="entry-current-indicator" title="Current entry"><span class="entry-current-indicator-inner"></span></div>
     <div class="entry-header">
         <div class="actions">
+            <button class="action-button action-view-tags" hidden disabled data-icon="magnifying-glass" title="Note has tags"></button>
             <button class="action-button action-view-note" hidden disabled data-icon="view-note" title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kanji" data-mode="term-kanji" title="Add expression" data-hotkey='["addNoteTermKanji","title","Add expression ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kana" data-mode="term-kana" title="Add reading" data-hotkey='["addNoteTermKana","title","Add reading ({0})"]'></button>

--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -5,7 +5,7 @@
     <div class="entry-current-indicator" title="Current entry"><span class="entry-current-indicator-inner"></span></div>
     <div class="entry-header">
         <div class="actions">
-            <button class="action-button collapsable-action-button action-view-tags" hidden disabled><span class="icon" data-icon="tag"></span></button>
+            <button class="action-button collapsible-action-button action-view-tags" hidden disabled><span class="icon" data-icon="tag"></span></button>
             <button class="action-button action-view-note" hidden disabled data-icon="view-note" title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kanji" data-mode="term-kanji" title="Add expression" data-hotkey='["addNoteTermKanji","title","Add expression ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kana" data-mode="term-kana" title="Add reading" data-hotkey='["addNoteTermKana","title","Add reading ({0})"]'></button>

--- a/ext/display-templates.html
+++ b/ext/display-templates.html
@@ -5,7 +5,7 @@
     <div class="entry-current-indicator" title="Current entry"><span class="entry-current-indicator-inner"></span></div>
     <div class="entry-header">
         <div class="actions">
-            <button class="action-button action-view-tags" hidden disabled><span class="icon" data-icon="tag"></span></button>
+            <button class="action-button collapsable-action-button action-view-tags" hidden disabled><span class="icon" data-icon="tag"></span></button>
             <button class="action-button action-view-note" hidden disabled data-icon="view-note" title="View added note" data-hotkey='["viewNote","title","View added note ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kanji" data-mode="term-kanji" title="Add expression" data-hotkey='["addNoteTermKanji","title","Add expression ({0})"]'></button>
             <button class="action-button action-add-note" hidden disabled data-icon="add-term-kana" data-mode="term-kana" title="Add reading" data-hotkey='["addNoteTermKana","title","Add reading ({0})"]'></button>

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -480,7 +480,6 @@ class Backend {
             const noteIdsArray = await this._anki.findNoteIds(cannotAddNotes);
             for (let i = 0, ii = Math.min(cannotAdd.length, noteIdsArray.length); i < ii; ++i) {
                 const noteIds = noteIdsArray[i];
-
                 if (noteIds.length > 0) {
                     cannotAdd[i].info.noteIds = noteIds;
                     cannotAdd[i].info.noteInfos = await this._anki.notesInfo(noteIds);

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -469,7 +469,6 @@ class Backend {
             const valid = AnkiUtil.isNoteDataValid(note);
             if (!valid) { canAdd = false; }
             const info = {canAdd, valid, noteIds: null};
-
             results.push(info);
             if (!canAdd && valid) {
                 cannotAdd.push({note, info});
@@ -484,29 +483,7 @@ class Backend {
 
                 if (noteIds.length > 0) {
                     cannotAdd[i].info.noteIds = noteIds;
-
-                    /* TODO: should i be selecting the first ID like this?
-                        looking at findNoteIds I can't see how we could find
-                        more than one ID, but an example that proves me wrong
-                        would be cool (and also how to get the right ID) */
-                    const noteId = noteIds[0];
-
-                    /* TODO: should I be catching any errors here? findNoteIds
-                        is not wrapped in try/catch, but I can't find a catch
-                        anywhere in the code that calls this function */
-                    const noteInfo = (await this._anki.notesInfo([noteId]))[0];
-
-                    /* TODO: is this the right way to get user settings?
-                        I couldn't find any examples in the code */
-                    const settingsTags = this._getSetting({
-                        path: 'anki.tags',
-                        scope: 'profile',
-                        optionsContext: {current: true}
-                    });
-
-                    if (settingsTags && noteInfo) {
-                        cannotAdd[i].info.tags = noteInfo.tags.filter((tag) => !settingsTags.includes(tag));
-                    }
+                    cannotAdd[i].info.noteInfos = await this._anki.notesInfo(noteIds);
                 }
             }
         }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -458,7 +458,7 @@ class Backend {
         return await this._anki.addNote(note);
     }
 
-    async _onApiGetAnkiNoteInfo({notes}) {
+    async _onApiGetAnkiNoteInfo({notes, fetchAdditionalInfo}) {
         const results = [];
         const cannotAdd = [];
         const canAddArray = await this._anki.canAddNotes(notes);
@@ -482,7 +482,9 @@ class Backend {
                 const noteIds = noteIdsArray[i];
                 if (noteIds.length > 0) {
                     cannotAdd[i].info.noteIds = noteIds;
-                    cannotAdd[i].info.noteInfos = await this._anki.notesInfo(noteIds);
+                    if (fetchAdditionalInfo) {
+                        cannotAdd[i].info.noteInfos = await this._anki.notesInfo(noteIds);
+                    }
                 }
             }
         }

--- a/ext/js/comm/anki.js
+++ b/ext/js/comm/anki.js
@@ -71,6 +71,12 @@ class AnkiConnect {
         return await this._invoke('canAddNotes', {notes});
     }
 
+    async notesInfo(notes) {
+        if (!this._enabled) { return []; }
+        await this._checkVersion();
+        return await this._invoke('notesInfo', {notes});
+    }
+
     async getDeckNames() {
         if (!this._enabled) { return []; }
         await this._checkVersion();

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -52,8 +52,8 @@ class API {
         return this._invoke('addAnkiNote', {note});
     }
 
-    getAnkiNoteInfo(notes) {
-        return this._invoke('getAnkiNoteInfo', {notes});
+    getAnkiNoteInfo(notes, fetchAdditionalInfo) {
+        return this._invoke('getAnkiNoteInfo', {notes, fetchAdditionalInfo});
     }
 
     injectAnkiNoteMedia(timestamp, definitionDetails, audioDetails, screenshotDetails, clipboardDetails) {

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -792,7 +792,7 @@ class OptionsUtil {
         // Version 11 changes:
         //  Changed dictionaries to an array.
         //  Changed audio.customSourceUrl's {expression} marker to {term}.
-        //  Added anki.displayTags
+        //  Added anki.displayTags.
         const customSourceUrlPattern = /\{expression\}/g;
         for (const profile of options.profiles) {
             const dictionariesNew = [];

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -792,6 +792,7 @@ class OptionsUtil {
         // Version 11 changes:
         //  Changed dictionaries to an array.
         //  Changed audio.customSourceUrl's {expression} marker to {term}.
+        //  Added anki.displayTags
         const customSourceUrlPattern = /\{expression\}/g;
         for (const profile of options.profiles) {
             const dictionariesNew = [];
@@ -805,6 +806,8 @@ class OptionsUtil {
                 customSourceUrl = customSourceUrl.replace(customSourceUrlPattern, '{term}');
             }
             profile.options.audio.customSourceUrl = customSourceUrl;
+
+            profile.options.anki.displayTags = 'never';
         }
         return options;
     }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1100,7 +1100,7 @@ class Display extends EventDispatcher {
             const infos = states[i];
             let noteId = null;
             for (let j = 0, jj = infos.length; j < jj; ++j) {
-                const {canAdd, noteIds} = infos[j];
+                const {canAdd, noteIds, tags} = infos[j];
                 const mode = modes[j];
                 const button = this._adderButtonFind(i, mode);
                 if (button === null) {
@@ -1112,6 +1112,17 @@ class Display extends EventDispatcher {
                 }
                 button.disabled = !canAdd;
                 button.hidden = false;
+
+                if (button.disabled && tags && tags.length >= 1) {
+                    const tagsIndicator = this._tagsIndicatorFind(i);
+                    if (tagsIndicator === null) {
+                        continue;
+                    }
+
+                    tagsIndicator.disabled = false;
+                    tagsIndicator.hidden = false;
+                    tagsIndicator.title = `Card tags: ${tags.join(', ')}`;
+                }
             }
             if (noteId !== null) {
                 this._viewerButtonShow(i, noteId);
@@ -1318,6 +1329,11 @@ class Display extends EventDispatcher {
     _adderButtonFind(index, mode) {
         const entry = this._getEntry(index);
         return entry !== null ? entry.querySelector(`.action-add-note[data-mode="${mode}"]`) : null;
+    }
+
+    _tagsIndicatorFind(index) {
+        const entry = this._getEntry(index);
+        return entry !== null ? entry.querySelector('.action-view-tags') : null;
     }
 
     _viewerButtonFind(index) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1082,8 +1082,8 @@ class Display extends EventDispatcher {
             let states;
             try {
                 const noteContext = this._getNoteContext();
-                const {checkForDuplicates} = this._options.anki;
-                states = await this._areDictionaryEntriesAddable(dictionaryEntries, modes, noteContext, checkForDuplicates ? null : true);
+                const {checkForDuplicates, displayTags} = this._options.anki;
+                states = await this._areDictionaryEntriesAddable(dictionaryEntries, modes, noteContext, checkForDuplicates ? null : true, displayTags !== 'never');
             } catch (e) {
                 return;
             }
@@ -1147,7 +1147,7 @@ class Display extends EventDispatcher {
         if (noteTags.size > 0) {
             tagsIndicator.disabled = false;
             tagsIndicator.hidden = false;
-            tagsIndicator.title = `Card tags: ${Array.from(noteTags).join(', ')}`;
+            tagsIndicator.title = `Card tags: ${[...noteTags].join(', ')}`;
         }
     }
 
@@ -1478,7 +1478,7 @@ class Display extends EventDispatcher {
         return templates;
     }
 
-    async _areDictionaryEntriesAddable(dictionaryEntries, modes, context, forceCanAddValue) {
+    async _areDictionaryEntriesAddable(dictionaryEntries, modes, context, forceCanAddValue, fetchAdditionalInfo) {
         const modeCount = modes.length;
         const notePromises = [];
         for (const dictionaryEntry of dictionaryEntries) {
@@ -1496,7 +1496,7 @@ class Display extends EventDispatcher {
             }
             infos = this._getAnkiNoteInfoForceValue(notes, forceCanAddValue);
         } else {
-            infos = await yomichan.api.getAnkiNoteInfo(notes);
+            infos = await yomichan.api.getAnkiNoteInfo(notes, fetchAdditionalInfo);
         }
 
         const results = [];

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1115,8 +1115,8 @@ class Display extends EventDispatcher {
                 button.hidden = false;
 
 
-                // this._setupTagsIndicator(i, noteInfos);
-                if (noteInfos) {
+                const showTags = this._options.anki.showTags;
+                if (showTags && noteInfos) {
                     this._setupTagsIndicator(i, noteInfos);
                 }
             }
@@ -1140,9 +1140,12 @@ class Display extends EventDispatcher {
         // in case a user has disabled note duplication check we look at the tags for all notes
         // that were found. this seems to fit the purpose of showing tags better
         // (i already have this word added but i still want to pay special attention to it for some reason)
-        const noteTags = noteInfos.reduce((tags, noteInfo) => tags.concat(noteInfo.tags), []);
+        let tags = noteInfos.reduce((ts, noteInfo) => ts.concat(noteInfo.tags), []);
 
-        const tags = noteTags.filter((tag) => !optionTags.includes(tag));
+        const filterTags = this._options.anki.filterTags;
+        if (filterTags) {
+            tags = tags.filter((tag) => !optionTags.includes(tag));
+        }
 
         tagsIndicator.disabled = false;
         tagsIndicator.hidden = false;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1147,9 +1147,11 @@ class Display extends EventDispatcher {
             tags = tags.filter((tag) => !optionTags.includes(tag));
         }
 
-        tagsIndicator.disabled = false;
-        tagsIndicator.hidden = false;
-        tagsIndicator.title = `Card tags: ${tags.join(', ')}`;
+        if (tags.length > 0) {
+            tagsIndicator.disabled = false;
+            tagsIndicator.hidden = false;
+            tagsIndicator.title = `Card tags: ${tags.join(', ')}`;
+        }
     }
 
     _onShowTags(e) {

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -61,6 +61,8 @@ class AnkiController {
         this._ankiEnableCheckbox = document.querySelector('[data-setting="anki.enable"]');
         this._ankiCardPrimary = document.querySelector('#anki-card-primary');
         const ankiCardPrimaryTypeRadios = document.querySelectorAll('input[type=radio][name=anki-card-primary-type]');
+        this._ankiShowCustomTagsToggle = document.querySelector('#show-tags-enabled');
+        this._ankiFilterTagsEnabledMoreOptions = document.querySelector('#filter-tags-enabled-more-options');
 
         this._setupFieldMenus();
 
@@ -69,6 +71,8 @@ class AnkiController {
         for (const input of ankiCardPrimaryTypeRadios) {
             input.addEventListener('change', this._onAnkiCardPrimaryTypeRadioChange.bind(this), false);
         }
+
+        this._ankiShowCustomTagsToggle.addEventListener('change', this._onAnkiShowTagsChanged.bind(this));
 
         const options = await this._settingsController.getOptions();
         this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
@@ -165,6 +169,8 @@ class AnkiController {
 
         this._selectorObserver.disconnect();
         this._selectorObserver.observe(document.documentElement, true);
+
+        this._ankiShowTagsMoreOptions(anki.showTags);
     }
 
     _onAnkiErrorMessageDetailsToggleClick() {
@@ -328,6 +334,15 @@ class AnkiController {
     _sortStringArray(array) {
         const stringComparer = this._stringComparer;
         array.sort((a, b) => stringComparer.compare(a, b));
+    }
+
+    _onAnkiShowTagsChanged(e) {
+        const value = e.currentTarget.checked;
+        this._ankiShowTagsMoreOptions(value);
+    }
+
+    _ankiShowTagsMoreOptions(value) {
+        this._ankiFilterTagsEnabledMoreOptions.hidden = !value;
     }
 }
 

--- a/ext/js/pages/settings/anki-controller.js
+++ b/ext/js/pages/settings/anki-controller.js
@@ -61,8 +61,6 @@ class AnkiController {
         this._ankiEnableCheckbox = document.querySelector('[data-setting="anki.enable"]');
         this._ankiCardPrimary = document.querySelector('#anki-card-primary');
         const ankiCardPrimaryTypeRadios = document.querySelectorAll('input[type=radio][name=anki-card-primary-type]');
-        this._ankiShowCustomTagsToggle = document.querySelector('#show-tags-enabled');
-        this._ankiFilterTagsEnabledMoreOptions = document.querySelector('#filter-tags-enabled-more-options');
 
         this._setupFieldMenus();
 
@@ -71,8 +69,6 @@ class AnkiController {
         for (const input of ankiCardPrimaryTypeRadios) {
             input.addEventListener('change', this._onAnkiCardPrimaryTypeRadioChange.bind(this), false);
         }
-
-        this._ankiShowCustomTagsToggle.addEventListener('change', this._onAnkiShowTagsChanged.bind(this));
 
         const options = await this._settingsController.getOptions();
         this._settingsController.on('optionsChanged', this._onOptionsChanged.bind(this));
@@ -169,8 +165,6 @@ class AnkiController {
 
         this._selectorObserver.disconnect();
         this._selectorObserver.observe(document.documentElement, true);
-
-        this._ankiShowTagsMoreOptions(anki.showTags);
     }
 
     _onAnkiErrorMessageDetailsToggleClick() {
@@ -334,15 +328,6 @@ class AnkiController {
     _sortStringArray(array) {
         const stringComparer = this._stringComparer;
         array.sort((a, b) => stringComparer.compare(a, b));
-    }
-
-    _onAnkiShowTagsChanged(e) {
-        const value = e.currentTarget.checked;
-        this._ankiShowTagsMoreOptions(value);
-    }
-
-    _ankiShowTagsMoreOptions(value) {
-        this._ankiFilterTagsEnabledMoreOptions.hidden = !value;
     }
 }
 

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1581,6 +1581,47 @@
                 <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
             </div>
         </div></div>
+        <div class="settings-item advanced-only">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Show custom card tags</div>
+                    <div class="settings-item-description">
+                        Show an icon next to the "view added note" button that shows all tags on that note (if it has
+                        any).
+                    </div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle">
+                        <input type="checkbox" data-setting="anki.showTags" id="show-tags-enabled">
+                        <span class="toggle-body">
+                            <span class="toggle-track"></span>
+                            <span class="toggle-knob"></span>
+                        </span>
+                    </label>
+                </div>
+            </div>
+            <div class="settings-item-children settings-item-children-group" id="filter-tags-enabled-more-options" hidden>
+                <div class="settings-item advanced-only">
+                    <div class="settings-item-inner">
+                        <div class="settings-item-left">
+                            <div class="settings-item-label">Filter tags</div>
+                            <div class="settings-item-description">
+                                Don't show tags included in the "Card tags" option above.
+                            </div>
+                        </div>
+                        <div class="settings-item-right">
+                            <label class="toggle">
+                                <input type="checkbox" data-setting="anki.filterTags" id="filter-tags-enabled">
+                                <span class="toggle-body">
+                                    <span class="toggle-track"></span>
+                                    <span class="toggle-knob"></span>
+                                </span>
+                            </label>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
     </div>
 
     <!-- Clipboard -->

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1599,10 +1599,10 @@
             </div>
             <div class="settings-item-children more" hidden>
                 <p>
-                    When coming across a word that is already in an anki deck, show an icon that lets you quickly see
-                    which tags that card has. If set to <em>Non-Standard</em> then all tags that are included in the
-                    <em>Card tags</em> option will be filtered out from the list. If no tags remain after filtering, then
-                    the icon will not be shown.
+                    When coming across a word that is already in an Anki deck, a button will appear that shows
+                    the tags the card has. If set to <em>Non-Standard</em>, all tags that are included in the
+                    <em>Card tags</em> option will be filtered out from the list. If no tags remain after filtering,
+                    then the button will not be shown.
                 </p>
                 <p>
                     <a class="more-toggle" data-parent-distance="3">Less&hellip;</a>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1565,22 +1565,6 @@
                 <label class="toggle"><input type="checkbox" data-setting="anki.suspendNewCards"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
-        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label">Configure Anki card format&hellip;</div>
-            </div>
-            <div class="settings-item-right open-panel-button-container">
-                <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
-            </div>
-        </div></div>
-        <div class="settings-item settings-item-button advanced-only" data-modal-action="show,anki-card-templates"><div class="settings-item-inner">
-            <div class="settings-item-left">
-                <div class="settings-item-label">Configure Anki card templates&hellip;</div>
-            </div>
-            <div class="settings-item-right open-panel-button-container">
-                <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
-            </div>
-        </div></div>
         <div class="settings-item advanced-only">
             <div class="settings-item-inner">
                 <div class="settings-item-left">
@@ -1609,6 +1593,22 @@
                 </p>
             </div>
         </div>
+        <div class="settings-item settings-item-button" data-modal-action="show,anki-cards"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Configure Anki card format&hellip;</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></div>
+        <div class="settings-item settings-item-button advanced-only" data-modal-action="show,anki-card-templates"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label">Configure Anki card templates&hellip;</div>
+            </div>
+            <div class="settings-item-right open-panel-button-container">
+                <button class="icon-button"><span class="icon-button-inner"><span class="icon" data-icon="material-right-arrow"></span></span></button>
+            </div>
+        </div></div>
     </div>
 
     <!-- Clipboard -->

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1584,42 +1584,29 @@
         <div class="settings-item advanced-only">
             <div class="settings-item-inner">
                 <div class="settings-item-left">
-                    <div class="settings-item-label">Show custom card tags</div>
-                    <div class="settings-item-description">
-                        Show an icon next to the "view added note" button that shows all tags on that note (if it has
-                        any).
+                    <div class="settings-item-label">
+                        Show card tags
+                        <a class="more-toggle more-only" data-parent-distance="4">(?)</a>
                     </div>
                 </div>
                 <div class="settings-item-right">
-                    <label class="toggle">
-                        <input type="checkbox" data-setting="anki.showTags" id="show-tags-enabled">
-                        <span class="toggle-body">
-                            <span class="toggle-track"></span>
-                            <span class="toggle-knob"></span>
-                        </span>
-                    </label>
+                    <select data-setting="anki.displayTags">
+                        <option value="never">Never</option>
+                        <option value="always">Always</option>
+                        <option value="non-standard">Non-Standard</option>
+                    </select>
                 </div>
             </div>
-            <div class="settings-item-children settings-item-children-group" id="filter-tags-enabled-more-options" hidden>
-                <div class="settings-item advanced-only">
-                    <div class="settings-item-inner">
-                        <div class="settings-item-left">
-                            <div class="settings-item-label">Filter tags</div>
-                            <div class="settings-item-description">
-                                Don't show tags included in the "Card tags" option above.
-                            </div>
-                        </div>
-                        <div class="settings-item-right">
-                            <label class="toggle">
-                                <input type="checkbox" data-setting="anki.filterTags" id="filter-tags-enabled">
-                                <span class="toggle-body">
-                                    <span class="toggle-track"></span>
-                                    <span class="toggle-knob"></span>
-                                </span>
-                            </label>
-                        </div>
-                    </div>
-                </div>
+            <div class="settings-item-children more" hidden>
+                <p>
+                    When coming across a word that is already in an anki deck, show an icon that lets you quickly see
+                    which tags that card has. If set to <em>Non-Standard</em> then all tags that are included in the
+                    <em>Card tags</em> option will be filtered out from the list. If no tags remain after filtering, then
+                    the icon will not be shown.
+                </p>
+                <p>
+                    <a class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                </p>
             </div>
         </div>
     </div>

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -431,6 +431,7 @@ function createProfileOptionsUpdatedTestData1() {
             terms: {deck: '', model: '', fields: {}},
             kanji: {deck: '', model: '', fields: {}},
             duplicateScope: 'collection',
+            displayTags: 'never',
             checkForDuplicates: true,
             fieldTemplates: null,
             suspendNewCards: false


### PR DESCRIPTION
This PR adds a small button next to the "add card/view added card" button on the display template. This button will only appear if:

1. The word has an anki card.
2. That card has tags.
3. At least one of those tags is not in the "Card tags" anki setting.

This button does nothing when clicked, but instead when hovered over will show a tooltip with all of the custom tags that belong to this card:

![ImageGlass_rnfeHloBC6](https://user-images.githubusercontent.com/12989318/116152295-1c12f900-a6bc-11eb-9cea-055b36a348a6.png)

![ImageGlass_Ph0TTHqidr](https://user-images.githubusercontent.com/12989318/116152306-1e755300-a6bc-11eb-8854-d65c4320abd8.png)

This PR would solve issue #1626. This feature would help my workflow, as I tend to add cards that I want to later edit or fix if/when I find a better context for them. I go into more details of my workflow in the issue.

There are a few things that still need to be considered:

- I'm not sure about code style/conventions/the way I'm handling data in `backend.js`. Particularly how I'm accessing user config, using anki-connect to get card tags, and also assuming that I will only ever get one ID for a particular note when calling `findNoteIds`. I go into detail with comments in lines 488-505 in `backend.js`.
- A different icon should probably be used. I quickly picked one at random from the icon folder. I'm not sure if there are any design guidelines or any other factor to decide on icons, but the current magnifying glass is a bit hard to see against a dark background.
- We could consider adding an option to enable/disable this behaviour, especially if fetching the required data from anki-connect turns out to be expensive.