### PR TITLE
Store anki note details

### DIFF
--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -31,7 +31,7 @@ class DisplayAnki {
         this._ankiNoteNotificationEventListeners = null;
         this._ankiTagNotification = null;
         this._updateAdderButtonsPromise = Promise.resolve();
-        this._updateAdderButtonsToken = null;
+        this._updateDictionaryEntryDetailsToken = null;
         this._eventListeners = new EventListenerCollection();
         this._dictionaryEntryDetails = null;
         this._noteContext = null;
@@ -67,7 +67,7 @@ class DisplayAnki {
     }
 
     cleanupEntries() {
-        this._updateAdderButtonsToken = null;
+        this._updateDictionaryEntryDetailsToken = null;
         this._hideAnkiNoteErrors(false);
     }
 
@@ -82,7 +82,7 @@ class DisplayAnki {
     }
 
     setupEntriesComplete() {
-        this._updateAdderButtons();
+        this._updateDictionaryEntryDetails();
     }
 
     async getLogData(dictionaryEntry) {
@@ -259,20 +259,20 @@ class DisplayAnki {
         return {type, term, reading};
     }
 
-    async _updateAdderButtons() {
+    async _updateDictionaryEntryDetails() {
         const {dictionaryEntries} = this._display;
         const token = {};
-        this._updateAdderButtonsToken = token;
+        this._updateDictionaryEntryDetailsToken = token;
         if (this._updateAdderButtonsPromise !== null) {
             await this._updateAdderButtonsPromise;
         }
-        if (this._updateAdderButtonsToken !== token) { return; }
+        if (this._updateDictionaryEntryDetailsToken !== token) { return; }
 
         const {promise, resolve} = deferPromise();
         try {
             this._updateAdderButtonsPromise = promise;
             const dictionaryEntryDetails = await this._areDictionaryEntriesAddable(dictionaryEntries);
-            if (this._updateAdderButtonsToken !== token) { return; }
+            if (this._updateDictionaryEntryDetailsToken !== token) { return; }
             this._dictionaryEntryDetails = dictionaryEntryDetails;
             this._updateAdderButtons2();
         } finally {

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -263,7 +263,9 @@ class DisplayAnki {
         const {dictionaryEntries} = this._display;
         const token = {};
         this._updateAdderButtonsToken = token;
-        await this._updateAdderButtonsPromise;
+        if (this._updateAdderButtonsPromise !== null) {
+            await this._updateAdderButtonsPromise;
+        }
         if (this._updateAdderButtonsToken !== token) { return; }
 
         const {promise, resolve} = deferPromise();
@@ -275,6 +277,9 @@ class DisplayAnki {
             this._updateAdderButtons2();
         } finally {
             resolve();
+            if (this._updateAdderButtonsPromise === promise) {
+                this._updateAdderButtonsPromise = null;
+            }
         }
     }
 

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -272,7 +272,7 @@ class DisplayAnki {
         const {promise, resolve} = deferPromise();
         try {
             this._updateAdderButtonsPromise = promise;
-            const dictionaryEntryDetails = await this._areDictionaryEntriesAddable(dictionaryEntries);
+            const dictionaryEntryDetails = await this._getDictionaryEntryDetails(dictionaryEntries);
             if (this._updateDictionaryEntryDetailsToken !== token) { return; }
             this._dictionaryEntryDetails = dictionaryEntryDetails;
             this._updateAdderButtons();
@@ -459,7 +459,7 @@ class DisplayAnki {
         return templates;
     }
 
-    async _areDictionaryEntriesAddable(dictionaryEntries) {
+    async _getDictionaryEntryDetails(dictionaryEntries) {
         const forceCanAddValue = (this._checkForDuplicates ? null : true);
         const fetchAdditionalInfo = (this._displayTags !== 'never');
 

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -68,6 +68,7 @@ class DisplayAnki {
 
     cleanupEntries() {
         this._updateDictionaryEntryDetailsToken = null;
+        this._dictionaryEntryDetails = null;
         this._hideAnkiNoteErrors(false);
     }
 

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -275,7 +275,7 @@ class DisplayAnki {
             const dictionaryEntryDetails = await this._areDictionaryEntriesAddable(dictionaryEntries);
             if (this._updateDictionaryEntryDetailsToken !== token) { return; }
             this._dictionaryEntryDetails = dictionaryEntryDetails;
-            this._updateAdderButtons2();
+            this._updateAdderButtons();
         } finally {
             resolve();
             if (this._updateAdderButtonsPromise === promise) {
@@ -284,7 +284,7 @@ class DisplayAnki {
         }
     }
 
-    _updateAdderButtons2() {
+    _updateAdderButtons() {
         const displayTags = this._displayTags;
         const dictionaryEntryDetails = this._dictionaryEntryDetails;
         for (let i = 0, ii = dictionaryEntryDetails.length; i < ii; ++i) {

--- a/ext/js/display/display-anki.js
+++ b/ext/js/display/display-anki.js
@@ -33,6 +33,7 @@ class DisplayAnki {
         this._updateAdderButtonsPromise = Promise.resolve();
         this._updateAdderButtonsToken = null;
         this._eventListeners = new EventListenerCollection();
+        this._dictionaryEntryDetails = null;
         this._noteContext = null;
         this._checkForDuplicates = false;
         this._suspendNewCards = false;
@@ -268,22 +269,21 @@ class DisplayAnki {
         const {promise, resolve} = deferPromise();
         try {
             this._updateAdderButtonsPromise = promise;
-
-            const states = await this._areDictionaryEntriesAddable(dictionaryEntries);
-
+            const dictionaryEntryDetails = await this._areDictionaryEntriesAddable(dictionaryEntries);
             if (this._updateAdderButtonsToken !== token) { return; }
-
-            this._updateAdderButtons2(states);
+            this._dictionaryEntryDetails = dictionaryEntryDetails;
+            this._updateAdderButtons2();
         } finally {
             resolve();
         }
     }
 
-    _updateAdderButtons2(states) {
+    _updateAdderButtons2() {
         const displayTags = this._displayTags;
-        for (let i = 0, ii = states.length; i < ii; ++i) {
+        const dictionaryEntryDetails = this._dictionaryEntryDetails;
+        for (let i = 0, ii = dictionaryEntryDetails.length; i < ii; ++i) {
             let noteId = null;
-            for (const {mode, canAdd, noteIds, noteInfos, ankiError} of states[i]) {
+            for (const {mode, canAdd, noteIds, noteInfos, ankiError} of dictionaryEntryDetails[i]) {
                 const button = this._adderButtonFind(i, mode);
                 if (button !== null) {
                     button.disabled = !canAdd;


### PR DESCRIPTION
This change updates `DisplayAnki` to store note details for each dictionary entry, rather than them being stored in a temporary variable before being discarded. This will allow this information to be reused for certain functionality in the future.