### PR TITLE
Replace 'wildcard' parameter with 'matchType'

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1080,7 +1080,8 @@ class Backend {
         const jp = this._japaneseUtil;
         const mode = 'simple';
         const options = this._getProfileOptions(optionsContext);
-        const findTermsOptions = this._getTranslatorFindTermsOptions(mode, {wildcard: null}, options);
+        const details = {matchType: 'exact'};
+        const findTermsOptions = this._getTranslatorFindTermsOptions(mode, details, options);
         const results = [];
         let previousUngroupedSegment = null;
         let i = 0;
@@ -1958,7 +1959,8 @@ class Backend {
     }
 
     _getTranslatorFindTermsOptions(mode, details, options) {
-        const {wildcard} = details;
+        let {matchType} = details;
+        if (typeof matchType !== 'string') { matchType = 'exact'; }
         const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
         const {
             general: {mainDictionary, sortFrequencyDictionary, sortFrequencyDictionaryOrder},
@@ -1985,7 +1987,7 @@ class Backend {
             excludeDictionaryDefinitions.add(mainDictionary);
         }
         return {
-            wildcard,
+            matchType,
             mainDictionary,
             sortFrequencyDictionary,
             sortFrequencyDictionaryOrder,

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -850,9 +850,9 @@ class Display extends EventDispatcher {
                 const match = /^([*\uff0a]*)([\w\W]*?)([*\uff0a]*)$/.exec(source);
                 if (match !== null) {
                     if (match[1]) {
-                        findDetails.wildcard = 'prefix';
+                        findDetails.matchType = 'suffix';
                     } else if (match[3]) {
-                        findDetails.wildcard = 'suffix';
+                        findDetails.matchType = 'prefix';
                     }
                     source = match[2];
                 }

--- a/ext/js/language/dictionary-database.js
+++ b/ext/js/language/dictionary-database.js
@@ -196,7 +196,7 @@ class DictionaryDatabase {
         }
     }
 
-    findTermsBulk(termList, dictionaries, wildcard) {
+    findTermsBulk(termList, dictionaries, matchType) {
         const visited = new Set();
         const predicate = (row) => {
             if (!dictionaries.has(row.dictionary)) { return false; }
@@ -206,17 +206,17 @@ class DictionaryDatabase {
             return true;
         };
 
-        const indexNames = (wildcard === 'prefix') ? ['expressionReverse', 'readingReverse'] : ['expression', 'reading'];
+        const indexNames = (matchType === 'suffix') ? ['expressionReverse', 'readingReverse'] : ['expression', 'reading'];
 
         let createQuery;
-        switch (wildcard) {
-            case 'suffix':
+        switch (matchType) {
+            case 'prefix':
                 createQuery = this._createBoundQuery1;
                 break;
-            case 'prefix':
+            case 'suffix':
                 createQuery = this._createBoundQuery2;
                 break;
-            default:
+            default: // 'exact'
                 createQuery = this._createOnlyQuery1;
                 break;
         }

--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -63,7 +63,7 @@ class Translator {
      * @param options An object using the following structure:
      * ```
      *   {
-     *     wildcard: (enum: null, 'prefix', 'suffix'),
+     *     matchType: (enum: 'exact', 'prefix', 'suffix'),
      *     mainDictionary: (string),
      *     sortFrequencyDictionary: (null or string),
      *     sortFrequencyDictionaryOrder: (enum: 'ascending', 'descending'),
@@ -227,7 +227,6 @@ class Translator {
     // Find terms internal implementation
 
     async _findTermsInternal(text, enabledDictionaryMap, options) {
-        const {wildcard} = options;
         if (options.removeNonJapaneseCharacters) {
             text = this._getJapaneseOnlyText(text);
         }
@@ -235,9 +234,10 @@ class Translator {
             return {dictionaryEntries: [], originalTextLength: 0};
         }
 
+        const {matchType} = options;
         const deinflections = await (
-            wildcard ?
-            this._findTermsWildcard(text, enabledDictionaryMap, wildcard) :
+            matchType && matchType !== 'exact' ?
+            this._findTermsWildcard(text, enabledDictionaryMap, matchType) :
             this._findTermDeinflections(text, enabledDictionaryMap, options)
         );
 
@@ -259,8 +259,8 @@ class Translator {
         return {dictionaryEntries, originalTextLength};
     }
 
-    async _findTermsWildcard(text, enabledDictionaryMap, wildcard) {
-        const databaseEntries = await this._database.findTermsBulk([text], enabledDictionaryMap, wildcard);
+    async _findTermsWildcard(text, enabledDictionaryMap, matchType) {
+        const databaseEntries = await this._database.findTermsBulk([text], enabledDictionaryMap, matchType);
         return databaseEntries.length > 0 ? [this._createDeinflection(text, text, text, 0, [], databaseEntries)] : [];
     }
 

--- a/test/test-database.js
+++ b/test/test-database.js
@@ -218,15 +218,15 @@ async function testFindTermsBulkTest1(database, titles) {
         {
             inputs: [
                 {
-                    wildcard: null,
+                    matchType: null,
                     termList: ['打', '打つ', '打ち込む']
                 },
                 {
-                    wildcard: null,
+                    matchType: null,
                     termList: ['だ', 'ダース', 'うつ', 'ぶつ', 'うちこむ', 'ぶちこむ']
                 },
                 {
-                    wildcard: 'suffix',
+                    matchType: 'prefix',
                     termList: ['打']
                 }
             ],
@@ -250,7 +250,7 @@ async function testFindTermsBulkTest1(database, titles) {
         {
             inputs: [
                 {
-                    wildcard: null,
+                    matchType: null,
                     termList: ['込む']
                 }
             ],
@@ -263,7 +263,7 @@ async function testFindTermsBulkTest1(database, titles) {
         {
             inputs: [
                 {
-                    wildcard: 'prefix',
+                    matchType: 'suffix',
                     termList: ['込む']
                 }
             ],
@@ -281,7 +281,7 @@ async function testFindTermsBulkTest1(database, titles) {
         {
             inputs: [
                 {
-                    wildcard: null,
+                    matchType: null,
                     termList: []
                 }
             ],
@@ -294,8 +294,8 @@ async function testFindTermsBulkTest1(database, titles) {
     ];
 
     for (const {inputs, expectedResults} of data) {
-        for (const {termList, wildcard} of inputs) {
-            const results = await database.findTermsBulk(termList, titles, wildcard);
+        for (const {termList, matchType} of inputs) {
+            const results = await database.findTermsBulk(termList, titles, matchType);
             assert.strictEqual(results.length, expectedResults.total);
             for (const [term, count] of expectedResults.terms) {
                 assert.strictEqual(countDictionaryDatabaseEntriesWithTerm(results, term), count);


### PR DESCRIPTION
`matchType` is more generic and a better representation of how the source text matches the text from the database.