### PR TITLE
Simplify createAudio function

### DIFF
--- a/ext/js/media/audio-system.js
+++ b/ext/js/media/audio-system.js
@@ -42,18 +42,13 @@ class AudioSystem extends EventDispatcher {
         return this._fallbackAudio;
     }
 
-    createAudio(url, sourceType) {
-        return new Promise((resolve, reject) => {
-            const audio = new Audio(url);
-            audio.addEventListener('loadeddata', () => {
-                if (!this._isAudioValid(audio, sourceType)) {
-                    reject(new Error('Could not retrieve audio'));
-                } else {
-                    resolve(audio);
-                }
-            });
-            audio.addEventListener('error', () => reject(audio.error));
-        });
+    async createAudio(url, sourceType) {
+        const audio = new Audio(url);
+        await this._waitForData(audio);
+        if (!this._isAudioValid(audio, sourceType)) {
+            throw new Error('Could not retrieve audio');
+        }
+        return audio;
     }
 
     createTextToSpeechAudio(text, voiceUri) {
@@ -68,6 +63,13 @@ class AudioSystem extends EventDispatcher {
 
     _onVoicesChanged(e) {
         this.trigger('voiceschanged', e);
+    }
+
+    _waitForData(audio) {
+        return new Promise((resolve, reject) => {
+            audio.addEventListener('loadeddata', () => resolve());
+            audio.addEventListener('error', () => reject(audio.error));
+        });
     }
 
     _isAudioValid(audio, sourceType) {


### PR DESCRIPTION
Refactored while testing an issue on Chrome where `createAudio` sometimes stalls and never returns or errors when audio is auto-played. Interestingly, the audio will play if the `audio` object is kept alive by any means, such as logging it to console or assigning it to `window`. Note: this change does _not_ fix the issue, but makes it easier to debug certain parts.