### PR TITLE
Update browser bugs

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -71,3 +71,13 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: Firefox
 * **Date**: 2021-03-05
 * **Links**: [Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1696721)
+
+## Focus changes don't preserve caret position for caret browsing
+* **Browser**: Chrome
+* **Date**: 2021-05-19
+* **Links**: [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1211175)
+
+## CSS :active state on &lt;label&gt; element doesn't match state on inner element
+* **Browser**: Chrome
+* **Date**: 2021-05-19
+* **Links**: [Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1211182)


### PR DESCRIPTION
* **Focus changes don't preserve caret position for caret browsing**
  https://bugs.chromium.org/p/chromium/issues/detail?id=1211175
  This is what is causing the issue in https://github.com/FooSoft/yomichan/issues/1627#issuecomment-835886794

* **CSS :active state on &lt;label&gt; element doesn't match state on inner element**
  https://bugs.chromium.org/p/chromium/issues/detail?id=1211182
  This is an issue detected a while ago when setting up some CSS rules which resulted in some duplicate rules being necessary.
