### PR TITLE
Dictionary worker updates

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -111,7 +111,6 @@ class Backend {
             ['getZoom',                      {async: true,  contentScript: true,  handler: this._onApiGetZoom.bind(this)}],
             ['getDefaultAnkiFieldTemplates', {async: false, contentScript: true,  handler: this._onApiGetDefaultAnkiFieldTemplates.bind(this)}],
             ['getDictionaryInfo',            {async: true,  contentScript: true,  handler: this._onApiGetDictionaryInfo.bind(this)}],
-            ['getDictionaryCounts',          {async: true,  contentScript: false, handler: this._onApiGetDictionaryCounts.bind(this)}],
             ['purgeDatabase',                {async: true,  contentScript: false, handler: this._onApiPurgeDatabase.bind(this)}],
             ['getMedia',                     {async: true,  contentScript: true,  handler: this._onApiGetMedia.bind(this)}],
             ['log',                          {async: false, contentScript: true,  handler: this._onApiLog.bind(this)}],
@@ -614,10 +613,6 @@ class Backend {
 
     async _onApiGetDictionaryInfo() {
         return await this._dictionaryDatabase.getDictionaryInfo();
-    }
-
-    async _onApiGetDictionaryCounts({dictionaryNames, getTotal}) {
-        return await this._dictionaryDatabase.getDictionaryCounts(dictionaryNames, getTotal);
     }
 
     async _onApiPurgeDatabase() {

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -120,10 +120,6 @@ class API {
         return this._invoke('getDictionaryInfo');
     }
 
-    getDictionaryCounts(dictionaryNames, getTotal) {
-        return this._invoke('getDictionaryCounts', {dictionaryNames, getTotal});
-    }
-
     purgeDatabase() {
         return this._invoke('purgeDatabase');
     }

--- a/ext/js/language/dictionary-worker-handler.js
+++ b/ext/js/language/dictionary-worker-handler.js
@@ -41,6 +41,9 @@ class DictionaryWorkerHandler {
             case 'deleteDictionary':
                 this._onMessageWithProgress(params, this._deleteDictionary.bind(this));
                 break;
+            case 'getDictionaryCounts':
+                this._onMessageWithProgress(params, this._getDictionaryCounts.bind(this));
+                break;
             case 'getImageResolution.response':
                 this._mediaLoader.handleMessage(params);
                 break;
@@ -82,6 +85,15 @@ class DictionaryWorkerHandler {
         const dictionaryDatabase = await this._getPreparedDictionaryDatabase();
         try {
             return await dictionaryDatabase.deleteDictionary(dictionaryTitle, {rate: 1000}, onProgress);
+        } finally {
+            dictionaryDatabase.close();
+        }
+    }
+
+    async _getDictionaryCounts({dictionaryNames, getTotal}) {
+        const dictionaryDatabase = await this._getPreparedDictionaryDatabase();
+        try {
+            return await dictionaryDatabase.getDictionaryCounts(dictionaryNames, getTotal);
         } finally {
             dictionaryDatabase.close();
         }

--- a/ext/js/language/dictionary-worker.js
+++ b/ext/js/language/dictionary-worker.js
@@ -38,6 +38,10 @@ class DictionaryWorker {
         return this._invoke('deleteDictionary', {dictionaryTitle}, [], onProgress);
     }
 
+    getDictionaryCounts(dictionaryNames, getTotal) {
+        return this._invoke('getDictionaryCounts', {dictionaryNames, getTotal}, [], null);
+    }
+
     // Private
 
     _invoke(action, params, transfer, onProgress, formatResult) {

--- a/ext/js/pages/settings/dictionary-controller.js
+++ b/ext/js/pages/settings/dictionary-controller.js
@@ -567,7 +567,7 @@ class DictionaryController {
 
             const token = this._databaseStateToken;
             const dictionaryTitles = this._dictionaryEntries.map(({dictionaryTitle}) => dictionaryTitle);
-            const {counts, total} = await yomichan.api.getDictionaryCounts(dictionaryTitles, true);
+            const {counts, total} = await new DictionaryWorker().getDictionaryCounts(dictionaryTitles, true);
             if (this._databaseStateToken !== token) { return; }
 
             for (let i = 0, ii = Math.min(counts.length, this._dictionaryEntries.length); i < ii; ++i) {


### PR DESCRIPTION
Dictionary database counting is now performed on a worker thread rather than on the backend, since it is a long-running operation.