### PR TITLE
Settings advanced indicators

### DIFF
--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -499,6 +499,9 @@ a.heading-link-light {
 .settings-group.settings-group-top-margin {
     margin-top: 1.0125em;
 }
+.settings-item {
+    position: relative;
+}
 .settings-item:not([hidden]) {
     display: block;
 }
@@ -679,6 +682,16 @@ select.short-height {
 
 
 /* Advanced settings */
+.settings-group.advanced-only>.settings-item::after,
+.settings-item.advanced-only::after {
+    content: '';
+    background-color: var(--advanced-color-lighter);
+    position: absolute;
+    right: 0;
+    top: 0;
+    height: 100%;
+    width: 0.25em;
+}
 .advanced-toggle {
     --accent-color: var(--advanced-color);
     --accent-color-lighter: var(--advanced-color-lighter);

--- a/ext/css/settings.css
+++ b/ext/css/settings.css
@@ -65,6 +65,9 @@
     --warning-color-light: #edc75e;
     --dim-background-color: rgba(0, 0, 0, 0.5);
     --content-dimmer-color: rgba(0, 0, 0, 0.1);
+    --advanced-color: #6640be;
+    --advanced-color-lighter: hsl(258, 50%, 75%);
+    --advanced-color-transparent25: rgba(102, 64, 190, 0.5);
 
     --modal-padding-horizontal: 1em;
     --modal-padding-vertical: 0.625em;
@@ -672,6 +675,14 @@ select.short-height {
     flex: 0 1 auto;
     padding-top: var(--padding);
     padding-right: var(--padding);
+}
+
+
+/* Advanced settings */
+.advanced-toggle {
+    --accent-color: var(--advanced-color);
+    --accent-color-lighter: var(--advanced-color-lighter);
+    --accent-color-transparent25: var(--advanced-color-transparent25);
 }
 
 

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -42,7 +42,7 @@
         </div>
         <div class="sidebar-bottom">
             <label class="button outline-item"><span class="outline-item-left">
-                <label class="toggle"><input id="advanced-checkbox" type="checkbox" data-setting="general.showAdvanced"
+                <label class="toggle advanced-toggle"><input id="advanced-checkbox" type="checkbox" data-setting="general.showAdvanced"
                     data-transform='{
                         "type": "setAttribute",
                         "selector": ":root",


### PR DESCRIPTION
This change shows a small purple bar on the right side of settings that only appear when advanced mode is enabled. The _Advanced_ toggle is also purple now to better correlate what the bar means.