### PR TITLE
Add support for definitionless main dictionary

### DIFF
--- a/dev/translator-vm.js
+++ b/dev/translator-vm.js
@@ -170,6 +170,12 @@ class TranslatorVM extends DatabaseVM {
             enabledDictionaryMap = new Map(enabledDictionaryMap);
             options.enabledDictionaryMap = enabledDictionaryMap;
         }
+        const {excludeDictionaryDefinitions} = options;
+        options.excludeDictionaryDefinitions = (
+            Array.isArray(excludeDictionaryDefinitions) ?
+            new Set(excludeDictionaryDefinitions) :
+            null
+        );
 
         return options;
     }


### PR DESCRIPTION
This allows a main dictionary to be selected for grouping, but excludes definitions and other content from that dictionary if it is not enabled. This allows one dictionary to be used for grouping related terms (e.g. JMDict) while only showing definitions from other dictionaries (e.g. a J2J dictionary without sequencing information).

Resolves https://github.com/FooSoft/yomichan/issues/1546#issuecomment-808729383