### PR TITLE
Update document-start.js to only run for docs.google.com

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -67,9 +67,8 @@
             {
                 "run_at": "document_start",
                 "matches": [
-                    "http://*/*",
-                    "https://*/*",
-                    "file://*/*"
+                    "http://docs.google.com/*",
+                    "https://docs.google.com/*"
                 ],
                 "match_about_blank": true,
                 "all_frames": true,

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -66,9 +66,8 @@
         {
             "run_at": "document_start",
             "matches": [
-                "http://*/*",
-                "https://*/*",
-                "file://*/*"
+                "http://docs.google.com/*",
+                "https://docs.google.com/*"
             ],
             "match_about_blank": true,
             "all_frames": true,


### PR DESCRIPTION
Partial workaround for issue mentioned in #1962.