### PR TITLE
Database improvements to data persistency

### DIFF
--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -162,10 +162,11 @@ class Database {
     delete(objectStoreName, key) {
         return new Promise((resolve, reject) => {
             const transaction = this.transaction([objectStoreName], 'readwrite');
+            transaction.onerror = (e) => reject(e.target.error);
+            transaction.oncomplete = () => resolve();
             const objectStore = transaction.objectStore(objectStoreName);
-            const request = objectStore.delete(key);
-            request.onerror = (e) => reject(e.target.error);
-            request.onsuccess = () => resolve();
+            objectStore.delete(key);
+            transaction.commit();
         });
     }
 

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -195,16 +195,6 @@ class Database {
         });
     }
 
-    persistData(objectStoreName) {
-        return new Promise((resolve, reject) => {
-            const transaction = this.transaction([objectStoreName], 'readonly');
-            const objectStore = transaction.objectStore(objectStoreName);
-            const cursor = objectStore.openCursor();
-            cursor.onerror = (e) => reject(e.target.error);
-            cursor.onsuccess = () => resolve();
-        });
-    }
-
     static deleteDatabase(databaseName) {
         return new Promise((resolve, reject) => {
             const request = indexedDB.deleteDatabase(databaseName);

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -95,19 +95,19 @@ class Database {
         });
     }
 
-    getAll(objectStoreOrIndex, query, resolve, reject, data) {
+    getAll(objectStoreOrIndex, query, onSuccess, onError, data) {
         if (typeof objectStoreOrIndex.getAll === 'function') {
-            this._getAllFast(objectStoreOrIndex, query, resolve, reject, data);
+            this._getAllFast(objectStoreOrIndex, query, onSuccess, onError, data);
         } else {
-            this._getAllUsingCursor(objectStoreOrIndex, query, resolve, reject, data);
+            this._getAllUsingCursor(objectStoreOrIndex, query, onSuccess, onError, data);
         }
     }
 
-    getAllKeys(objectStoreOrIndex, query, resolve, reject) {
+    getAllKeys(objectStoreOrIndex, query, onSuccess, onError) {
         if (typeof objectStoreOrIndex.getAllKeys === 'function') {
-            this._getAllKeysFast(objectStoreOrIndex, query, resolve, reject);
+            this._getAllKeysFast(objectStoreOrIndex, query, onSuccess, onError);
         } else {
-            this._getAllKeysUsingCursor(objectStoreOrIndex, query, resolve, reject);
+            this._getAllKeysUsingCursor(objectStoreOrIndex, query, onSuccess, onError);
         }
     }
 
@@ -266,44 +266,44 @@ class Database {
         return false;
     }
 
-    _getAllFast(objectStoreOrIndex, query, resolve, reject, data) {
+    _getAllFast(objectStoreOrIndex, query, onSuccess, onReject, data) {
         const request = objectStoreOrIndex.getAll(query);
-        request.onerror = (e) => reject(e.target.error, data);
-        request.onsuccess = (e) => resolve(e.target.result, data);
+        request.onerror = (e) => onReject(e.target.error, data);
+        request.onsuccess = (e) => onSuccess(e.target.result, data);
     }
 
-    _getAllUsingCursor(objectStoreOrIndex, query, resolve, reject, data) {
+    _getAllUsingCursor(objectStoreOrIndex, query, onSuccess, onReject, data) {
         const results = [];
         const request = objectStoreOrIndex.openCursor(query, 'next');
-        request.onerror = (e) => reject(e.target.error, data);
+        request.onerror = (e) => onReject(e.target.error, data);
         request.onsuccess = (e) => {
             const cursor = e.target.result;
             if (cursor) {
                 results.push(cursor.value);
                 cursor.continue();
             } else {
-                resolve(results, data);
+                onSuccess(results, data);
             }
         };
     }
 
-    _getAllKeysFast(objectStoreOrIndex, query, resolve, reject) {
+    _getAllKeysFast(objectStoreOrIndex, query, onSuccess, onError) {
         const request = objectStoreOrIndex.getAllKeys(query);
-        request.onerror = (e) => reject(e.target.error);
-        request.onsuccess = (e) => resolve(e.target.result);
+        request.onerror = (e) => onError(e.target.error);
+        request.onsuccess = (e) => onSuccess(e.target.result);
     }
 
-    _getAllKeysUsingCursor(objectStoreOrIndex, query, resolve, reject) {
+    _getAllKeysUsingCursor(objectStoreOrIndex, query, onSuccess, onError) {
         const results = [];
         const request = objectStoreOrIndex.openKeyCursor(query, 'next');
-        request.onerror = (e) => reject(e.target.error);
+        request.onerror = (e) => onError(e.target.error);
         request.onsuccess = (e) => {
             const cursor = e.target.result;
             if (cursor) {
                 results.push(cursor.primaryKey);
                 cursor.continue();
             } else {
-                resolve(results);
+                onSuccess(results);
             }
         };
     }

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -104,7 +104,7 @@ class Database {
     }
 
     getAllKeys(objectStoreOrIndex, query, resolve, reject) {
-        if (typeof objectStoreOrIndex.getAll === 'function') {
+        if (typeof objectStoreOrIndex.getAllKeys === 'function') {
             this._getAllKeysFast(objectStoreOrIndex, query, resolve, reject);
         } else {
             this._getAllKeysUsingCursor(objectStoreOrIndex, query, resolve, reject);

--- a/ext/js/data/database.js
+++ b/ext/js/data/database.js
@@ -76,22 +76,14 @@ class Database {
                 return;
             }
 
-            const end = start + count;
-            let completedCount = 0;
-            const onError = (e) => reject(e.target.error);
-            const onSuccess = () => {
-                if (++completedCount >= count) {
-                    resolve();
-                }
-            };
-
             const transaction = this.transaction([objectStoreName], 'readwrite');
+            transaction.onerror = (e) => reject(e.target.error);
+            transaction.oncomplete = () => resolve();
             const objectStore = transaction.objectStore(objectStoreName);
-            for (let i = start; i < end; ++i) {
-                const request = objectStore.add(items[i]);
-                request.onerror = onError;
-                request.onsuccess = onSuccess;
+            for (let i = start, ii = start + count; i < ii; ++i) {
+                objectStore.add(items[i]);
             }
+            transaction.commit();
         });
     }
 

--- a/ext/js/language/dictionary-database.js
+++ b/ext/js/language/dictionary-database.js
@@ -317,10 +317,6 @@ class DictionaryDatabase {
         return this._db.bulkAdd(objectStoreName, items, start, count);
     }
 
-    persistData(objectStoreName) {
-        return this._db.persistData(objectStoreName);
-    }
-
     // Private
 
     _findMultiBulk(objectStoreName, indexNames, items, createQuery, predicate, createResult) {

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -149,10 +149,6 @@ class DictionaryImporter {
                 this._progressData.index += count;
                 this._progress();
             }
-
-            // This function is required in order to make the added data persist after the worker is terminated.
-            // https://bugs.chromium.org/p/chromium/issues/detail?id=1237686
-            await dictionaryDatabase.persistData(objectStoreName);
         };
 
         await bulkAdd('terms', termList);


### PR DESCRIPTION
The `transaction.oncomplete` event should be used to determine when data has been fully added to the database rather than `request.onsuccess`.

This is the actual fix to https://github.com/FooSoft/yomichan/issues/1869#issuecomment-892243316 / #1877.