### PR TITLE
Improve source term exact match count

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1007,7 +1007,6 @@ class Translator {
         let dictionaryIndex = Number.MAX_SAFE_INTEGER;
         let dictionaryPriority = Number.MIN_SAFE_INTEGER;
         let maxTransformedTextLength = 0;
-        let sourceTermExactMatchCount = 0;
         let isPrimary = false;
         const definitions = [];
         const definitionsMap = checkDuplicateDefinitions ? new Map() : null;
@@ -1020,7 +1019,6 @@ class Translator {
             if (dictionaryEntry.isPrimary) {
                 isPrimary = true;
                 maxTransformedTextLength = Math.max(maxTransformedTextLength, dictionaryEntry.maxTransformedTextLength);
-                sourceTermExactMatchCount += dictionaryEntry.sourceTermExactMatchCount;
                 const dictionaryEntryInflections = dictionaryEntry.inflections;
                 if (inflections === null || dictionaryEntryInflections.length < inflections.length) {
                     inflections = dictionaryEntryInflections;
@@ -1033,6 +1031,18 @@ class Translator {
             }
         }
 
+        const headwordsArray = [...headwords.values()];
+
+        let sourceTermExactMatchCount = 0;
+        for (const {term, sources} of headwordsArray) {
+            for (const {deinflectedText, isPrimary: isPrimary2} of sources) {
+                if (isPrimary2 && deinflectedText === term) {
+                    ++sourceTermExactMatchCount;
+                    break;
+                }
+            }
+        }
+
         return this._createTermDictionaryEntry(
             -1,
             isPrimary,
@@ -1042,7 +1052,7 @@ class Translator {
             dictionaryPriority,
             sourceTermExactMatchCount,
             maxTransformedTextLength,
-            [...headwords.values()],
+            headwordsArray,
             definitions
         );
     }

--- a/test/data/translator-test-results-note-data1.json
+++ b/test/data/translator-test-results-note-data1.json
@@ -8933,7 +8933,7 @@
               ]
             }
           ],
-          "sourceTermExactMatchCount": 2,
+          "sourceTermExactMatchCount": 1,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,
@@ -9261,7 +9261,7 @@
               ]
             }
           ],
-          "sourceTermExactMatchCount": 2,
+          "sourceTermExactMatchCount": 1,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,
@@ -9539,7 +9539,7 @@
             }
           ],
           "pitches": [],
-          "sourceTermExactMatchCount": 2,
+          "sourceTermExactMatchCount": 1,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,
@@ -9791,7 +9791,7 @@
             }
           ],
           "pitches": [],
-          "sourceTermExactMatchCount": 2,
+          "sourceTermExactMatchCount": 1,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,
@@ -10745,7 +10745,7 @@
               ]
             }
           ],
-          "sourceTermExactMatchCount": 4,
+          "sourceTermExactMatchCount": 2,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,
@@ -11198,7 +11198,7 @@
             }
           ],
           "pitches": [],
-          "sourceTermExactMatchCount": 4,
+          "sourceTermExactMatchCount": 2,
           "screenshotFileName": null,
           "clipboardImageFileName": null,
           "clipboardText": null,

--- a/test/data/translator-test-results.json
+++ b/test/data/translator-test-results.json
@@ -5578,7 +5578,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 2,
+        "sourceTermExactMatchCount": 1,
         "maxTransformedTextLength": 4,
         "headwords": [
           {
@@ -5797,7 +5797,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 2,
+        "sourceTermExactMatchCount": 1,
         "maxTransformedTextLength": 4,
         "headwords": [
           {
@@ -5996,7 +5996,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 2,
+        "sourceTermExactMatchCount": 1,
         "maxTransformedTextLength": 2,
         "headwords": [
           {
@@ -6177,7 +6177,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 2,
+        "sourceTermExactMatchCount": 1,
         "maxTransformedTextLength": 2,
         "headwords": [
           {
@@ -6630,7 +6630,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 4,
+        "sourceTermExactMatchCount": 2,
         "maxTransformedTextLength": 4,
         "headwords": [
           {
@@ -7029,7 +7029,7 @@
         "score": 10,
         "dictionaryIndex": 0,
         "dictionaryPriority": 0,
-        "sourceTermExactMatchCount": 4,
+        "sourceTermExactMatchCount": 2,
         "maxTransformedTextLength": 2,
         "headwords": [
           {


### PR DESCRIPTION
Updates grouped `sourceTermExactMatchCount` to be based on the number of headwords instead of the number of definitions.

Resolves #1668.