### PR TITLE
Scanning wildcards

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -435,7 +435,8 @@
                                     "enableOnPopupExpressions",
                                     "enableOnSearchPage",
                                     "enableSearchTags",
-                                    "layoutAwareScan"
+                                    "layoutAwareScan",
+                                    "matchTypePrefix"
                                 ],
                                 "properties": {
                                     "inputs": {
@@ -656,6 +657,10 @@
                                         "default": false
                                     },
                                     "layoutAwareScan": {
+                                        "type": "boolean",
+                                        "default": false
+                                    },
+                                    "matchTypePrefix": {
                                         "type": "boolean",
                                         "default": false
                                     }

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -397,6 +397,7 @@ class Frontend {
             pointerEventsEnabled: scanningOptions.pointerEventsEnabled,
             scanLength: scanningOptions.length,
             layoutAwareScan: scanningOptions.layoutAwareScan,
+            matchTypePrefix: scanningOptions.matchTypePrefix,
             preventMiddleMouse,
             sentenceParsingOptions
         });

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -464,7 +464,8 @@ class OptionsUtil {
             {async: true,  update: this._updateVersion12.bind(this)},
             {async: true,  update: this._updateVersion13.bind(this)},
             {async: false, update: this._updateVersion14.bind(this)},
-            {async: false, update: this._updateVersion15.bind(this)}
+            {async: false, update: this._updateVersion15.bind(this)},
+            {async: false, update: this._updateVersion16.bind(this)}
         ];
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
             result.splice(targetVersion);
@@ -885,6 +886,15 @@ class OptionsUtil {
         for (const profile of options.profiles) {
             profile.options.general.sortFrequencyDictionary = null;
             profile.options.general.sortFrequencyDictionaryOrder = 'descending';
+        }
+        return options;
+    }
+
+    _updateVersion16(options) {
+        // Version 16 changes:
+        //  Added scanning.matchTypePrefix.
+        for (const profile of options.profiles) {
+            profile.options.scanning.matchTypePrefix = false;
         }
         return options;
     }

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -325,6 +325,7 @@ class Display extends EventDispatcher {
                 scanLength: scanningOptions.length,
                 layoutAwareScan: scanningOptions.layoutAwareScan,
                 preventMiddleMouse: scanningOptions.preventMiddleMouse.onSearchQuery,
+                matchTypePrefix: false,
                 sentenceParsingOptions
             }
         });

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -61,6 +61,7 @@ class TextScanner extends EventDispatcher {
         this._scanLength = 1;
         this._layoutAwareScan = false;
         this._preventMiddleMouse = false;
+        this._matchTypePrefix = false;
         this._sentenceScanExtent = 0;
         this._sentenceTerminateAtNewlines = true;
         this._sentenceTerminatorMap = new Map();
@@ -155,7 +156,8 @@ class TextScanner extends EventDispatcher {
         scanLength,
         layoutAwareScan,
         preventMiddleMouse,
-        sentenceParsingOptions
+        sentenceParsingOptions,
+        matchTypePrefix
     }) {
         if (Array.isArray(inputs)) {
             this._inputs = inputs.map(({
@@ -209,6 +211,9 @@ class TextScanner extends EventDispatcher {
         }
         if (typeof preventMiddleMouse === 'boolean') {
             this._preventMiddleMouse = preventMiddleMouse;
+        }
+        if (typeof matchTypePrefix === 'boolean') {
+            this._matchTypePrefix = matchTypePrefix;
         }
         if (typeof sentenceParsingOptions === 'object' && sentenceParsingOptions !== null) {
             const {scanExtent, terminationCharacterMode, terminationCharacters} = sentenceParsingOptions;
@@ -854,7 +859,9 @@ class TextScanner extends EventDispatcher {
         const searchText = this.getTextSourceContent(textSource, scanLength, layoutAwareScan);
         if (searchText.length === 0) { return null; }
 
-        const {dictionaryEntries, originalTextLength} = await yomichan.api.termsFind(searchText, {}, optionsContext);
+        const details = {};
+        if (this._matchTypePrefix) { details.matchType = 'prefix'; }
+        const {dictionaryEntries, originalTextLength} = await yomichan.api.termsFind(searchText, details, optionsContext);
         if (dictionaryEntries.length === 0) { return null; }
 
         textSource.setEndOffset(originalTextLength, layoutAwareScan);

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -484,6 +484,32 @@
                 <label class="toggle"><input type="checkbox" data-setting="scanning.deepDomScan"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
             </div>
         </div></div>
+        <div class="settings-item advanced-only">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
+                    <div class="settings-item-label">Wildcard scanning</div>
+                    <div class="settings-item-description">
+                        Enable suffix wildcard when looking up scanned webpage text.
+                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
+                    </div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle"><input type="checkbox" data-setting="scanning.matchTypePrefix"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                </div>
+            </div>
+            <div class="settings-item-children more" hidden>
+                <p>
+                    Rather than searching for the source text exactly, the text will only be required to be a prefix of an existing term.
+                    For example, scanning 読み will effectively search for 読み*, which may bring up additional results such as 読み方.
+                </p>
+                <p class="danger-text">
+                    This will likely cause scanning and lookup to be slower.
+                </p>
+                <p>
+                    <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                </p>
+            </div>
+        </div>
         <div class="settings-item advanced-only"><div class="settings-item-inner settings-item-inner-wrappable">
             <div class="settings-item-left">
                 <div class="settings-item-label">Text scan length</div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -503,7 +503,7 @@
                     For example, scanning 読み will effectively search for 読み*, which may bring up additional results such as 読み方.
                 </p>
                 <p class="danger-text">
-                    This will likely cause scanning and lookup to be slower.
+                    This will likely cause scanning and lookup to be slower, and the results may not be as relevant.
                 </p>
                 <p>
                     <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -344,6 +344,7 @@ function createProfileOptionsUpdatedTestData1() {
             layoutAwareScan: false,
             hideDelay: 0,
             pointerEventsEnabled: false,
+            matchTypePrefix: false,
             preventMiddleMouse: {
                 onWebPages: false,
                 onPopupPages: false,
@@ -595,7 +596,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 15,
+        version: 16,
         global: {
             database: {
                 prefixWildcardsSupported: false


### PR DESCRIPTION
This change adds support for using a suffix wildcard during webpage scanning. Note that the lookup process will take longer with this enabled, since more results are returned from the database.

Note: there is a possible inconsistency when navigating backward in the popup history and the search needs to be re-performed. The search won't do a wildcard search the same way the original scanner did it. This is sufficiently rare and mostly inconsequential, so this issue isn't addressed at this time.

Resolves #2013.