### PR TITLE
Fix hotkey input field conflict

### DIFF
--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -321,7 +321,7 @@ class DocumentUtil {
             case 'SELECT':
                 return true;
             default:
-                return element.contentEditable;
+                return element.isContentEditable;
         }
     }
 

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -320,7 +320,7 @@ class DocumentUtil {
             case 'SELECT':
                 return true;
             default:
-                return false;
+                return element.contentEditable;
         }
     }
 

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -311,6 +311,19 @@ class DocumentUtil {
         return !(browser === 'firefox' || browser === 'firefox-mobile') || os === 'mac';
     }
 
+    static isInputElement(element) {
+        if (element === null) { return false; }
+        const type = element.nodeName.toUpperCase();
+        switch (type) {
+            case 'INPUT':
+            case 'TEXTAREA':
+            case 'SELECT':
+                return true;
+            default:
+                return false;
+        }
+    }
+
     // Private
 
     static _getActiveButtons(event, array) {

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -311,7 +311,8 @@ class DocumentUtil {
         return !(browser === 'firefox' || browser === 'firefox-mobile') || os === 'mac';
     }
 
-    static isInputElement(element) {
+    static isInputElementFocused() {
+        const element = document.activeElement;
         if (element === null) { return false; }
         const type = element.nodeName.toUpperCase();
         switch (type) {

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -311,6 +311,8 @@ class DocumentUtil {
         return !(browser === 'firefox' || browser === 'firefox-mobile') || os === 'mac';
     }
 
+    // Private
+
     static _getActiveButtons(event, array) {
         let {buttons} = event;
         if (typeof buttons === 'number' && buttons > 0) {
@@ -324,8 +326,6 @@ class DocumentUtil {
             }
         }
     }
-
-    // Private
 
     _setImposterStyle(style, propertyName, value) {
         style.setProperty(propertyName, value, 'important');

--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -153,11 +153,10 @@ class HotkeyHandler extends EventDispatcher {
     // Private
 
     _onKeyDown(e) {
-        const key = e.code;
-        const hotkeyInfo = this._hotkeys.get(key);
+        const hotkeyInfo = this._hotkeys.get(e.code);
         if (typeof hotkeyInfo !== 'undefined') {
             const eventModifiers = DocumentUtil.getActiveModifiers(e);
-            if (this._invokeHandlers(eventModifiers, hotkeyInfo)) {
+            if (this._invokeHandlers(eventModifiers, hotkeyInfo, e.key)) {
                 e.preventDefault();
                 return;
             }
@@ -165,9 +164,9 @@ class HotkeyHandler extends EventDispatcher {
         this.trigger('keydownNonHotkey', e);
     }
 
-    _invokeHandlers(modifiers, hotkeyInfo) {
+    _invokeHandlers(modifiers, hotkeyInfo, key) {
         for (const {modifiers: handlerModifiers, action, argument} of hotkeyInfo.handlers) {
-            if (!this._areSame(handlerModifiers, modifiers) || !this._isHotkeyPermitted(modifiers)) { continue; }
+            if (!this._areSame(handlerModifiers, modifiers) || !this._isHotkeyPermitted(modifiers, key)) { continue; }
 
             const actionHandler = this._actions.get(action);
             if (typeof actionHandler !== 'undefined') {
@@ -224,10 +223,15 @@ class HotkeyHandler extends EventDispatcher {
         }
     }
 
-    _isHotkeyPermitted(modifiers) {
+    _isHotkeyPermitted(modifiers, key) {
         return !(
             (modifiers.length === 0 || (modifiers.length === 1 && modifiers[0] === 'shift')) &&
-            DocumentUtil.isInputElement(document.activeElement)
+            DocumentUtil.isInputElement(document.activeElement) &&
+            this._isKeyCharacterInput(key)
         );
+    }
+
+    _isKeyCharacterInput(key) {
+        return key.length === 1;
     }
 }

--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -226,7 +226,7 @@ class HotkeyHandler extends EventDispatcher {
     _isHotkeyPermitted(modifiers, key) {
         return !(
             (modifiers.length === 0 || (modifiers.length === 1 && modifiers[0] === 'shift')) &&
-            DocumentUtil.isInputElement(document.activeElement) &&
+            DocumentUtil.isInputElementFocused() &&
             this._isKeyCharacterInput(key)
         );
     }

--- a/ext/js/input/hotkey-handler.js
+++ b/ext/js/input/hotkey-handler.js
@@ -167,7 +167,7 @@ class HotkeyHandler extends EventDispatcher {
 
     _invokeHandlers(modifiers, hotkeyInfo) {
         for (const {modifiers: handlerModifiers, action, argument} of hotkeyInfo.handlers) {
-            if (!this._areSame(handlerModifiers, modifiers)) { continue; }
+            if (!this._areSame(handlerModifiers, modifiers) || !this._isHotkeyPermitted(modifiers)) { continue; }
 
             const actionHandler = this._actions.get(action);
             if (typeof actionHandler !== 'undefined') {
@@ -222,5 +222,12 @@ class HotkeyHandler extends EventDispatcher {
         } else {
             this._eventListeners.removeAllEventListeners();
         }
+    }
+
+    _isHotkeyPermitted(modifiers) {
+        return !(
+            (modifiers.length === 0 || (modifiers.length === 1 && modifiers[0] === 'shift')) &&
+            DocumentUtil.isInputElement(document.activeElement)
+        );
     }
 }

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -156,7 +156,7 @@ class SettingsDisplayController {
     _onKeyDown(e) {
         switch (e.code) {
             case 'Escape':
-                if (!DocumentUtil.isInputElement(document.activeElement)) {
+                if (!DocumentUtil.isInputElementFocused()) {
                     this._closeTopMenuOrModal();
                     e.preventDefault();
                 }

--- a/ext/js/pages/settings/settings-display-controller.js
+++ b/ext/js/pages/settings/settings-display-controller.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DocumentUtil
  * PopupMenu
  * SelectorObserver
  */
@@ -155,7 +156,7 @@ class SettingsDisplayController {
     _onKeyDown(e) {
         switch (e.code) {
             case 'Escape':
-                if (!this._isElementAnInput(document.activeElement)) {
+                if (!DocumentUtil.isInputElement(document.activeElement)) {
                     this._closeTopMenuOrModal();
                     e.preventDefault();
                 }
@@ -354,18 +355,6 @@ class SettingsDisplayController {
                 const indentLength = (Math.ceil((start - lineStart + 1) / indent.length) * indent.length - (start - lineStart));
                 document.execCommand('insertText', false, indent.substring(0, indentLength));
             }
-        }
-    }
-
-    _isElementAnInput(element) {
-        const type = element !== null ? element.nodeName.toUpperCase() : null;
-        switch (type) {
-            case 'INPUT':
-            case 'TEXTAREA':
-            case 'SELECT':
-                return true;
-            default:
-                return false;
         }
     }
 

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -263,6 +263,7 @@
 <script src="/js/data/anki-util.js"></script>
 <script src="/js/data/permissions-util.js"></script>
 <script src="/js/dom/document-focus-controller.js"></script>
+<script src="/js/dom/document-util.js"></script>
 <script src="/js/dom/html-template-collection.js"></script>
 <script src="/js/dom/panel-element.js"></script>
 <script src="/js/dom/popup-menu.js"></script>


### PR DESCRIPTION
Hotkeys using no modifier or only the shift key should be blocked if they correspond to a character input while a text field is focused.

Fixes #1948.