### PR TITLE
ScriptManager updates

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -98,7 +98,8 @@
         ],
         "optional_permissions": [
             "clipboardRead",
-            "nativeMessaging"
+            "nativeMessaging",
+            "webNavigation"
         ],
         "commands": {
             "toggleTextScanning": {
@@ -172,6 +173,7 @@
             "fileName": "yomichan-chrome-mv3.zip",
             "modifications": [
                 {"action": "set",    "path": ["manifest_version"], "value": 3},
+                {"action": "set",    "path": ["minimum_chrome_version"], "value": "96.0.0.0"},
                 {"action": "move",   "path": ["browser_action"], "newPath": ["action"]},
                 {"action": "delete", "path": ["background", "page"]},
                 {"action": "delete", "path": ["background", "persistent"]},
@@ -185,6 +187,7 @@
                 {"action": "remove", "path": ["permissions"], "item": "webRequestBlocking"},
                 {"action": "add",    "path": ["permissions"], "items": ["declarativeNetRequest", "scripting"]},
                 {"action": "set",    "path": ["host_permissions"], "value": ["<all_urls>"], "after": "optional_permissions"},
+                {"action": "remove", "path": ["optional_permissions"], "item": "webNavigation"},
                 {"action": "move",   "path": ["web_accessible_resources"], "newPath": ["web_accessible_resources_old"]},
                 {"action": "set",    "path": ["web_accessible_resources"], "value": [{"resources": [], "matches": ["<all_urls>"]}], "after": "web_accessible_resources_old"},
                 {"action": "move",   "path": ["web_accessible_resources_old"], "newPath": ["web_accessible_resources", 0, "resources"]}

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -564,7 +564,7 @@ class Backend {
     async _onApiInjectStylesheet({type, value}, sender) {
         const {frameId, tab} = sender;
         if (!isObject(tab)) { throw new Error('Invalid tab'); }
-        return await this._scriptManager.injectStylesheet(type, value, tab.id, frameId);
+        return await this._scriptManager.injectStylesheet(type, value, tab.id, frameId, false, true, 'document_start');
     }
 
     async _onApiGetStylesheetContent({url}) {

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -2156,7 +2156,7 @@ class Backend {
 
         if (file === null) { return; }
 
-        await this._scriptManager.injectScript(file, tabId, frameId);
+        await this._scriptManager.injectScript(file, tabId, frameId, false, true, 'document_start');
     }
 
     async _getNormalizedDictionaryDatabaseMedia(targets) {

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -38,6 +38,7 @@ class ScriptManager {
             return Promise.reject(new Error('Stylesheet injection not supported'));
         }
     }
+
     /**
      * Injects a script into a specific tab and frame.
      * @param {string} file The path to a file to inject.

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -97,7 +97,8 @@
     ],
     "optional_permissions": [
         "clipboardRead",
-        "nativeMessaging"
+        "nativeMessaging",
+        "webNavigation"
     ],
     "commands": {
         "toggleTextScanning": {

--- a/ext/permissions.html
+++ b/ext/permissions.html
@@ -123,6 +123,18 @@
                 <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="nativeMessaging"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
+        <div class="settings-item" data-hide-for-manifest-version="3"><div class="settings-item-inner">
+            <div class="settings-item-left">
+                <div class="settings-item-label"><code>webNavigation</code> <span class="light">(optional)</span></div>
+                <div class="settings-item-description">
+                    Yomichan may require this permission to inject content scripts for certain browsers
+                    if Google Docs accessibility mode is enabled.
+                </div>
+            </div>
+            <div class="settings-item-right">
+                <label class="toggle"><input type="checkbox" class="permissions-toggle" data-required-permissions="webNavigation"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+            </div>
+        </div></div>
         <div class="settings-item"><div class="settings-item-inner">
             <div class="settings-item-left">
                 <div class="settings-item-label">Allow in private windows <span class="light">(optional)</span></div>


### PR DESCRIPTION
`ScriptManager` now supports declarative content script updates. On up-to-date browsers, it uses native APIs to accomplish this, falling back to manual execution if those APIs aren't supported.

This will eventually be used to resolve #1962 in a more effective manner.