### PR TITLE
Set `Content-Type` header of AnkiConnect requests to `application/json`

### DIFF
--- a/ext/js/comm/anki.js
+++ b/ext/js/comm/anki.js
@@ -174,6 +174,9 @@ class AnkiConnect {
                 mode: 'cors',
                 cache: 'default',
                 credentials: 'omit',
+                headers: {
+                    'Content-Type': 'application/json'
+                },
                 redirect: 'follow',
                 referrerPolicy: 'no-referrer',
                 body: JSON.stringify({action, params, version: this._localVersion})


### PR DESCRIPTION
Fixes https://github.com/FooSoft/yomichan/issues/2046