### PR TITLE
Fix history replacement issue

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -515,7 +515,7 @@ class Frontend {
         const {url} = optionsContext;
         const details = {
             focus,
-            history: false,
+            historyMode: 'clear',
             params: {
                 type,
                 query,

--- a/ext/js/display/display-history.js
+++ b/ext/js/display/display-history.js
@@ -112,7 +112,7 @@ class DisplayHistory extends EventDispatcher {
     }
 
     _triggerStateChanged(synthetic) {
-        this.trigger('stateChanged', {history: this, synthetic});
+        this.trigger('stateChanged', {synthetic});
     }
 
     _updateHistoryFromCurrent(replace) {

--- a/ext/js/display/search-display-controller.js
+++ b/ext/js/display/search-display-controller.js
@@ -185,12 +185,12 @@ class SearchDisplayController {
         e.preventDefault();
         e.stopImmediatePropagation();
         this._display.blurElement(e.currentTarget);
-        this._search(true, true, true, null);
+        this._search(true, 'new', true, null);
     }
 
     _onSearch(e) {
         e.preventDefault();
-        this._search(true, true, true, null);
+        this._search(true, 'new', true, null);
     }
 
     _onCopy() {
@@ -205,7 +205,7 @@ class SearchDisplayController {
         }
         this._queryInput.value = text;
         this._updateSearchHeight(true);
-        this._search(animate, false, autoSearchContent, ['clipboard']);
+        this._search(animate, 'clear', autoSearchContent, ['clipboard']);
     }
 
     _onWanakanaEnableChange(e) {
@@ -362,7 +362,7 @@ class SearchDisplayController {
         });
     }
 
-    _search(animate, history, lookup, flags) {
+    _search(animate, historyMode, lookup, flags) {
         const query = this._queryInput.value;
         const depth = this._display.depth;
         const url = window.location.href;
@@ -373,7 +373,7 @@ class SearchDisplayController {
         }
         const details = {
             focus: false,
-            history,
+            historyMode,
             params: {
                 query
             },


### PR DESCRIPTION
Fixes an issue where the _Back_ button would disappear after scanning the query parser twice in the popup. This only affected cases where the query parser would be visible, e.g. button text.