### PR TITLE
Update browser bugs with info about IndexedDB usage in a Worker

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -86,3 +86,8 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: Firefox
 * **Date**: 2021-06-06
 * **Links**: [Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1714883)
+
+## IndexedDB writes from a Worker thread do not persist if worker is terminated
+* **Browser**: Chrome, Firefox _(warning only)_
+* **Date**: 2021-08-07
+* **Links**: [Chrome Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1237686), [Firefox Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1724602)


### PR DESCRIPTION
Data added to the database from a Worker thread does not persist if the Worker is terminated.

https://bugs.chromium.org/p/chromium/issues/detail?id=1237686
https://bugzilla.mozilla.org/show_bug.cgi?id=1724602

Originally pointed out in https://github.com/FooSoft/yomichan/issues/1869#issuecomment-892243316