### PR TITLE
Fix non-text <input> elements being included in scanning content

### DIFF
--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -39,8 +39,10 @@ class DocumentUtil {
                 case 'SELECT':
                     return new TextSourceElement(element);
                 case 'INPUT':
-                    imposterSourceElement = element;
-                    [imposter, imposterContainer] = this._createImposter(element, false);
+                    if (element.type === 'text') {
+                        imposterSourceElement = element;
+                        [imposter, imposterContainer] = this._createImposter(element, false);
+                    }
                     break;
                 case 'TEXTAREA':
                     imposterSourceElement = element;


### PR DESCRIPTION
This fixes a minor bug where `<input type=checkbox>` would be scanned, and its `.value` property would return `'on'`, which could result in the text "おん" being scanned if romaji => kana conversion was enabled.