### PR TITLE
Restore the Anki on macOS warning from the old settings page

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1438,6 +1438,13 @@
                 </p>
                 <div class="danger-text" id="anki-error-message-details"></div>
             </div>
+            <div class="settings-item-children" data-show-for-os="mac">
+                <p class="warning-text">
+                    <strong>Notice for macOS users:</strong>
+                    If Yomichan has issues connecting to AnkiConnect, it may be necessary to adjust adjust some system settings.
+                    See <a href="https://foosoft.net/projects/anki-connect/#notes-for-mac-os-x-users" target="_blank" rel="noopener noreferrer">this link</a> for details.
+                </p>
+            </div>
         </div>
         <div class="settings-item">
             <div class="settings-item-inner settings-item-inner-wrappable">


### PR DESCRIPTION
Related: #1672