### PR TITLE
Ensure frequency values are always numbers

### DIFF
--- a/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-kanji-meta-bank-v3-schema.json
@@ -17,7 +17,7 @@
                 "description": "Type of data. \"freq\" corresponds to frequency information."
             },
             {
-                "type": ["string", "number"],
+                "type": ["number"],
                 "description": "Data for the character."
             }
         ]

--- a/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-meta-bank-v3-schema.json
@@ -28,7 +28,7 @@
                     {
                         "oneOf": [
                             {
-                                "type": ["string", "number"],
+                                "type": ["number"],
                                 "description": "Frequency information for the term."
                             },
                             {
@@ -44,7 +44,7 @@
                                         "description": "Reading for the term."
                                     },
                                     "frequency": {
-                                        "type": ["string", "number"],
+                                        "type": ["number"],
                                         "description": "Frequency information for the term."
                                     }
                                 }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -819,7 +819,7 @@ class Translator {
                                     dictionaryIndex,
                                     dictionaryPriority,
                                     hasReading,
-                                    frequency
+                                    this._convertFrequency(frequency)
                                 ));
                             }
                         }
@@ -873,7 +873,7 @@ class Translator {
                             dictionaryIndex,
                             dictionaryPriority,
                             character,
-                            data
+                            this._convertFrequency(data)
                         ));
                     }
                     break;
@@ -922,6 +922,18 @@ class Translator {
             const i = v1.order - v2.order;
             return (i !== 0) ? i : stringComparer.compare(v1.content, v2.content);
         });
+    }
+
+    _convertFrequency(value) {
+        switch (typeof value) {
+            case 'number':
+                return value;
+            case 'string':
+                value = Number.parseFloat(value);
+                return Number.isFinite(value) ? value : 0;
+            default:
+                return 0;
+        }
     }
 
     // Helpers


### PR DESCRIPTION
Very few dictionaries have actually represented frequency values as a string, and those that do should not be considered valid. If there is a need for generalized string tags, that need can be addressed separately.