### PR TITLE
Revert term/reading string normalization due to undesirable changes

### DIFF
--- a/ext/js/language/dictionary-importer.js
+++ b/ext/js/language/dictionary-importer.js
@@ -587,10 +587,12 @@ class DictionaryImporter {
     }
 
     _normalizeTermOrReading(text) {
-        try {
-            return text.normalize('NFC');
-        } catch (e) {
-            return text;
-        }
+        // Note: this function should not perform String.normalize on the text,
+        // as it will characters in an undesirable way.
+        // Thus, this function is currently a no-op.
+        // Example:
+        // - '\u9038'.normalize('NFC') => '\u9038' (逸)
+        // - '\ufa67'.normalize('NFC') => '\u9038' (逸 => 逸)
+        return text;
     }
 }


### PR DESCRIPTION
[`String.normalize`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/normalize) should not be performed on terms/readings since it has unintended effects, such as modifying kanji.

```js
'\u9038'.normalize('NFC') === '\u9038' // 逸
'\ufa67'.normalize('NFC') === '\u9038' // 逸 => 逸
```

Change originally introduced in #1941.
Originally discussed in #461.
Detected while investigating #1956.