### PR TITLE
Revert "Add support for custom text type generation (#1683)"

### DIFF
--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -293,8 +293,6 @@ class DisplayGenerator {
             return this._createTermDefinitionEntryText(entry);
         } else if (typeof entry === 'object' && entry !== null) {
             switch (entry.type) {
-                case 'text':
-                    return this._createTermDefinitionEntryText(entry.text);
                 case 'image':
                     return this._createTermDefinitionEntryImage(entry, dictionary);
             }


### PR DESCRIPTION
Turns out this is unnecessary because the internal format is different.