### PR TITLE
matchType/deinflect distinction

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1080,7 +1080,7 @@ class Backend {
         const jp = this._japaneseUtil;
         const mode = 'simple';
         const options = this._getProfileOptions(optionsContext);
-        const details = {matchType: 'exact'};
+        const details = {matchType: 'exact', deinflect: true};
         const findTermsOptions = this._getTranslatorFindTermsOptions(mode, details, options);
         const results = [];
         let previousUngroupedSegment = null;
@@ -1959,8 +1959,9 @@ class Backend {
     }
 
     _getTranslatorFindTermsOptions(mode, details, options) {
-        let {matchType} = details;
+        let {matchType, deinflect} = details;
         if (typeof matchType !== 'string') { matchType = 'exact'; }
+        if (typeof deinflect !== 'boolean') { deinflect = true; }
         const enabledDictionaryMap = this._getTranslatorEnabledDictionaryMap(options);
         const {
             general: {mainDictionary, sortFrequencyDictionary, sortFrequencyDictionaryOrder},
@@ -1988,6 +1989,7 @@ class Backend {
         }
         return {
             matchType,
+            deinflect,
             mainDictionary,
             sortFrequencyDictionary,
             sortFrequencyDictionaryOrder,

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -851,8 +851,10 @@ class Display extends EventDispatcher {
                 if (match !== null) {
                     if (match[1]) {
                         findDetails.matchType = 'suffix';
+                        findDetails.deinflect = false;
                     } else if (match[3]) {
                         findDetails.matchType = 'prefix';
+                        findDetails.deinflect = false;
                     }
                     source = match[2];
                 }

--- a/test/data/translator-test-inputs.json
+++ b/test/data/translator-test-inputs.json
@@ -12,7 +12,8 @@
             ]
         },
         "default": {
-            "wildcard": null,
+            "matchType": "exact",
+            "deinflect": true,
             "mainDictionary": "${title}",
             "sortFrequencyDictionary": null,
             "sortFrequencyDictionaryOrder": "descending",


### PR DESCRIPTION
This change makes a distinction between the `matchType` parameter and a new `deinflect` parameter. Previously, deinflection was performed if and only if `matchType` was `'exact'`. Now, deinflection can be performed when match type is either `'prefix'` or `'suffix'`, which allows wildcard lookup after deinflection.