### PR TITLE
Fix incorrect katakana template docs

### DIFF
--- a/docs/templates.md
+++ b/docs/templates.md
@@ -821,8 +821,8 @@ Converts hiragana text to katakana.
   <summary>Example:</summary>
 
   ```handlebars
-  {{#hiragana "よみちゃん ヨミちゃん ヨミチャン"}}{{/hiragana}}
-  {{#hiragana}}よみちゃん ヨミちゃん ヨミチャン{{/hiragana}}
+  {{#katakana "よみちゃん ヨミちゃん ヨミチャン"}}{{/katakana}}
+  {{#katakana}}よみちゃん ヨミちゃん ヨミチャン{{/katakana}}
   ```
 
   Output:


### PR DESCRIPTION
Tip: one should press CTRL+S _before_ committing.

#1908