### PR TITLE
Improve term grouping

### DIFF
--- a/docs/interfaces/dictionary-entry.ts
+++ b/docs/interfaces/dictionary-entry.ts
@@ -201,14 +201,6 @@ namespace Translation {
          */
         isPrimary: boolean;
         /**
-         * Database sequence number for the term, or `-1` if multiple entries have been merged.
-         */
-        sequence: number;
-        /**
-         * The dictionary that the sequence number originated from, or `null` if there is no sequence.
-         */
-        sequenceDictionary: string;
-        /**
          * A list of inflections that was applied to get the term.
          */
         inflections: string[];

--- a/docs/interfaces/dictionary-entry.ts
+++ b/docs/interfaces/dictionary-entry.ts
@@ -297,9 +297,11 @@ namespace Translation {
          */
         dictionary: string;
         /**
-         * Database sequence number for the term. The value will be `-1` if there is no sequence.
+         * A list of database sequence numbers for the term. A value of `-1` corresponds to no sequence.
+         * The list can have multiple values if multiple definitions with different sequences have been merged.
+         * The list should always have at least one item.
          */
-        sequence: number;
+        sequences: number;
         /**
          * Tags for the definition.
          */

--- a/ext/js/data/anki-note-data-creator.js
+++ b/ext/js/data/anki-note-data-creator.js
@@ -362,7 +362,7 @@ class AnkiNoteDataCreator {
 
         const definitions = [];
         const definitionTags = [];
-        for (const {tags, headwordIndices, entries, dictionary, sequence} of dictionaryEntry.definitions) {
+        for (const {tags, headwordIndices, entries, dictionary, sequences} of dictionaryEntry.definitions) {
             const definitionTags2 = [];
             for (const tag of tags) {
                 definitionTags.push(this._convertTag(tag));
@@ -371,7 +371,7 @@ class AnkiNoteDataCreator {
             if (!hasDefinitions) { continue; }
             const only = merged ? DictionaryDataUtil.getDisambiguations(dictionaryEntry.headwords, headwordIndices, allTermsSet, allReadingsSet) : void 0;
             definitions.push({
-                sequence,
+                sequence: sequences[0],
                 dictionary,
                 glossary: entries,
                 definitionTags: definitionTags2,
@@ -613,8 +613,9 @@ class AnkiNoteDataCreator {
     _getTermDictionaryEntrySequence(dictionaryEntry) {
         let hasSequence = false;
         let mainSequence = -1;
-        for (const {sequence, isPrimary} of dictionaryEntry.definitions) {
+        for (const {sequences, isPrimary} of dictionaryEntry.definitions) {
             if (!isPrimary) { continue; }
+            const sequence = sequences[0];
             if (!hasSequence) {
                 mainSequence = sequence;
                 hasSequence = true;

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1027,9 +1027,9 @@ class Translator {
                 }
             }
             if (checkDuplicateDefinitions) {
-                this._addTermDefinitions2(definitions, definitionsMap, dictionaryEntry.definitions, headwordIndexMap);
+                this._addTermDefinitions(definitions, definitionsMap, dictionaryEntry.definitions, headwordIndexMap);
             } else {
-                this._addTermDefinitions(definitions, dictionaryEntry.definitions, headwordIndexMap);
+                this._addTermDefinitionsFast(definitions, dictionaryEntry.definitions, headwordIndexMap);
             }
         }
 
@@ -1143,7 +1143,7 @@ class Translator {
         headwordIndices.splice(start, 0, headwordIndex);
     }
 
-    _addTermDefinitions(definitions, newDefinitions, headwordIndexMap) {
+    _addTermDefinitionsFast(definitions, newDefinitions, headwordIndexMap) {
         for (const {headwordIndices, dictionary, sequences, isPrimary, tags, entries} of newDefinitions) {
             const headwordIndicesNew = [];
             for (const headwordIndex of headwordIndices) {
@@ -1153,7 +1153,7 @@ class Translator {
         }
     }
 
-    _addTermDefinitions2(definitions, definitionsMap, newDefinitions, headwordIndexMap) {
+    _addTermDefinitions(definitions, definitionsMap, newDefinitions, headwordIndexMap) {
         for (const {headwordIndices, dictionary, sequences, isPrimary, tags, entries} of newDefinitions) {
             const key = this._createMapKey([dictionary, ...entries]);
             let definition = definitionsMap.get(key);

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -620,7 +620,7 @@ class Translator {
                 tag1.order = Math.min(tag1.order, tag2.order);
                 tag1.score = Math.max(tag1.score, tag2.score);
                 tag1.dictionaries.push(...tag2.dictionaries);
-                this._addUniqueStrings(tag1.content, tag2.content);
+                this._addUniqueSimple(tag1.content, tag2.content);
                 tags.splice(j, 1);
                 --tagCount;
                 --j;
@@ -1049,7 +1049,7 @@ class Translator {
 
     // Data collection addition functions
 
-    _addUniqueStrings(list, newItems) {
+    _addUniqueSimple(list, newItems) {
         for (const item of newItems) {
             if (!list.includes(item)) {
                 list.push(item);
@@ -1093,7 +1093,7 @@ class Translator {
                 for (; i < ii; ++i) {
                     const tagGroup = tagGroups[i];
                     if (tagGroup.dictionary === dictionary) {
-                        this._addUniqueStrings(tagGroup.tagNames, newTagGroup.tagNames);
+                        this._addUniqueSimple(tagGroup.tagNames, newTagGroup.tagNames);
                         break;
                     }
                 }
@@ -1114,7 +1114,7 @@ class Translator {
             }
             this._addUniqueSources(headword.sources, sources);
             this._addUniqueTagGroups(headword.tags, tags);
-            this._addUniqueStrings(headword.wordClasses, wordClasses);
+            this._addUniqueSimple(headword.wordClasses, wordClasses);
             headwordIndexMap.push(headword.index);
         }
         return headwordIndexMap;

--- a/test/data/translator-test-results.json
+++ b/test/data/translator-test-results.json
@@ -322,7 +322,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -454,7 +456,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -594,7 +598,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -728,7 +734,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -862,7 +870,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -996,7 +1006,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1128,7 +1140,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1260,7 +1274,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1400,7 +1416,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1552,7 +1570,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1700,7 +1720,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -1852,7 +1874,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2006,7 +2030,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2142,7 +2168,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2278,7 +2306,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2414,7 +2444,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2546,7 +2578,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2678,7 +2712,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2816,7 +2852,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 5,
+            "sequences": [
+              5
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -2944,7 +2982,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3082,7 +3122,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3222,7 +3264,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3356,7 +3400,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3496,7 +3542,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3630,7 +3678,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3770,7 +3820,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -3918,7 +3970,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4072,7 +4126,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4208,7 +4264,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4348,7 +4406,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4500,7 +4560,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4654,7 +4716,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4790,7 +4854,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -4928,7 +4994,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 5,
+            "sequences": [
+              5
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -5028,7 +5096,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5076,7 +5146,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5124,7 +5196,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5172,7 +5246,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5222,7 +5298,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5272,7 +5350,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5322,7 +5402,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5372,7 +5454,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5418,7 +5502,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5464,7 +5550,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [],
             "entries": [
@@ -5580,7 +5668,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -5621,7 +5711,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -5773,7 +5865,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -5814,7 +5908,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -5968,7 +6064,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6009,7 +6107,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6145,7 +6245,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6186,7 +6288,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6318,7 +6422,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6450,7 +6556,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6669,7 +6777,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6710,7 +6820,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6751,7 +6863,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -6792,7 +6906,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7038,7 +7154,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7079,7 +7197,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7120,7 +7240,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7161,7 +7283,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7311,7 +7435,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7443,7 +7569,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7587,7 +7715,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7743,7 +7873,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -7895,7 +8027,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8051,7 +8185,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8205,7 +8341,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8341,7 +8479,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8477,7 +8617,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8613,7 +8755,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8745,7 +8889,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -8877,7 +9023,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9017,7 +9165,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9169,7 +9319,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9317,7 +9469,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9469,7 +9623,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9623,7 +9779,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9759,7 +9917,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -9895,7 +10055,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10031,7 +10193,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10163,7 +10327,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10295,7 +10461,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10435,7 +10603,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10587,7 +10757,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10735,7 +10907,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -10887,7 +11061,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11041,7 +11217,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11177,7 +11355,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11313,7 +11493,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11449,7 +11631,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11581,7 +11765,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 1,
+            "sequences": [
+              1
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11713,7 +11899,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 2,
+            "sequences": [
+              2
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11829,7 +12017,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 6,
+            "sequences": [
+              6
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11896,7 +12086,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 7,
+            "sequences": [
+              7
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -11979,7 +12171,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 6,
+            "sequences": [
+              6
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -12165,7 +12359,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -12206,7 +12402,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": false,
             "tags": [
               {
@@ -12247,7 +12445,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -12288,7 +12488,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 4,
+            "sequences": [
+              4
+            ],
             "isPrimary": false,
             "tags": [
               {
@@ -12534,7 +12736,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -12575,7 +12779,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": false,
             "tags": [
               {
@@ -12616,7 +12822,9 @@
               0
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": true,
             "tags": [
               {
@@ -12657,7 +12865,9 @@
               1
             ],
             "dictionary": "Test Dictionary 2",
-            "sequence": 3,
+            "sequences": [
+              3
+            ],
             "isPrimary": false,
             "tags": [
               {


### PR DESCRIPTION
Definitions are now grouped without requiring a unique sequence.

Fixes an issue mentioned in https://github.com/FooSoft/yomichan/issues/1642#issuecomment-835347719.