### PR TITLE
Make accessibility settings non-advanced

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -37,7 +37,7 @@
             <a href="#!clipboard"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="clipboard"></span></span><span class="outline-item-label">Clipboard</span></a>
             <a href="#!shortcuts"        class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="keyboard"></span></span><span class="outline-item-label">Shortcuts</span></a>
             <a href="#!backup"           class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="backup"></span></span><span class="outline-item-label">Backup</span></a>
-            <a href="#!accessibility"    class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="accessibility"></span></span><span class="outline-item-label">Accessibility</span></a>
+            <a href="#!accessibility"    class="button outline-item"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="accessibility"></span></span><span class="outline-item-label">Accessibility</span></a>
             <a href="#!security"         class="button outline-item advanced-only"><span class="outline-item-left"><span class="outline-item-icon icon" data-icon="lock"></span></span><span class="outline-item-label">Security</span></a>
         </div>
         <div class="sidebar-bottom">
@@ -1885,11 +1885,11 @@
     </div>
 
     <!-- Accessibility -->
-    <div class="heading-container advanced-only">
+    <div class="heading-container">
         <div class="heading-container-icon"><span class="icon" data-icon="accessibility"></span></div>
         <div class="heading-container-left"><h2 id="accessibility"><a href="#!accessibility">Accessibility</a></h2></div>
     </div>
-    <div class="settings-group advanced-only">
+    <div class="settings-group">
         <div class="settings-item">
             <div class="settings-item-inner">
                 <div class="settings-item-left">


### PR DESCRIPTION
Google Docs canvas rendering has (or is nearing) public deployment, so expose the settings when in non-advanced mode.