### PR TITLE
Improve secondary definitions

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -431,7 +431,7 @@ class Translator {
                     targetMap.set(key, target);
                 }
                 target.groups.push(group);
-                if (!dictionaryEntry.isPrimary && !target.searchSecondary) {
+                if (!target.searchSecondary) {
                     target.searchSecondary = true;
                     termList.push({term, reading});
                     targetList.push(target);
@@ -494,6 +494,8 @@ class Translator {
         }
         return newDictionaryEntries;
     }
+
+    // Removing data
 
     _removeExcludedDefinitions(dictionaryEntries, excludeDictionaryDefinitions) {
         for (let i = dictionaryEntries.length - 1; i >= 0; --i) {

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -425,17 +425,13 @@ class Translator {
                 let target = targetMap.get(key);
                 if (typeof target === 'undefined') {
                     target = {
-                        groups: [],
-                        searchSecondary: false
+                        groups: []
                     };
                     targetMap.set(key, target);
                 }
                 target.groups.push(group);
-                if (!target.searchSecondary) {
-                    target.searchSecondary = true;
-                    termList.push({term, reading});
-                    targetList.push(target);
-                }
+                termList.push({term, reading});
+                targetList.push(target);
             }
         }
 


### PR DESCRIPTION
Secondary definitions are now searched using the source term as well, since there are cases where "inconsistent" results could show up. For example, see https://github.com/FooSoft/yomichan/issues/1580#issuecomment-813118330.