### PR TITLE
Rename MediaLoader to DisplayContentManager

### DIFF
--- a/ext/js/display/display-content-manager.js
+++ b/ext/js/display/display-content-manager.js
@@ -19,7 +19,7 @@
  * StringUtil
  */
 
-class MediaLoader {
+class DisplayContentManager {
     constructor() {
         this._token = {};
         this._mediaCache = new Map();

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -23,12 +23,12 @@
  */
 
 class DisplayGenerator {
-    constructor({japaneseUtil, mediaLoader, hotkeyHelpController=null}) {
+    constructor({japaneseUtil, contentManager, hotkeyHelpController=null}) {
         this._japaneseUtil = japaneseUtil;
-        this._mediaLoader = mediaLoader;
+        this._contentManager = contentManager;
         this._hotkeyHelpController = hotkeyHelpController;
         this._templates = null;
-        this._structuredContentGenerator = new StructuredContentGenerator(this._mediaLoader, document);
+        this._structuredContentGenerator = new StructuredContentGenerator(this._contentManager, document);
         this._pronunciationGenerator = new PronunciationGenerator(japaneseUtil);
     }
 

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DisplayContentManager
  * DisplayGenerator
  * DisplayHistory
  * DisplayNotification
@@ -24,7 +25,6 @@
  * FrameEndpoint
  * Frontend
  * HotkeyHelpController
- * MediaLoader
  * OptionToggleHotkeyHandler
  * PopupFactory
  * PopupMenu
@@ -52,11 +52,11 @@ class Display extends EventDispatcher {
         this._styleNode = null;
         this._eventListeners = new EventListenerCollection();
         this._setContentToken = null;
-        this._mediaLoader = new MediaLoader();
+        this._contentManager = new DisplayContentManager();
         this._hotkeyHelpController = new HotkeyHelpController();
         this._displayGenerator = new DisplayGenerator({
             japaneseUtil,
-            mediaLoader: this._mediaLoader,
+            contentManager: this._contentManager,
             hotkeyHelpController: this._hotkeyHelpController
         });
         this._messageHandlers = new Map();
@@ -543,7 +543,7 @@ class Display extends EventDispatcher {
             this._closePopups();
             this._closeAllPopupMenus();
             this._eventListeners.removeAllEventListeners();
-            this._mediaLoader.unloadAll();
+            this._contentManager.unloadAll();
             this._hideTagNotification(false);
             this._triggerContentClear();
             this._dictionaryEntries = [];

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -16,8 +16,8 @@
  */
 
 class StructuredContentGenerator {
-    constructor(mediaLoader, document) {
-        this._mediaLoader = mediaLoader;
+    constructor(contentManager, document) {
+        this._contentManager = contentManager;
         this._document = document;
     }
 
@@ -141,8 +141,8 @@ class StructuredContentGenerator {
 
         aspectRatioSizer.style.paddingTop = `${invAspectRatio * 100.0}%`;
 
-        if (this._mediaLoader !== null) {
-            this._mediaLoader.loadMedia(
+        if (this._contentManager !== null) {
+            this._contentManager.loadMedia(
                 path,
                 dictionary,
                 (url) => this._setImageData(node, image, imageBackground, url, false),

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -106,6 +106,7 @@
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>
+<script src="/js/display/display-content-manager.js"></script>
 <script src="/js/display/display-generator.js"></script>
 <script src="/js/display/display-history.js"></script>
 <script src="/js/display/display-notification.js"></script>
@@ -132,7 +133,6 @@
 <script src="/js/language/sandbox/japanese-util.js"></script>
 <script src="/js/language/text-scanner.js"></script>
 <script src="/js/media/audio-system.js"></script>
-<script src="/js/media/media-loader.js"></script>
 <script src="/js/media/media-util.js"></script>
 <script src="/js/media/text-to-speech-audio.js"></script>
 <script src="/js/script/dynamic-loader.js"></script>

--- a/ext/search.html
+++ b/ext/search.html
@@ -93,6 +93,7 @@
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>
+<script src="/js/display/display-content-manager.js"></script>
 <script src="/js/display/display-generator.js"></script>
 <script src="/js/display/display-history.js"></script>
 <script src="/js/display/display-notification.js"></script>
@@ -119,7 +120,6 @@
 <script src="/js/language/sandbox/japanese-util.js"></script>
 <script src="/js/language/text-scanner.js"></script>
 <script src="/js/media/audio-system.js"></script>
-<script src="/js/media/media-loader.js"></script>
 <script src="/js/media/media-util.js"></script>
 <script src="/js/media/text-to-speech-audio.js"></script>
 <script src="/js/script/dynamic-loader.js"></script>


### PR DESCRIPTION
Moving towards generalizing the functionality of the current `MediaLoader`. Also disambiguates with other classes named `*MediaLoader`.