### PR TITLE
Hotkey dictionary navigation fix

### DIFF
--- a/ext/js/dom/scroll-element.js
+++ b/ext/js/dom/scroll-element.js
@@ -68,6 +68,10 @@ class ScrollElement {
         this._animationRequestId = null;
     }
 
+    getRect() {
+        return this._node.getBoundingClientRect();
+    }
+
     // Private
 
     _onAnimationFrame(time) {


### PR DESCRIPTION
This change does two things:
* Fixes the _nextEntryDifferentDictionary_ and _previousEntryDifferentDictionary_ hotkey actions, which were broken due to previous changes to the dictionary entry data format.
* Improves their behaviour to work when _Result grouping mode_ is _Group term-reading pairs_ or _Group related terms_.

This may potentially require some additional changes to the behaviour of _previousEntryDifferentDictionary_ in the future, as it is not very useful in certain situations, but that can be postponed for now.

Resolves #1830.