### PR TITLE
Add separation before template-renderer-frame-main.js

### DIFF
--- a/ext/template-renderer.html
+++ b/ext/template-renderer.html
@@ -22,6 +22,7 @@
 <script src="/js/language/japanese-util.js"></script>
 <script src="/js/templates/template-renderer.js"></script>
 <script src="/js/templates/template-renderer-frame-api.js"></script>
+
 <script src="/js/templates/template-renderer-frame-main.js"></script>
 
 </body>


### PR DESCRIPTION
The main script must run last, and the scripts must be in alphabetical order. The main script was only coincidentally the last alphabetically.