### PR TITLE
FrameOffsetForwarder fixes

### DIFF
--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -316,12 +316,7 @@ class PopupProxy extends EventDispatcher {
     async _updateFrameOffsetInner(now) {
         this._frameOffsetPromise = this._frameOffsetForwarder.getOffset();
         try {
-            let offset = null;
-            try {
-                offset = await this._frameOffsetPromise;
-            } catch (e) {
-                // NOP
-            }
+            const offset = await this._frameOffsetPromise;
             this._frameOffset = offset !== null ? offset : [0, 0];
             if (offset === null) {
                 this.trigger('offsetNotFound');

--- a/ext/js/comm/frame-offset-forwarder.js
+++ b/ext/js/comm/frame-offset-forwarder.js
@@ -48,13 +48,14 @@ class FrameOffsetForwarder {
 
         const results = await Promise.all(promises);
 
-        let xOffset = 0;
-        let yOffset = 0;
-        for (const {x, y} of results) {
-            xOffset += x;
-            yOffset += y;
+        let x = 0;
+        let y = 0;
+        for (const result of results) {
+            if (result === null) { return null; }
+            x += result.x;
+            y += result.y;
         }
-        return [xOffset, yOffset];
+        return [x, y];
     }
 
     // Private

--- a/ext/js/comm/frame-offset-forwarder.js
+++ b/ext/js/comm/frame-offset-forwarder.js
@@ -37,25 +37,29 @@ class FrameOffsetForwarder {
             return [0, 0];
         }
 
-        const ancestorFrameIds = await this._frameAncestryHandler.getFrameAncestryInfo();
+        try {
+            const ancestorFrameIds = await this._frameAncestryHandler.getFrameAncestryInfo();
 
-        let childFrameId = this._frameId;
-        const promises = [];
-        for (const frameId of ancestorFrameIds) {
-            promises.push(yomichan.crossFrame.invoke(frameId, 'FrameOffsetForwarder.getChildFrameRect', {frameId: childFrameId}));
-            childFrameId = frameId;
+            let childFrameId = this._frameId;
+            const promises = [];
+            for (const frameId of ancestorFrameIds) {
+                promises.push(yomichan.crossFrame.invoke(frameId, 'FrameOffsetForwarder.getChildFrameRect', {frameId: childFrameId}));
+                childFrameId = frameId;
+            }
+
+            const results = await Promise.all(promises);
+
+            let x = 0;
+            let y = 0;
+            for (const result of results) {
+                if (result === null) { return null; }
+                x += result.x;
+                y += result.y;
+            }
+            return [x, y];
+        } catch (e) {
+            return null;
         }
-
-        const results = await Promise.all(promises);
-
-        let x = 0;
-        let y = 0;
-        for (const result of results) {
-            if (result === null) { return null; }
-            x += result.x;
-            y += result.y;
-        }
-        return [x, y];
     }
 
     // Private


### PR DESCRIPTION
Improves the results of `FrameOffsetForwarder.getOffset()` to return `null` rather than throw an error.