### PR TITLE
Pronunciation template helper

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -742,6 +742,39 @@ These functions are used together in order to request media and other types of o
 </details>
 
 
+### `pronunciation`
+
+Converts pronunciation information into a formatted HTML content string. The display layout is the
+same as the system used for generating popup and search page dictionary entries.
+
+<details>
+  <summary>Syntax:</summary>
+
+  <code>{{#pronunciation <i>format=string</i> <i>reading=string</i> <i>downstepPosition=integer</i> <i>[nasalPositions=array]</i> <i>[devoicePositions=array]</i>}}{{/pronunciation}}</code><br>
+
+  * _`format`_ <br>
+    The format of the HTML to generate. This can be any of the following values:
+    * `'text'`
+    * `'graph'`
+    * `'position'`
+  * _`reading`_ <br>
+    The kana reading of the term.
+  * _`downstepPosition`_ <br>
+    The mora position of the downstep in the reading.
+  * _`nasalPositions`_ _(optional)_ <br>
+    An array of indices of mora that have a nasal pronunciation.
+  * _`devoicePositions`_ _(optional)_ <br>
+    An array of indices of mora that are devoiced.
+</details>
+<details>
+  <summary>Example:</summary>
+
+  ```handlebars
+  {{~#pronunciation format='text' reading='よむ' downstepPosition=1~}}{{~/pronunciation~}}
+  ```
+</details>
+
+
 ## Legacy Helpers
 
 Yomichan has historically used Handlebars templates to generate the HTML used on the search page and results popup.

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -689,7 +689,7 @@ These functions are used together in order to request media and other types of o
     The type of media to check for.
   * _`args`_ <br>
     Additional arguments for the media. The arguments depend on the media type.
-  * _`escape`_ <br>
+  * _`escape`_ _(optional)_ <br>
     Whether or not the resulting text should be HTML-escaped. If omitted, defaults to `true`.
 
   **Available media types and arguments**

--- a/docs/templates.md
+++ b/docs/templates.md
@@ -3,7 +3,7 @@
 ## Helpers
 
 Yomichan supports several custom Handlebars helpers for rendering templates.
-The source code for these templates can be found [here](../ext/js/templates/sandbox/template-renderer.js).
+The source code for these templates can be found [here](../ext/js/templates/sandbox/anki-template-renderer.js).
 
 
 ### `dumpObject`

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -477,7 +477,7 @@ class DisplayGenerator {
         this._createPitchAccentDisambiguations(n, exclusiveTerms, exclusiveReadings);
 
         n = node.querySelector('.pronunciation-downstep-notation-container');
-        n.appendChild(this._pronunciationGenerator.createPronunciationDownstepNotation(position));
+        n.appendChild(this._pronunciationGenerator.createPronunciationDownstepPosition(position));
 
         n = node.querySelector('.pronunciation-text-container');
         n.lang = 'ja';

--- a/ext/js/display/sandbox/pronunciation-generator.js
+++ b/ext/js/display/sandbox/pronunciation-generator.js
@@ -144,7 +144,7 @@ class PronunciationGenerator {
         return svg;
     }
 
-    createPronunciationDownstepNotation(downstepPosition) {
+    createPronunciationDownstepPosition(downstepPosition) {
         downstepPosition = `${downstepPosition}`;
 
         const n1 = document.createElement('span');

--- a/ext/js/dom/sandbox/css-style-applier.js
+++ b/ext/js/dom/sandbox/css-style-applier.js
@@ -54,7 +54,7 @@ class CssStyleApplier {
     applyClassStyles(elements) {
         const elementStyles = [];
         for (const element of elements) {
-            const {className} = element;
+            const className = element.getAttribute('class');
             if (className.length === 0) { continue; }
             let cssTextNew = '';
             for (const {selectorText, styles} of this._getRulesForClass(className)) {

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -35,7 +35,7 @@ class AnkiTemplateRenderer {
      * Creates a new instance of the class.
      */
     constructor() {
-        this._cssStyleApplier = new CssStyleApplier('/data/structured-content-style.json');
+        this._structuredContentStyleApplier = new CssStyleApplier('/data/structured-content-style.json');
         this._japaneseUtil = new JapaneseUtil(null);
         this._templateRenderer = new TemplateRenderer();
         this._ankiNoteDataCreator = new AnkiNoteDataCreator(this._japaneseUtil);
@@ -93,7 +93,7 @@ class AnkiTemplateRenderer {
             this._onRenderSetup.bind(this),
             this._onRenderCleanup.bind(this)
         );
-        await this._cssStyleApplier.prepare();
+        await this._structuredContentStyleApplier.prepare();
     }
 
     // Private
@@ -479,7 +479,7 @@ class AnkiTemplateRenderer {
                     break;
             }
         }
-        this._cssStyleApplier.applyClassStyles(elements);
+        this._structuredContentStyleApplier.applyClassStyles(elements);
         for (const element of elements) {
             const {dataset} = element;
             for (const key of Object.keys(dataset)) {

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -21,6 +21,7 @@
  * DictionaryDataUtil
  * Handlebars
  * JapaneseUtil
+ * PronunciationGenerator
  * StructuredContentGenerator
  * TemplateRenderer
  * TemplateRendererMediaProvider
@@ -36,10 +37,12 @@ class AnkiTemplateRenderer {
      */
     constructor() {
         this._structuredContentStyleApplier = new CssStyleApplier('/data/structured-content-style.json');
+        this._pronunciationStyleApplier = new CssStyleApplier('/data/pronunciation-style.json');
         this._japaneseUtil = new JapaneseUtil(null);
         this._templateRenderer = new TemplateRenderer();
         this._ankiNoteDataCreator = new AnkiNoteDataCreator(this._japaneseUtil);
         this._mediaProvider = new TemplateRendererMediaProvider();
+        this._pronunciationGenerator = new PronunciationGenerator();
         this._stateStack = null;
         this._requirements = null;
         this._cleanupCallbacks = null;
@@ -93,7 +96,10 @@ class AnkiTemplateRenderer {
             this._onRenderSetup.bind(this),
             this._onRenderCleanup.bind(this)
         );
-        await this._structuredContentStyleApplier.prepare();
+        await Promise.all([
+            this._structuredContentStyleApplier.prepare(),
+            this._pronunciationStyleApplier.prepare()
+        ]);
     }
 
     // Private

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -460,16 +460,16 @@ class AnkiTemplateRenderer {
         return element;
     }
 
-    _getHtml(node) {
+    _getHtml(node, styleApplier) {
         const container = this._getTemporaryElement();
         container.appendChild(node);
-        this._normalizeHtml(container);
+        this._normalizeHtml(container, styleApplier);
         const result = container.innerHTML;
         container.textContent = '';
         return result;
     }
 
-    _normalizeHtml(root) {
+    _normalizeHtml(root, styleApplier) {
         const {ELEMENT_NODE, TEXT_NODE} = Node;
         const treeWalker = document.createTreeWalker(root, NodeFilter.SHOW_ELEMENT | NodeFilter.SHOW_TEXT);
         const elements = [];
@@ -486,7 +486,7 @@ class AnkiTemplateRenderer {
                     break;
             }
         }
-        this._structuredContentStyleApplier.applyClassStyles(elements);
+        styleApplier.applyClassStyles(elements);
         for (const element of elements) {
             const {dataset} = element;
             for (const key of Object.keys(dataset)) {
@@ -539,13 +539,13 @@ class AnkiTemplateRenderer {
     _formatGlossaryImage(content, dictionary, data) {
         const structuredContentGenerator = this._createStructuredContentGenerator(data);
         const node = structuredContentGenerator.createDefinitionImage(content, dictionary);
-        return this._getHtml(node);
+        return this._getHtml(node, this._structuredContentStyleApplier);
     }
 
     _formatStructuredContent(content, dictionary, data) {
         const structuredContentGenerator = this._createStructuredContentGenerator(data);
         const node = structuredContentGenerator.createStructuredContent(content.content, dictionary);
-        return node !== null ? this._getHtml(node) : '';
+        return node !== null ? this._getHtml(node, this._structuredContentStyleApplier) : '';
     }
 
     _hasMedia(context, ...args) {
@@ -574,15 +574,18 @@ class AnkiTemplateRenderer {
         switch (format) {
             case 'downstep-notation':
                 return this._getHtml(
-                    this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions)
+                    this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions),
+                    this._pronunciationStyleApplier
                 );
             case 'graph':
                 return this._getHtml(
-                    this._pronunciationGenerator.createPronunciationGraph(morae, downstepPosition)
+                    this._pronunciationGenerator.createPronunciationGraph(morae, downstepPosition),
+                    this._pronunciationStyleApplier
                 );
             case 'position':
                 return this._getHtml(
-                    this._pronunciationGenerator.createPronunciationDownstepPosition(downstepPosition)
+                    this._pronunciationGenerator.createPronunciationDownstepPosition(downstepPosition),
+                    this._pronunciationStyleApplier
                 );
             default:
                 return '';

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -86,7 +86,8 @@ class AnkiTemplateRenderer {
             ['pitchCategories',  this._pitchCategories.bind(this)],
             ['formatGlossary',   this._formatGlossary.bind(this)],
             ['hasMedia',         this._hasMedia.bind(this)],
-            ['getMedia',         this._getMedia.bind(this)]
+            ['getMedia',         this._getMedia.bind(this)],
+            ['pronunciation',    this._pronunciation.bind(this)]
         ]);
         this._templateRenderer.registerDataType('ankiNote', {
             modifier: ({marker, commonData}) => this._ankiNoteDataCreator.create(marker, commonData),
@@ -557,5 +558,34 @@ class AnkiTemplateRenderer {
         const ii = args.length - 1;
         const options = args[ii];
         return this._mediaProvider.getMedia(options.data.root, args.slice(0, ii), options.hash);
+    }
+
+    _pronunciation(context, ...args) {
+        const ii = args.length - 1;
+        const options = args[ii];
+        let {format, reading, downstepPosition, nasalPositions, devoicePositions} = options.hash;
+
+        if (typeof reading !== 'string' || reading.length === 0) { return ''; }
+        if (typeof downstepPosition !== 'number') { return ''; }
+        if (!Array.isArray(nasalPositions)) { nasalPositions = []; }
+        if (!Array.isArray(devoicePositions)) { devoicePositions = []; }
+        const morae = this._japaneseUtil.getKanaMorae(reading);
+
+        switch (format) {
+            case 'downstep-notation':
+                return this._getHtml(
+                    this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions)
+                );
+            case 'graph':
+                return this._getHtml(
+                    this._pronunciationGenerator.createPronunciationGraph(morae, downstepPosition)
+                );
+            case 'position':
+                return this._getHtml(
+                    this._pronunciationGenerator.createPronunciationDownstepPosition(downstepPosition)
+                );
+            default:
+                return '';
+        }
     }
 }

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -572,7 +572,7 @@ class AnkiTemplateRenderer {
         const morae = this._japaneseUtil.getKanaMorae(reading);
 
         switch (format) {
-            case 'downstep-notation':
+            case 'text':
                 return this._getHtml(
                     this._pronunciationGenerator.createPronunciationText(morae, downstepPosition, nasalPositions, devoicePositions),
                     this._pronunciationStyleApplier

--- a/ext/js/templates/sandbox/anki-template-renderer.js
+++ b/ext/js/templates/sandbox/anki-template-renderer.js
@@ -42,7 +42,7 @@ class AnkiTemplateRenderer {
         this._templateRenderer = new TemplateRenderer();
         this._ankiNoteDataCreator = new AnkiNoteDataCreator(this._japaneseUtil);
         this._mediaProvider = new TemplateRendererMediaProvider();
-        this._pronunciationGenerator = new PronunciationGenerator();
+        this._pronunciationGenerator = new PronunciationGenerator(this._japaneseUtil);
         this._stateStack = null;
         this._requirements = null;
         this._cleanupCallbacks = null;

--- a/ext/template-renderer.html
+++ b/ext/template-renderer.html
@@ -18,6 +18,7 @@
 <script src="/lib/handlebars.min.js"></script>
 
 <script src="/js/data/sandbox/anki-note-data-creator.js"></script>
+<script src="/js/display/sandbox/pronunciation-generator.js"></script>
 <script src="/js/display/sandbox/structured-content-generator.js"></script>
 <script src="/js/dom/sandbox/css-style-applier.js"></script>
 <script src="/js/language/sandbox/dictionary-data-util.js"></script>

--- a/test/test-anki-note-builder.js
+++ b/test/test-anki-note-builder.js
@@ -235,6 +235,9 @@ async function getRenderResults(dictionaryEntries, type, mode, template, AnkiNot
             compactTags: false
         });
         if (!write) {
+            for (const error of errors) {
+                console.error(error);
+            }
             assert.strictEqual(errors.length, 0);
         }
         results.push(noteFields);

--- a/test/test-anki-note-builder.js
+++ b/test/test-anki-note-builder.js
@@ -44,6 +44,7 @@ async function createVM() {
         'js/data/anki-note-builder.js',
         'js/data/anki-util.js',
         'js/dom/sandbox/css-style-applier.js',
+        'js/display/sandbox/pronunciation-generator.js',
         'js/display/sandbox/structured-content-generator.js',
         'js/templates/sandbox/anki-template-renderer.js',
         'js/templates/sandbox/template-renderer.js',


### PR DESCRIPTION
This change adds a new `pronunciation` helper for generating HTML to display pronunciation info in Anki templates. This change does not replace the existing template or add support for nasal/devoice positions, which will be done in a future commit.

Related: #1824.