### PR TITLE
Google Docs accessibility

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -120,6 +120,7 @@
             "files": ["ext/**/*.js"],
             "excludedFiles": [
                 "ext/js/core.js",
+                "ext/js/document-start.js",
                 "ext/js/**/sandbox/**/*.js"
             ],
             "globals": {
@@ -146,6 +147,7 @@
             "files": ["ext/**/*.js"],
             "excludedFiles": [
                 "ext/js/core.js",
+                "ext/js/document-start.js",
                 "ext/js/yomichan.js",
                 "ext/js/**/sandbox/**/*.js"
             ],

--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -33,11 +33,14 @@
         },
         "content_scripts": [
             {
+                "run_at": "document_idle",
                 "matches": [
                     "http://*/*",
                     "https://*/*",
                     "file://*/*"
                 ],
+                "match_about_blank": true,
+                "all_frames": true,
                 "js": [
                     "js/core.js",
                     "js/yomichan.js",
@@ -59,9 +62,20 @@
                     "js/language/text-scanner.js",
                     "js/script/dynamic-loader.js",
                     "js/app/content-script-main.js"
+                ]
+            },
+            {
+                "run_at": "document_start",
+                "matches": [
+                    "http://*/*",
+                    "https://*/*",
+                    "file://*/*"
                 ],
                 "match_about_blank": true,
-                "all_frames": true
+                "all_frames": true,
+                "js": [
+                    "js/document-start.js"
+                ]
             }
         ],
         "minimum_chrome_version": "57.0.0.0",

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -72,7 +72,8 @@
                             "anki",
                             "sentenceParsing",
                             "inputs",
-                            "clipboard"
+                            "clipboard",
+                            "accessibility"
                         ],
                         "properties": {
                             "general": {
@@ -1107,6 +1108,18 @@
                                         "type": "integer",
                                         "default": 1000,
                                         "minimum": 0
+                                    }
+                                }
+                            },
+                            "accessibility": {
+                                "type": "object",
+                                "required": [
+                                    "forceGoogleDocsHtmlRendering"
+                                ],
+                                "properties": {
+                                    "forceGoogleDocsHtmlRendering": {
+                                        "type": "boolean",
+                                        "default": false
                                     }
                                 }
                             }

--- a/ext/js/accessibility/google-docs.js
+++ b/ext/js/accessibility/google-docs.js
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2021  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+(() => {
+    let parent = document.head;
+    if (parent === null) {
+        parent = document.documentElement;
+        if (parent === null) { return; }
+    }
+    const script = document.createElement('script');
+    script.textContent = 'window._docs_force_html_by_ext = true;';
+    parent.appendChild(script);
+})();

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -462,7 +462,8 @@ class OptionsUtil {
             {async: true,  update: this._updateVersion10.bind(this)},
             {async: false, update: this._updateVersion11.bind(this)},
             {async: true,  update: this._updateVersion12.bind(this)},
-            {async: true,  update: this._updateVersion13.bind(this)}
+            {async: true,  update: this._updateVersion13.bind(this)},
+            {async: false, update: this._updateVersion14.bind(this)}
         ];
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
             result.splice(targetVersion);
@@ -861,6 +862,17 @@ class OptionsUtil {
         await this._applyAnkiFieldTemplatesPatch(options, '/data/templates/anki-field-templates-upgrade-v13.handlebars');
         for (const profile of options.profiles) {
             profile.options.anki.duplicateScopeCheckAllModels = false;
+        }
+        return options;
+    }
+
+    _updateVersion14(options) {
+        // Version 14 changes:
+        //  Added accessibility options.
+        for (const profile of options.profiles) {
+            profile.options.accessibility = {
+                forceGoogleDocsHtmlRendering: false
+            };
         }
         return options;
     }

--- a/ext/js/document-start.js
+++ b/ext/js/document-start.js
@@ -1,0 +1,18 @@
+/*
+ * Copyright (C) 2021  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+chrome.runtime.sendMessage({action: 'documentStart'}, () => void chrome.runtime.lastError);

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -32,11 +32,14 @@
     },
     "content_scripts": [
         {
+            "run_at": "document_idle",
             "matches": [
                 "http://*/*",
                 "https://*/*",
                 "file://*/*"
             ],
+            "match_about_blank": true,
+            "all_frames": true,
             "js": [
                 "js/core.js",
                 "js/yomichan.js",
@@ -58,9 +61,20 @@
                 "js/language/text-scanner.js",
                 "js/script/dynamic-loader.js",
                 "js/app/content-script-main.js"
+            ]
+        },
+        {
+            "run_at": "document_start",
+            "matches": [
+                "http://*/*",
+                "https://*/*",
+                "file://*/*"
             ],
             "match_about_blank": true,
-            "all_frames": true
+            "all_frames": true,
+            "js": [
+                "js/document-start.js"
+            ]
         }
     ],
     "minimum_chrome_version": "57.0.0.0",

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -37,6 +37,7 @@
             <a href="#!clipboard"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="clipboard"></span></span><span class="outline-item-label">Clipboard</span></a>
             <a href="#!shortcuts"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="keyboard"></span></span><span class="outline-item-label">Shortcuts</span></a>
             <a href="#!backup"           class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="backup"></span></span><span class="outline-item-label">Backup</span></a>
+            <a href="#!accessibility"    class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="accessibility"></span></span><span class="outline-item-label">Accessibility</span></a>
             <a href="#!security"         class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="lock"></span></span><span class="outline-item-label">Security</span></a>
         </div>
         <div class="sidebar-bottom">
@@ -1814,6 +1815,39 @@
                 </div>
             </div>
         </div></div>
+    </div>
+
+    <!-- Accessibility -->
+    <div class="heading-container advanced-only">
+        <div class="heading-container-icon"><span class="icon" data-icon="accessibility"></span></div>
+        <div class="heading-container-left"><h2 id="accessibility"><a href="#!accessibility">Accessibility</a></h2></div>
+    </div>
+    <div class="settings-group advanced-only">
+        <div class="settings-item">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">
+                        Force HTML-based rendering for Google Docs
+                        <a class="more-toggle more-only" data-parent-distance="4">(?)</a>
+                    </div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle"><input type="checkbox" data-setting="accessibility.forceGoogleDocsHtmlRendering"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                </div>
+            </div>
+            <div class="settings-item-children more" hidden>
+                <p>
+                    Google Docs is moving from HTML-based rendering to
+                    <a href="https://developer.mozilla.org/en-US/docs/Web/HTML/Element/canvas" target="_blank" rel="noopener noreferrer">canvas-based</a>
+                    rendering to display content<sup><a href="https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html" target="_blank" rel="noopener noreferrer">[2]</a></sup>,
+                    which prevents Yomichan from being able to scan text.
+                    Enabling this option will force HTML-based rendering to be used.
+                </p>
+                <p>
+                    <a class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                </p>
+            </div>
+        </div>
     </div>
 
     <!-- Security -->

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -503,6 +503,9 @@ function createProfileOptionsUpdatedTestData1() {
             enableSearchPageMonitor: false,
             autoSearchContent: true,
             maximumSearchLength: 1000
+        },
+        accessibility: {
+            forceGoogleDocsHtmlRendering: false
         }
     };
 }
@@ -590,7 +593,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 13,
+        version: 14,
         global: {
             database: {
                 prefixWildcardsSupported: false


### PR DESCRIPTION
This change adds an option to force Google Docs to render using HTML rather than `<canvas>`. See #1670 for details.
https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html

Resolves #1670.