### PR TITLE
Selection clear improvements

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -121,7 +121,7 @@ class Frontend {
         yomichan.on('closePopups', this._onClosePopups.bind(this));
         chrome.runtime.onMessage.addListener(this._onRuntimeMessage.bind(this));
 
-        this._textScanner.on('clearSelection', this._onClearSelection.bind(this));
+        this._textScanner.on('clear', this._onTextScannerClear.bind(this));
         this._textScanner.on('searched', this._onSearched.bind(this));
 
         yomichan.crossFrame.registerHandlers([
@@ -253,6 +253,10 @@ class Frontend {
         this._updateContentScale();
     }
 
+    _onTextScannerClear() {
+        this._clearSelection(false);
+    }
+
     _onClearSelection({passive}) {
         this._stopClearSelectionDelayed();
         if (this._popup !== null) {
@@ -300,6 +304,11 @@ class Frontend {
     _clearSelection(passive) {
         this._stopClearSelectionDelayed();
         this._textScanner.clearSelection(passive);
+        if (this._popup !== null) {
+            this._popup.hide(!passive);
+            this._popup.clearAutoPlayTimer();
+            this._isPointerOverPopup = false;
+        }
     }
 
     _clearSelectionDelayed(delay, restart, passive) {
@@ -566,6 +575,7 @@ class Frontend {
     _updateTextScannerEnabled() {
         const enabled = (this._options !== null && this._options.general.enable && !this._disabledOverride);
         this._textScanner.setEnabled(enabled);
+        this._clearSelection(true);
     }
 
     _updateContentScale() {

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -294,12 +294,12 @@ class Frontend {
 
     _clearSelection(passive) {
         this._stopClearSelectionDelayed();
-        this._textScanner.clearSelection();
         if (this._popup !== null) {
-            this._popup.hide(!passive);
             this._popup.clearAutoPlayTimer();
+            this._popup.hide(!passive);
             this._isPointerOverPopup = false;
         }
+        this._textScanner.clearSelection();
     }
 
     _clearSelectionDelayed(delay, restart, passive) {

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -257,15 +257,6 @@ class Frontend {
         this._clearSelection(false);
     }
 
-    _onClearSelection({passive}) {
-        this._stopClearSelectionDelayed();
-        if (this._popup !== null) {
-            this._popup.hide(!passive);
-            this._popup.clearAutoPlayTimer();
-            this._isPointerOverPopup = false;
-        }
-    }
-
     _onSearched({type, dictionaryEntries, sentence, inputInfo: {eventType, passive, detail}, textSource, optionsContext, detail: {documentTitle}, error}) {
         const scanningOptions = this._options.scanning;
 
@@ -303,7 +294,7 @@ class Frontend {
 
     _clearSelection(passive) {
         this._stopClearSelectionDelayed();
-        this._textScanner.clearSelection(passive);
+        this._textScanner.clearSelection();
         if (this._popup !== null) {
             this._popup.hide(!passive);
             this._popup.clearAutoPlayTimer();

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1852,7 +1852,7 @@ class Display extends EventDispatcher {
                 contentOrigin: this.getContentOrigin()
             }
         };
-        this._contentTextScanner.clearSelection(true);
+        this._contentTextScanner.clearSelection();
         this.setContent(details);
     }
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1789,6 +1789,7 @@ class Display extends EventDispatcher {
             this._contentTextScanner.includeSelector = '.click-scannable,.click-scannable *';
             this._contentTextScanner.excludeSelector = '.scan-disable,.scan-disable *';
             this._contentTextScanner.prepare();
+            this._contentTextScanner.on('clear', this._onContentTextScannerClear.bind(this));
             this._contentTextScanner.on('searched', this._onContentTextScannerSearched.bind(this));
         }
 
@@ -1820,6 +1821,10 @@ class Display extends EventDispatcher {
         });
 
         this._contentTextScanner.setEnabled(true);
+    }
+
+    _onContentTextScannerClear() {
+        this._contentTextScanner.clearSelection();
     }
 
     _onContentTextScannerSearched({type, dictionaryEntries, sentence, textSource, optionsContext, error}) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -1771,6 +1771,7 @@ class Display extends EventDispatcher {
         if (!options.scanning.enablePopupSearch) {
             if (this._contentTextScanner !== null) {
                 this._contentTextScanner.setEnabled(false);
+                this._contentTextScanner.clearSelection();
             }
             return;
         }

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -47,6 +47,7 @@ class QueryParser extends EventDispatcher {
 
     prepare() {
         this._textScanner.prepare();
+        this._textScanner.on('clear', this._onTextScannerClear.bind(this));
         this._textScanner.on('searched', this._onSearched.bind(this));
         this._queryParserModeSelect.addEventListener('change', this._onParserChange.bind(this), false);
     }
@@ -85,6 +86,10 @@ class QueryParser extends EventDispatcher {
     }
 
     // Private
+
+    _onTextScannerClear() {
+        this._textScanner.clearSelection();
+    }
 
     _onSearched(e) {
         const {error} = e;

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -257,7 +257,7 @@ class TextScanner extends EventDispatcher {
         return (this._textSourceCurrent !== null);
     }
 
-    clearSelection(passive) {
+    clearSelection() {
         if (!this._canClearSelection) { return; }
         if (this._textSourceCurrent !== null) {
             if (this._textSourceCurrentSelected) {
@@ -271,7 +271,6 @@ class TextScanner extends EventDispatcher {
             this._textSourceCurrentSelected = false;
             this._inputInfoCurrent = null;
         }
-        this.trigger('clearSelection', {passive});
     }
 
     getCurrentTextSource() {

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -139,8 +139,6 @@ class TextScanner extends EventDispatcher {
 
         if (value) {
             this._hookEvents();
-        } else {
-            this.clearSelection(true);
         }
     }
 
@@ -431,7 +429,7 @@ class TextScanner extends EventDispatcher {
             case 0: // Primary
                 if (this._searchOnClick) { this._resetPreventNextClickScan(); }
                 this._scanTimerClear();
-                this.clearSelection(false);
+                this._triggerClear('mousedown');
                 break;
             case 1: // Middle
                 if (this._preventMiddleMouse) {
@@ -1104,5 +1102,9 @@ class TextScanner extends EventDispatcher {
                 // NOP
             }
         }
+    }
+
+    _triggerClear(reason) {
+        this.trigger('clear', {reason});
     }
 }


### PR DESCRIPTION
Some general improvements to the event flow for selection clearing. `TextScanner` now sends a `'clear'` event, which clients are responsible for responding to and actually calling `clearSelection`. This allows other logic to be added before the `clearSelection` invocation.