### PR TITLE
Database readwrite transaction updates

### DIFF
--- a/ext/js/language/dictionary-database.js
+++ b/ext/js/language/dictionary-database.js
@@ -139,8 +139,10 @@ class DictionaryDatabase {
         return result;
     }
 
-    async deleteDictionary(dictionaryName, progressSettings, onProgress) {
-        const {rate} = progressSettings;
+    async deleteDictionary(dictionaryName, progressRate, onProgress) {
+        if (typeof progressRate !== 'number') {
+            progressRate = 1;
+        }
         if (typeof onProgress !== 'function') {
             onProgress = () => {};
         }
@@ -180,7 +182,7 @@ class DictionaryDatabase {
         const onProgress2 = () => {
             const processed = progressData.processed + 1;
             progressData.processed = processed;
-            if ((processed % rate) === 0 || processed === progressData.count) {
+            if ((processed % progressRate) === 0 || processed === progressData.count) {
                 onProgress(progressData);
             }
         };

--- a/ext/js/language/dictionary-database.js
+++ b/ext/js/language/dictionary-database.js
@@ -141,6 +141,9 @@ class DictionaryDatabase {
 
     async deleteDictionary(dictionaryName, progressSettings, onProgress) {
         const {rate} = progressSettings;
+        if (typeof onProgress !== 'function') {
+            onProgress = () => {};
+        }
 
         const targetGroups = [
             [

--- a/ext/js/language/dictionary-worker-handler.js
+++ b/ext/js/language/dictionary-worker-handler.js
@@ -84,7 +84,7 @@ class DictionaryWorkerHandler {
     async _deleteDictionary({dictionaryTitle}, onProgress) {
         const dictionaryDatabase = await this._getPreparedDictionaryDatabase();
         try {
-            return await dictionaryDatabase.deleteDictionary(dictionaryTitle, {rate: 1000}, onProgress);
+            return await dictionaryDatabase.deleteDictionary(dictionaryTitle, 1000, onProgress);
         } finally {
             dictionaryDatabase.close();
         }

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -122,7 +122,7 @@ async function testDatabase1() {
                 let progressEvent = false;
                 await dictionaryDatabase.deleteDictionary(
                     title,
-                    {rate: 1000},
+                    1000,
                     () => {
                         progressEvent = true;
                     }
@@ -788,7 +788,7 @@ async function testDatabase2() {
     const dictionaryDatabase = new DictionaryDatabase();
 
     // Error: not prepared
-    await assert.rejects(async () => await dictionaryDatabase.deleteDictionary(title, {rate: 1000}));
+    await assert.rejects(async () => await dictionaryDatabase.deleteDictionary(title, 1000));
     await assert.rejects(async () => await dictionaryDatabase.findTermsBulk(['?'], titles, null));
     await assert.rejects(async () => await dictionaryDatabase.findTermsExactBulk([{term: '?', reading: '?'}], titles));
     await assert.rejects(async () => await dictionaryDatabase.findTermsBySequenceBulk([{query: 1, dictionary: title}]));

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -788,7 +788,7 @@ async function testDatabase2() {
     const dictionaryDatabase = new DictionaryDatabase();
 
     // Error: not prepared
-    await assert.rejects(async () => await dictionaryDatabase.deleteDictionary(title, {rate: 1000}, () => {}));
+    await assert.rejects(async () => await dictionaryDatabase.deleteDictionary(title, {rate: 1000}));
     await assert.rejects(async () => await dictionaryDatabase.findTermsBulk(['?'], titles, null));
     await assert.rejects(async () => await dictionaryDatabase.findTermsExactBulk([{term: '?', reading: '?'}], titles));
     await assert.rejects(async () => await dictionaryDatabase.findTermsBySequenceBulk([{query: 1, dictionary: title}]));


### PR DESCRIPTION
* Fixes a rare issue where dictionary settings would be repeatedly re-created if deleting a dictionary in one tab and viewing the settings from another tab. This was due to the dictionary metadata being deleted first; it is now deleted last.

This may fix https://github.com/FooSoft/yomichan/issues/1922#issuecomment-913034108.