### PR TITLE
Add disable-popup-preview option to the settings page

### DIFF
--- a/ext/js/pages/settings/popup-preview-controller.js
+++ b/ext/js/pages/settings/popup-preview-controller.js
@@ -26,6 +26,8 @@ class PopupPreviewController {
     }
 
     async prepare() {
+        if (new URLSearchParams(location.search).get('popup-preview') === 'false') { return; }
+
         this._frame = document.querySelector('#popup-preview-frame');
         this._customCss = document.querySelector('#custom-popup-css');
         this._customOuterCss = document.querySelector('#custom-popup-outer-css');
@@ -37,6 +39,8 @@ class PopupPreviewController {
         this._customOuterCss.addEventListener('settingChanged', this._onCustomOuterCssChange.bind(this), false);
         this._frame.addEventListener('load', this._onFrameLoad.bind(this), false);
         this._settingsController.on('optionsContextChanged', this._onOptionsContextChange.bind(this));
+
+        this._frame.src = '/popup-preview.html';
     }
 
     // Private

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1980,7 +1980,7 @@
 <div class="content-right">
     <div class="preview-sidebar"><div class="preview-sidebar-inner">
         <div class="preview-frame-container">
-            <iframe src="/popup-preview.html" class="preview-frame" id="popup-preview-frame"></iframe>
+            <iframe class="preview-frame" id="popup-preview-frame"></iframe>
         </div>
     </div></div>
 </div>


### PR DESCRIPTION
This change adds an option to the settings page which can be used to disable the popup preview. `popup-preview=false` can be added to the URL search query to disable the preview.

Related: #1955