### PR TITLE
Fix search page not being cleared properly

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -552,7 +552,7 @@ class Display extends EventDispatcher {
             // Prepare
             const urlSearchParams = new URLSearchParams(location.search);
             let type = urlSearchParams.get('type');
-            if (type === null) { type = 'terms'; }
+            if (type === null && urlSearchParams.get('query') !== null) { type = 'terms'; }
 
             const fullVisible = urlSearchParams.get('full-visible');
             this._queryParserVisibleOverride = (fullVisible === null ? null : (fullVisible !== 'false'));


### PR DESCRIPTION
The popup was being opened to an empty `'terms'` page, which was triggering an options update before it was fully configured.

Fixes https://github.com/FooSoft/yomichan/issues/1997#issuecomment-964000124.