### PR TITLE
Update browser bugs

### DIFF
--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -91,3 +91,8 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Browser**: ~~Chrome~~, Firefox _(warning only)_
 * **Date**: 2021-08-07
 * **Links**: ~~[Chrome Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1237686)~~, [Firefox Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1724602)
+
+## Web extension content scripts don't run on certain about:blank popups
+* **Browser**: Firefox
+* **Date**: 2021-08-16
+* **Links**: [Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1726068)

--- a/docs/browser-bugs.md
+++ b/docs/browser-bugs.md
@@ -88,6 +88,6 @@ This page lists several of the browser bugs that have affected Yomichan over the
 * **Links**: [Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1714883)
 
 ## IndexedDB writes from a Worker thread do not persist if worker is terminated
-* **Browser**: Chrome, Firefox _(warning only)_
+* **Browser**: ~~Chrome~~, Firefox _(warning only)_
 * **Date**: 2021-08-07
-* **Links**: [Chrome Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1237686), [Firefox Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1724602)
+* **Links**: ~~[Chrome Report](https://bugs.chromium.org/p/chromium/issues/detail?id=1237686)~~, [Firefox Report](https://bugzilla.mozilla.org/show_bug.cgi?id=1724602)


### PR DESCRIPTION
Web extension content scripts don't run on certain about:blank popups
https://bugzilla.mozilla.org/show_bug.cgi?id=1726068

Originally reported in: #1870