### PR TITLE
Dictionary media import improvements

### DIFF
--- a/dev/database-vm.js
+++ b/dev/database-vm.js
@@ -69,7 +69,7 @@ class DatabaseVM extends VM {
 }
 
 class DatabaseVMDictionaryImporterMediaLoader {
-    async getImageResolution() {
+    async getImageDetails() {
         // Placeholder values
         return {width: 100, height: 100};
     }

--- a/dev/database-vm.js
+++ b/dev/database-vm.js
@@ -69,9 +69,9 @@ class DatabaseVM extends VM {
 }
 
 class DatabaseVMDictionaryImporterMediaLoader {
-    async getImageDetails() {
+    async getImageDetails(content) {
         // Placeholder values
-        return {width: 100, height: 100};
+        return {content, width: 100, height: 100};
     }
 }
 

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -31,6 +31,7 @@
  * PermissionsUtil
  * ProfileConditionsUtil
  * RequestBuilder
+ * StringUtil
  * Translator
  * wanakana
  */
@@ -621,7 +622,14 @@ class Backend {
     }
 
     async _onApiGetMedia({targets}) {
-        return await this._dictionaryDatabase.getMedia(targets);
+        const results = await this._dictionaryDatabase.getMedia(targets);
+        for (const item of results) {
+            const {content} = item;
+            if (content instanceof ArrayBuffer) {
+                item.content = StringUtil.arrayBufferToBase64(content);
+            }
+        }
+        return results;
     }
 
     _onApiLog({error, level, context}) {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -622,14 +622,7 @@ class Backend {
     }
 
     async _onApiGetMedia({targets}) {
-        const results = await this._dictionaryDatabase.getMedia(targets);
-        for (const item of results) {
-            const {content} = item;
-            if (content instanceof ArrayBuffer) {
-                item.content = StringUtil.arrayBufferToBase64(content);
-            }
-        }
-        return results;
+        return await this._getNormalizedDictionaryDatabaseMedia(targets);
     }
 
     _onApiLog({error, level, context}) {
@@ -1855,7 +1848,7 @@ class Backend {
             detailsList.push(details);
             detailsMap.set(key, details);
         }
-        const mediaList = await this._dictionaryDatabase.getMedia(targets);
+        const mediaList = await this._getNormalizedDictionaryDatabaseMedia(targets);
 
         for (const media of mediaList) {
             const {dictionary, path} = media;
@@ -2290,5 +2283,16 @@ class Backend {
         if (file === null) { return; }
 
         return await this._injectScript(file, tab.id, frameId);
+    }
+
+    async _getNormalizedDictionaryDatabaseMedia(targets) {
+        const results = await this._dictionaryDatabase.getMedia(targets);
+        for (const item of results) {
+            const {content} = item;
+            if (content instanceof ArrayBuffer) {
+                item.content = StringUtil.arrayBufferToBase64(content);
+            }
+        }
+        return results;
     }
 }

--- a/ext/js/data/sandbox/string-util.js
+++ b/ext/js/data/sandbox/string-util.js
@@ -58,4 +58,19 @@ class StringUtil {
             return binary;
         }
     }
+
+    /**
+     * Converts a base64 string to an ArrayBuffer.
+     * @param content The binary content string encoded in base64.
+     * @returns A new `ArrayBuffer` object corresponding to the specified content.
+     */
+    static base64ToArrayBuffer(content) {
+        const binaryContent = atob(content);
+        const length = binaryContent.length;
+        const array = new Uint8Array(length);
+        for (let i = 0; i < length; ++i) {
+            array[i] = binaryContent.charCodeAt(i);
+        }
+        return array.buffer;
+    }
 }

--- a/ext/js/language/dictionary-importer-media-loader.js
+++ b/ext/js/language/dictionary-importer-media-loader.js
@@ -15,23 +15,17 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-/* global
- * MediaUtil
- */
-
 /**
  * Class used for loading and validating media during the dictionary import process.
  */
 class DictionaryImporterMediaLoader {
     /**
-     * Attempts to load an image using a base64 encoded content and a media type
-     * and returns its resolution.
-     * @param content The binary content for the image, encoded in base64.
+     * Attempts to load an image using an ArrayBuffer and a media type to return details about it.
+     * @param content The binary content for the image, encoded as an ArrayBuffer.
      * @param mediaType The media type for the image content.
-     * @returns A Promise which resolves with {width, height} on success,
-     *   otherwise an error is thrown.
+     * @returns A Promise which resolves with {content, width, height} on success, otherwise an error is thrown.
      */
-    getImageDetails(content, mediaType) {
+    getImageDetails(content, mediaType, transfer) {
         return new Promise((resolve, reject) => {
             const image = new Image();
             const eventListeners = new EventListenerCollection();
@@ -42,14 +36,15 @@ class DictionaryImporterMediaLoader {
             };
             eventListeners.addEventListener(image, 'load', () => {
                 const {naturalWidth: width, naturalHeight: height} = image;
+                if (Array.isArray(transfer)) { transfer.push(content); }
                 cleanup();
-                resolve({width, height});
+                resolve({content, width, height});
             }, false);
             eventListeners.addEventListener(image, 'error', () => {
                 cleanup();
                 reject(new Error('Image failed to load'));
             }, false);
-            const blob = MediaUtil.createBlobFromBase64Content(content, mediaType);
+            const blob = new Blob([content], {type: mediaType});
             const url = URL.createObjectURL(blob);
             image.src = url;
         });

--- a/ext/js/language/dictionary-importer-media-loader.js
+++ b/ext/js/language/dictionary-importer-media-loader.js
@@ -31,7 +31,7 @@ class DictionaryImporterMediaLoader {
      * @returns A Promise which resolves with {width, height} on success,
      *   otherwise an error is thrown.
      */
-    getImageResolution(mediaType, content) {
+    getImageDetails(mediaType, content) {
         return new Promise((resolve, reject) => {
             const image = new Image();
             const eventListeners = new EventListenerCollection();

--- a/ext/js/language/dictionary-importer-media-loader.js
+++ b/ext/js/language/dictionary-importer-media-loader.js
@@ -26,12 +26,12 @@ class DictionaryImporterMediaLoader {
     /**
      * Attempts to load an image using a base64 encoded content and a media type
      * and returns its resolution.
-     * @param mediaType The media type for the image content.
      * @param content The binary content for the image, encoded in base64.
+     * @param mediaType The media type for the image content.
      * @returns A Promise which resolves with {width, height} on success,
      *   otherwise an error is thrown.
      */
-    getImageDetails(mediaType, content) {
+    getImageDetails(content, mediaType) {
         return new Promise((resolve, reject) => {
             const image = new Image();
             const eventListeners = new EventListenerCollection();

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -432,7 +432,7 @@ class DictionaryImporter {
         let width;
         let height;
         try {
-            ({width, height} = await this._mediaLoader.getImageDetails(mediaType, content));
+            ({width, height} = await this._mediaLoader.getImageDetails(content, mediaType));
         } catch (e) {
             throw createError('Could not load image');
         }

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -328,12 +328,9 @@ class DictionaryImporter {
         const media = new Map();
         const context = {archive, media};
 
-        const promises = [];
         for (const requirement of requirements) {
-            promises.push(this._resolveAsyncRequirement(context, requirement));
+            await this._resolveAsyncRequirement(context, requirement);
         }
-
-        await Promise.all(promises);
 
         return {
             media: [...media.values()]

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -432,7 +432,7 @@ class DictionaryImporter {
         let width;
         let height;
         try {
-            ({width, height} = await this._mediaLoader.getImageResolution(mediaType, content));
+            ({width, height} = await this._mediaLoader.getImageDetails(mediaType, content));
         } catch (e) {
             throw createError('Could not load image');
         }

--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -422,7 +422,7 @@ class DictionaryImporter {
         }
 
         // Load file content
-        const content = await file.async('base64');
+        let content = await file.async('arraybuffer');
         const mediaType = MediaUtil.getImageMediaTypeFromFileName(path);
         if (mediaType === null) {
             throw createError('Could not determine media type for image');
@@ -432,7 +432,7 @@ class DictionaryImporter {
         let width;
         let height;
         try {
-            ({width, height} = await this._mediaLoader.getImageDetails(content, mediaType));
+            ({content, width, height} = await this._mediaLoader.getImageDetails(content, mediaType));
         } catch (e) {
             throw createError('Could not load image');
         }

--- a/ext/js/language/dictionary-worker-handler.js
+++ b/ext/js/language/dictionary-worker-handler.js
@@ -44,7 +44,7 @@ class DictionaryWorkerHandler {
             case 'getDictionaryCounts':
                 this._onMessageWithProgress(params, this._getDictionaryCounts.bind(this));
                 break;
-            case 'getImageResolution.response':
+            case 'getImageDetails.response':
                 this._mediaLoader.handleMessage(params);
                 break;
         }

--- a/ext/js/language/dictionary-worker-media-loader.js
+++ b/ext/js/language/dictionary-worker-media-loader.js
@@ -45,12 +45,10 @@ class DictionaryWorkerMediaLoader {
     }
 
     /**
-     * Attempts to load an image using a base64 encoded content and a media type
-     * and returns its resolution.
-     * @param content The binary content for the image, encoded in base64.
+     * Attempts to load an image using an ArrayBuffer and a media type to return details about it.
+     * @param content The binary content for the image, encoded as an ArrayBuffer.
      * @param mediaType The media type for the image content.
-     * @returns A Promise which resolves with {width, height} on success,
-     *   otherwise an error is thrown.
+     * @returns A Promise which resolves with {content, width, height} on success, otherwise an error is thrown.
      */
     getImageDetails(content, mediaType) {
         return new Promise((resolve, reject) => {
@@ -59,7 +57,7 @@ class DictionaryWorkerMediaLoader {
             self.postMessage({
                 action: 'getImageDetails',
                 params: {id, content, mediaType}
-            });
+            }, [content]);
         });
     }
 }

--- a/ext/js/language/dictionary-worker-media-loader.js
+++ b/ext/js/language/dictionary-worker-media-loader.js
@@ -47,18 +47,18 @@ class DictionaryWorkerMediaLoader {
     /**
      * Attempts to load an image using a base64 encoded content and a media type
      * and returns its resolution.
-     * @param mediaType The media type for the image content.
      * @param content The binary content for the image, encoded in base64.
+     * @param mediaType The media type for the image content.
      * @returns A Promise which resolves with {width, height} on success,
      *   otherwise an error is thrown.
      */
-    getImageDetails(mediaType, content) {
+    getImageDetails(content, mediaType) {
         return new Promise((resolve, reject) => {
             const id = generateId(16);
             this._requests.set(id, {resolve, reject});
             self.postMessage({
                 action: 'getImageDetails',
-                params: {id, mediaType, content}
+                params: {id, content, mediaType}
             });
         });
     }

--- a/ext/js/language/dictionary-worker-media-loader.js
+++ b/ext/js/language/dictionary-worker-media-loader.js
@@ -52,12 +52,12 @@ class DictionaryWorkerMediaLoader {
      * @returns A Promise which resolves with {width, height} on success,
      *   otherwise an error is thrown.
      */
-    getImageResolution(mediaType, content) {
+    getImageDetails(mediaType, content) {
         return new Promise((resolve, reject) => {
             const id = generateId(16);
             this._requests.set(id, {resolve, reject});
             self.postMessage({
-                action: 'getImageResolution',
+                action: 'getImageDetails',
                 params: {id, mediaType, content}
             });
         });

--- a/ext/js/language/dictionary-worker.js
+++ b/ext/js/language/dictionary-worker.js
@@ -117,14 +117,15 @@ class DictionaryWorker {
 
     async _onMessageGetImageDetails(params, worker) {
         const {id, content, mediaType} = params;
+        const transfer = [];
         let response;
         try {
-            const result = await this._dictionaryImporterMediaLoader.getImageDetails(content, mediaType);
+            const result = await this._dictionaryImporterMediaLoader.getImageDetails(content, mediaType, transfer);
             response = {id, result};
         } catch (e) {
             response = {id, error: serializeError(e)};
         }
-        worker.postMessage({action: 'getImageDetails.response', params: response});
+        worker.postMessage({action: 'getImageDetails.response', params: response}, transfer);
     }
 
     _formatimportDictionaryResult(result) {

--- a/ext/js/language/dictionary-worker.js
+++ b/ext/js/language/dictionary-worker.js
@@ -116,10 +116,10 @@ class DictionaryWorker {
     }
 
     async _onMessageGetImageDetails(params, worker) {
-        const {id, mediaType, content} = params;
+        const {id, content, mediaType} = params;
         let response;
         try {
-            const result = await this._dictionaryImporterMediaLoader.getImageDetails(mediaType, content);
+            const result = await this._dictionaryImporterMediaLoader.getImageDetails(content, mediaType);
             response = {id, result};
         } catch (e) {
             response = {id, error: serializeError(e)};

--- a/ext/js/language/dictionary-worker.js
+++ b/ext/js/language/dictionary-worker.js
@@ -85,8 +85,8 @@ class DictionaryWorker {
             case 'progress':
                 this._onMessageProgress(params, details.onProgress);
                 break;
-            case 'getImageResolution':
-                this._onMessageGetImageResolution(params, details.worker);
+            case 'getImageDetails':
+                this._onMessageGetImageDetails(params, details.worker);
                 break;
         }
     }
@@ -115,16 +115,16 @@ class DictionaryWorker {
         onProgress(...args);
     }
 
-    async _onMessageGetImageResolution(params, worker) {
+    async _onMessageGetImageDetails(params, worker) {
         const {id, mediaType, content} = params;
         let response;
         try {
-            const result = await this._dictionaryImporterMediaLoader.getImageResolution(mediaType, content);
+            const result = await this._dictionaryImporterMediaLoader.getImageDetails(mediaType, content);
             response = {id, result};
         } catch (e) {
             response = {id, error: serializeError(e)};
         }
-        worker.postMessage({action: 'getImageResolution.response', params: response});
+        worker.postMessage({action: 'getImageDetails.response', params: response});
     }
 
     _formatimportDictionaryResult(result) {

--- a/ext/js/media/media-loader.js
+++ b/ext/js/media/media-loader.js
@@ -16,7 +16,7 @@
  */
 
 /* global
- * MediaUtil
+ * StringUtil
  */
 
 class MediaLoader {
@@ -86,7 +86,8 @@ class MediaLoader {
         const token = this._token;
         const data = (await yomichan.api.getMedia([{path, dictionary}]))[0];
         if (token === this._token && data !== null) {
-            const blob = MediaUtil.createBlobFromBase64Content(data.content, data.mediaType);
+            const buffer = StringUtil.base64ToArrayBuffer(data.content);
+            const blob = new Blob([buffer], {type: data.mediaType});
             const url = URL.createObjectURL(blob);
             cachedData.data = data;
             cachedData.url = url;

--- a/ext/js/media/media-util.js
+++ b/ext/js/media/media-util.js
@@ -129,20 +129,4 @@ class MediaUtil {
                 return null;
         }
     }
-
-    /**
-     * Creates a new `Blob` object from a base64 string of content.
-     * @param content The binary content string encoded in base64.
-     * @param mediaType The type of the media.
-     * @returns A new `Blob` object corresponding to the specified content.
-     */
-    static createBlobFromBase64Content(content, mediaType) {
-        const binaryContent = atob(content);
-        const length = binaryContent.length;
-        const array = new Uint8Array(length);
-        for (let i = 0; i < length; ++i) {
-            array[i] = binaryContent.charCodeAt(i);
-        }
-        return new Blob([array.buffer], {type: mediaType});
-    }
 }

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -100,6 +100,7 @@
 <script src="/js/comm/frame-endpoint.js"></script>
 <script src="/js/data/anki-note-builder.js"></script>
 <script src="/js/data/anki-util.js"></script>
+<script src="/js/data/sandbox/string-util.js"></script>
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>

--- a/ext/search.html
+++ b/ext/search.html
@@ -86,6 +86,7 @@
 <script src="/js/comm/cross-frame-api.js"></script>
 <script src="/js/data/anki-note-builder.js"></script>
 <script src="/js/data/anki-util.js"></script>
+<script src="/js/data/sandbox/string-util.js"></script>
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -3488,7 +3488,6 @@
 <script src="/js/language/sandbox/dictionary-data-util.js"></script>
 <script src="/js/language/sandbox/japanese-util.js"></script>
 <script src="/js/media/audio-system.js"></script>
-<script src="/js/media/media-util.js"></script>
 <script src="/js/media/text-to-speech-audio.js"></script>
 <script src="/js/pages/settings/anki-controller.js"></script>
 <script src="/js/pages/settings/anki-templates-controller.js"></script>

--- a/ext/welcome.html
+++ b/ext/welcome.html
@@ -407,7 +407,6 @@
 <script src="/js/input/hotkey-util.js"></script>
 <script src="/js/language/dictionary-importer-media-loader.js"></script>
 <script src="/js/language/dictionary-worker.js"></script>
-<script src="/js/media/media-util.js"></script>
 <script src="/js/pages/settings/dictionary-controller.js"></script>
 <script src="/js/pages/settings/dictionary-import-controller.js"></script>
 <script src="/js/pages/settings/generic-setting-controller.js"></script>


### PR DESCRIPTION
* Dictionary images are now processed in serial rather than in parallel. This should fix this memory issues mentioned in #1918.
* Dictionary image data is now passed from the worker thread to the main thread as a transfered `ArrayBuffer`, which should result in less JSON-serialized message data.
* Dictionary image data is now added to the database as an `ArrayBuffer`, which should hopefully result in less storage memory usage. It is still converted to base64 after being fetched from the database.