### PR TITLE
Theme updates

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -49,6 +49,7 @@
                     "js/app/popup-factory.js",
                     "js/app/popup-proxy.js",
                     "js/app/popup-window.js",
+                    "js/app/theme-controller.js",
                     "js/comm/api.js",
                     "js/comm/cross-frame-api.js",
                     "js/comm/frame-ancestry-handler.js",

--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -309,25 +309,25 @@ a {
 
 
 /* Scrollbars */
-:root:not([data-theme=default]) .scrollbar {
+:root:not([data-theme=light]) .scrollbar {
     scrollbar-color: var(--scrollbar-thumb-color) var(--scrollbar-track-color);
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar {
     width: auto;
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar-button {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-button {
     height: 0;
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar-thumb {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-thumb {
     background-color: var(--scrollbar-thumb-color);
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar-track {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track {
     background-color: var(--scrollbar-thumb-color);
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar-track-piece {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-track-piece {
     background-color: var(--scrollbar-track-color);
 }
-:root:not([data-theme=default]) .scrollbar::-webkit-scrollbar-corner {
+:root:not([data-theme=light]) .scrollbar::-webkit-scrollbar-corner {
     background-color: var(--scrollbar-track-color);
 }
 :root .scrollbar-inverse {

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -31,8 +31,7 @@ iframe.yomichan-popup[data-theme=dark] {
     background-color: #1e1e1e;
     border-color: #666666;
 }
-iframe.yomichan-popup[data-outer-theme=dark],
-iframe.yomichan-popup[data-outer-theme=auto][data-site-theme=dark] {
+iframe.yomichan-popup[data-outer-theme=dark] {
     box-shadow: 0 0 10em rgba(255, 255, 255, 0.5);
 }
 iframe.yomichan-popup[data-popup-display-mode=full-width] {

--- a/ext/css/popup-outer.css
+++ b/ext/css/popup-outer.css
@@ -32,7 +32,7 @@ iframe.yomichan-popup[data-theme=dark] {
     border-color: #666666;
 }
 iframe.yomichan-popup[data-outer-theme=dark],
-iframe.yomichan-popup[data-outer-theme=auto][data-site-color=dark] {
+iframe.yomichan-popup[data-outer-theme=auto][data-site-theme=dark] {
     box-shadow: 0 0 10em rgba(255, 255, 255, 0.5);
 }
 iframe.yomichan-popup[data-popup-display-mode=full-width] {

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -214,12 +214,12 @@
                                     },
                                     "popupTheme": {
                                         "type": "string",
-                                        "enum": ["default", "dark", "browser"],
+                                        "enum": ["light", "dark", "browser"],
                                         "default": "default"
                                     },
                                     "popupOuterTheme": {
                                         "type": "string",
-                                        "enum": ["default", "dark", "browser", "auto"],
+                                        "enum": ["light", "dark", "browser", "site"],
                                         "default": "default"
                                     },
                                     "customPopupCss": {

--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -214,12 +214,12 @@
                                     },
                                     "popupTheme": {
                                         "type": "string",
-                                        "enum": ["default", "dark"],
+                                        "enum": ["default", "dark", "browser"],
                                         "default": "default"
                                     },
                                     "popupOuterTheme": {
                                         "type": "string",
-                                        "enum": ["default", "dark", "auto"],
+                                        "enum": ["default", "dark", "browser", "auto"],
                                         "default": "default"
                                     },
                                     "customPopupCss": {

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -235,6 +235,7 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Updates the outer theme of the popup.
+     * @returns {Promise<void>}
      */
     updateTheme() {
         return this._invokeSafe('PopupFactory.updateTheme', {id: this._id});

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -235,7 +235,6 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Updates the outer theme of the popup.
-     * @returns {Promise<void>}
      */
     updateTheme() {
         return this._invokeSafe('PopupFactory.updateTheme', {id: this._id});

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -212,7 +212,7 @@ class PopupWindow extends EventDispatcher {
     /**
      * Updates the outer theme of the popup.
      */
-    updateTheme() {
+    async updateTheme() {
         // NOP
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -57,6 +57,7 @@ class Popup extends EventDispatcher {
 
         this._popupTheme = 'default';
         this._popupOuterTheme = 'default';
+        this._browserTheme = 'light';
 
         this._frameSizeContentScale = null;
         this._frameClient = null;
@@ -156,6 +157,9 @@ class Popup extends EventDispatcher {
         this._visible.on('change', this._onVisibleChange.bind(this));
         yomichan.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
         this._onVisibleChange({value: this.isVisibleSync()});
+        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        mediaQueryList.addEventListener('change', this._onPrefersColorSchemeDarkChange.bind(this));
+        this._onPrefersColorSchemeDarkChange(mediaQueryList);
     }
 
     /**
@@ -294,6 +298,7 @@ class Popup extends EventDispatcher {
         data.theme = this._popupTheme;
         data.outerTheme = this._popupOuterTheme;
         data.siteTheme = this._getSiteTheme();
+        data.browserTheme = this._browserTheme;
     }
 
     /**
@@ -351,6 +356,11 @@ class Popup extends EventDispatcher {
 
     _onFrameMouseOut() {
         this.trigger('framePointerOut', {});
+    }
+
+    _onPrefersColorSchemeDarkChange({matches}) {
+        this._browserTheme = (matches ? 'dark' : 'light');
+        this.updateTheme();
     }
 
     _inject() {

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -290,9 +290,10 @@ class Popup extends EventDispatcher {
      * @returns {Promise<void>}
      */
     updateTheme() {
-        this._frame.dataset.theme = this._popupTheme;
-        this._frame.dataset.outerTheme = this._popupOuterTheme;
-        this._frame.dataset.siteTheme = this._getSiteTheme();
+        const data = this._frame.dataset;
+        data.theme = this._popupTheme;
+        data.outerTheme = this._popupOuterTheme;
+        data.siteTheme = this._getSiteTheme();
     }
 
     /**

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -288,8 +288,9 @@ class Popup extends EventDispatcher {
 
     /**
      * Updates the outer theme of the popup.
+     * @returns {Promise<void>}
      */
-    updateTheme() {
+    async updateTheme() {
         this._themeController.updateTheme();
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -288,9 +288,8 @@ class Popup extends EventDispatcher {
 
     /**
      * Updates the outer theme of the popup.
-     * @returns {Promise<void>}
      */
-    async updateTheme() {
+    updateTheme() {
         this._themeController.updateTheme();
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -18,6 +18,7 @@
 /* global
  * DocumentUtil
  * FrameClient
+ * ThemeController
  * dynamicLoader
  */
 
@@ -55,10 +56,6 @@ class Popup extends EventDispatcher {
         this._contentScale = 1.0;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
 
-        this._popupTheme = 'default';
-        this._popupOuterTheme = 'default';
-        this._browserTheme = 'light';
-
         this._frameSizeContentScale = null;
         this._frameClient = null;
         this._frame = document.createElement('iframe');
@@ -68,6 +65,8 @@ class Popup extends EventDispatcher {
 
         this._container = this._frame;
         this._shadow = null;
+
+        this._themeController = new ThemeController(this._frame);
 
         this._fullscreenEventListeners = new EventListenerCollection();
     }
@@ -157,9 +156,7 @@ class Popup extends EventDispatcher {
         this._visible.on('change', this._onVisibleChange.bind(this));
         yomichan.on('extensionUnloaded', this._onExtensionUnloaded.bind(this));
         this._onVisibleChange({value: this.isVisibleSync()});
-        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-        mediaQueryList.addEventListener('change', this._onPrefersColorSchemeDarkChange.bind(this));
-        this._onPrefersColorSchemeDarkChange(mediaQueryList);
+        this._themeController.prepare();
     }
 
     /**
@@ -293,12 +290,8 @@ class Popup extends EventDispatcher {
      * Updates the outer theme of the popup.
      * @returns {Promise<void>}
      */
-    updateTheme() {
-        const data = this._frame.dataset;
-        data.theme = this._popupTheme;
-        data.outerTheme = this._popupOuterTheme;
-        data.siteTheme = this._getSiteTheme();
-        data.browserTheme = this._browserTheme;
+    async updateTheme() {
+        this._themeController.updateTheme();
     }
 
     /**
@@ -356,11 +349,6 @@ class Popup extends EventDispatcher {
 
     _onFrameMouseOut() {
         this.trigger('framePointerOut', {});
-    }
-
-    _onPrefersColorSchemeDarkChange({matches}) {
-        this._browserTheme = (matches ? 'dark' : 'light');
-        this.updateTheme();
     }
 
     _inject() {
@@ -601,19 +589,6 @@ class Popup extends EventDispatcher {
         }
     }
 
-    _getSiteTheme() {
-        const color = [255, 255, 255];
-        const {documentElement, body} = document;
-        if (documentElement !== null) {
-            this._addColor(color, window.getComputedStyle(documentElement).backgroundColor);
-        }
-        if (body !== null) {
-            this._addColor(color, window.getComputedStyle(body).backgroundColor);
-        }
-        const dark = (color[0] < 128 && color[1] < 128 && color[2] < 128);
-        return dark ? 'dark' : 'light';
-    }
-
     async _invoke(action, params={}) {
         const contentWindow = this._frame.contentWindow;
         if (this._frameClient === null || !this._frameClient.isConnected() || contentWindow === null) { return; }
@@ -774,34 +749,6 @@ class Popup extends EventDispatcher {
         return [position, size, after];
     }
 
-    _addColor(target, cssColor) {
-        if (typeof cssColor !== 'string') { return; }
-
-        const color = this._getColorInfo(cssColor);
-        if (color === null) { return; }
-
-        const a = color[3];
-        if (a <= 0.0) { return; }
-
-        const aInv = 1.0 - a;
-        for (let i = 0; i < 3; ++i) {
-            target[i] = target[i] * aInv + color[i] * a;
-        }
-    }
-
-    _getColorInfo(cssColor) {
-        const m = /^\s*rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)\s*$/.exec(cssColor);
-        if (m === null) { return null; }
-
-        const m4 = m[4];
-        return [
-            Number.parseInt(m[1], 10),
-            Number.parseInt(m[2], 10),
-            Number.parseInt(m[3], 10),
-            m4 ? Math.max(0.0, Math.min(1.0, Number.parseFloat(m4))) : 1.0
-        ];
-    }
-
     _getViewport(useVisualViewport) {
         const visualViewport = window.visualViewport;
         if (visualViewport !== null && typeof visualViewport === 'object') {
@@ -838,10 +785,9 @@ class Popup extends EventDispatcher {
     async _setOptionsContext(optionsContext) {
         this._optionsContext = optionsContext;
         this._options = await yomichan.api.optionsGet(optionsContext);
-        ({
-            popupTheme: this._popupTheme,
-            popupOuterTheme: this._popupOuterTheme
-        } = this._options.general);
+        const {general} = this._options;
+        this._themeController.theme = general.popupTheme;
+        this._themeController.outerTheme = general.popupOuterTheme;
         this.updateTheme();
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -55,6 +55,9 @@ class Popup extends EventDispatcher {
         this._contentScale = 1.0;
         this._targetOrigin = chrome.runtime.getURL('/').replace(/\/$/, '');
 
+        this._popupTheme = 'default';
+        this._popupOuterTheme = 'default';
+
         this._frameSizeContentScale = null;
         this._frameClient = null;
         this._frame = document.createElement('iframe');
@@ -287,9 +290,8 @@ class Popup extends EventDispatcher {
      * @returns {Promise<void>}
      */
     updateTheme() {
-        const {popupTheme, popupOuterTheme} = this._options.general;
-        this._frame.dataset.theme = popupTheme;
-        this._frame.dataset.outerTheme = popupOuterTheme;
+        this._frame.dataset.theme = this._popupTheme;
+        this._frame.dataset.outerTheme = this._popupOuterTheme;
         this._frame.dataset.siteTheme = this._getSiteTheme();
     }
 
@@ -825,6 +827,10 @@ class Popup extends EventDispatcher {
     async _setOptionsContext(optionsContext) {
         this._optionsContext = optionsContext;
         this._options = await yomichan.api.optionsGet(optionsContext);
+        ({
+            popupTheme: this._popupTheme,
+            popupOuterTheme: this._popupOuterTheme
+        } = this._options.general);
         this.updateTheme();
     }
 

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -290,7 +290,7 @@ class Popup extends EventDispatcher {
         const {popupTheme, popupOuterTheme} = this._options.general;
         this._frame.dataset.theme = popupTheme;
         this._frame.dataset.outerTheme = popupOuterTheme;
-        this._frame.dataset.siteColor = this._getSiteColor();
+        this._frame.dataset.siteTheme = this._getSiteTheme();
     }
 
     /**
@@ -588,7 +588,7 @@ class Popup extends EventDispatcher {
         }
     }
 
-    _getSiteColor() {
+    _getSiteTheme() {
         const color = [255, 255, 255];
         const {documentElement, body} = document;
         if (documentElement !== null) {

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This class is used to control theme attributes on DOM elements.
+ */
+class ThemeController {
+    /**
+     * Creates a new instance of the class.
+     * @param {?Element} element A DOM element which theme properties are applied to.
+     */
+    constructor(element) {
+        this._element = element;
+        this._theme = 'default';
+        this._outerTheme = 'default';
+        this._siteTheme = null;
+        this._browserTheme = 'light';
+    }
+
+    /**
+     * Gets the DOM element which theme properties are applied to.
+     * @type {?Element}
+     */
+    get element() {
+        return this._element;
+    }
+
+    /**
+     * Sets the DOM element which theme properties are applied to.
+     * @param {?Element} value The DOM element to assign.
+     */
+    set element(value) {
+        this._element = value;
+    }
+
+    /**
+     * Gets the main theme for the content.
+     * @type {string}
+     */
+    get theme() {
+        return this._theme;
+    }
+
+    /**
+     * Sets the main theme for the content.
+     * @param {string} value The theme value to assign.
+     */
+    set theme(value) {
+        this._theme = value;
+    }
+
+    /**
+     * Gets the outer theme for the content.
+     * @type {string}
+     */
+    get outerTheme() {
+        return this._outerTheme;
+    }
+
+    /**
+     * Sets the outer theme for the content.
+     * @param {string} value The outer theme value to assign.
+     */
+    set outerTheme(value) {
+        this._outerTheme = value;
+    }
+
+    /**
+     * Gets the override value for the site theme.
+     * If this value is `null`, the computed value will be used.
+     * @type {?string}
+     */
+    get siteTheme() {
+        return this._siteTheme;
+    }
+
+    /**
+     * Sets the override value for the site theme.
+     * If this value is `null`, the computed value will be used.
+     * @param {?string} value The site theme value to assign.
+     */
+    set siteTheme(value) {
+        this._siteTheme = value;
+    }
+
+    /**
+     * Gets the browser's preferred color theme.
+     * The value can be either 'light' or 'dark'.
+     * @type {?string}
+     */
+    get browserTheme() {
+        return this._browserTheme;
+    }
+
+    /**
+     * Prepares the instance for use and applies the theme settings.
+     */
+    prepare() {
+        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        mediaQueryList.addEventListener('change', this._onPrefersColorSchemeDarkChange.bind(this));
+        this._onPrefersColorSchemeDarkChange(mediaQueryList);
+    }
+
+    /**
+     * Updates the theme attributes on the target element.
+     * If the site theme value isn't overridden, the current site theme is recomputed.
+     */
+    updateTheme() {
+        if (this._element === null) { return; }
+        const computedSiteTheme = this._siteTheme !== null ? this._siteTheme : this.computeSiteTheme();
+        const data = this._element.dataset;
+        data.theme = this._resolveThemeValue(this._theme, computedSiteTheme);
+        data.outerTheme = this._resolveThemeValue(this._outerTheme, computedSiteTheme);
+        data.siteTheme = computedSiteTheme;
+        data.browserTheme = this._browserTheme;
+        data.themeRaw = this._theme;
+        data.outerThemeRaw = this._outerTheme;
+    }
+
+    /**
+     * Computes the current site theme based on the background color.
+     * @returns {'light'|'dark'} The theme of the site.
+     */
+    computeSiteTheme() {
+        const color = [255, 255, 255];
+        const {documentElement, body} = document;
+        if (documentElement !== null) {
+            this._addColor(color, window.getComputedStyle(documentElement).backgroundColor);
+        }
+        if (body !== null) {
+            this._addColor(color, window.getComputedStyle(body).backgroundColor);
+        }
+        const dark = (color[0] < 128 && color[1] < 128 && color[2] < 128);
+        return dark ? 'dark' : 'light';
+    }
+
+    /**
+     * Event handler for when the preferred browser theme changes.
+     * @param {MediaQueryList|MediaQueryListEvent} detail The object containing event details.
+     * @param {boolean} detail.matches The object containing event details.
+     */
+    _onPrefersColorSchemeDarkChange({matches}) {
+        this._browserTheme = (matches ? 'dark' : 'light');
+        this.updateTheme();
+    }
+
+    /**
+     * Resolves a settings theme value to the actual value which should be used.
+     * @param {string} theme The theme value to resolve.
+     * @param {string} computedSiteTheme The computed site theme value to use for when the theme value is `'auto'`.
+     * @returns {string} The resolved theme value.
+     */
+    _resolveThemeValue(theme, computedSiteTheme) {
+        switch (theme) {
+            case 'auto': return computedSiteTheme;
+            case 'browser': return this._browserTheme;
+            default: return theme;
+        }
+    }
+
+    /**
+     * Adds the value of a CSS color to an accumulation target.
+     * @param {[number, number, number]} target The target color buffer to accumulate into.
+     * @param {string|*} cssColor The CSS color value to add to the target. If this value is not a string,
+     *   the target will not be modified.
+     */
+    _addColor(target, cssColor) {
+        if (typeof cssColor !== 'string') { return; }
+
+        const color = this._getColorInfo(cssColor);
+        if (color === null) { return; }
+
+        const a = color[3];
+        if (a <= 0.0) { return; }
+
+        const aInv = 1.0 - a;
+        for (let i = 0; i < 3; ++i) {
+            target[i] = target[i] * aInv + color[i] * a;
+        }
+    }
+
+    /**
+     * Decomposes a CSS color string into its RGBA values.
+     * @param {string} cssColor The color value to decompose. This value is expected to be in the form RGB(r, g, b) or RGBA(r, g, b, a).
+     * @returns {?[number, number, number, number]} The color and alpha values. The color component values range from [0, 255], and the alpha ranges from [0, 1].
+     */
+    _getColorInfo(cssColor) {
+        const m = /^\s*rgba?\s*\(\s*(\d+)\s*,\s*(\d+)\s*,\s*(\d+)\s*(?:,\s*([\d.]+)\s*)?\)\s*$/.exec(cssColor);
+        if (m === null) { return null; }
+
+        const m4 = m[4];
+        return [
+            Number.parseInt(m[1], 10),
+            Number.parseInt(m[2], 10),
+            Number.parseInt(m[3], 10),
+            m4 ? Math.max(0.0, Math.min(1.0, Number.parseFloat(m4))) : 1.0
+        ];
+    }
+}

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -166,16 +166,10 @@ class ThemeController {
      */
     _resolveThemeValue(theme, computedSiteTheme) {
         switch (theme) {
-            case 'auto':
-                theme = computedSiteTheme;
-                break;
-            case 'browser':
-                theme = this._browserTheme;
-                break;
-            default:
-                return theme;
+            case 'auto': return computedSiteTheme;
+            case 'browser': return this._browserTheme;
+            default: return theme;
         }
-        return (theme === 'light' ? 'default' : theme);
     }
 
     /**

--- a/ext/js/app/theme-controller.js
+++ b/ext/js/app/theme-controller.js
@@ -166,10 +166,16 @@ class ThemeController {
      */
     _resolveThemeValue(theme, computedSiteTheme) {
         switch (theme) {
-            case 'auto': return computedSiteTheme;
-            case 'browser': return this._browserTheme;
-            default: return theme;
+            case 'auto':
+                theme = computedSiteTheme;
+                break;
+            case 'browser':
+                theme = this._browserTheme;
+                break;
+            default:
+                return theme;
         }
+        return (theme === 'light' ? 'default' : theme);
     }
 
     /**

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -466,7 +466,8 @@ class OptionsUtil {
             {async: false, update: this._updateVersion14.bind(this)},
             {async: false, update: this._updateVersion15.bind(this)},
             {async: false, update: this._updateVersion16.bind(this)},
-            {async: false, update: this._updateVersion17.bind(this)}
+            {async: false, update: this._updateVersion17.bind(this)},
+            {async: false, update: this._updateVersion18.bind(this)}
         ];
         if (typeof targetVersion === 'number' && targetVersion < result.length) {
             result.splice(targetVersion);
@@ -920,6 +921,24 @@ class OptionsUtil {
                     includeCharacterAtStart: false,
                     includeCharacterAtEnd: true
                 });
+            }
+        }
+        return options;
+    }
+
+    _updateVersion18(options) {
+        // Version 18 changes:
+        //  general.popupTheme's 'default' value changed to 'light'
+        //  general.popupOuterTheme's 'default' value changed to 'light'
+        //  general.popupOuterTheme's 'auto' value changed to 'site'
+        for (const profile of options.profiles) {
+            const {general} = profile.options;
+            if (general.popupTheme === 'default') {
+                general.popupTheme = 'light';
+            }
+            switch (general.popupOuterTheme) {
+                case 'default': general.popupOuterTheme = 'light'; break;
+                case 'auto': general.popupOuterTheme = 'site'; break;
             }
         }
         return options;

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -117,6 +117,7 @@ class Display extends EventDispatcher {
 
         this._popupTheme = 'default';
         this._popupOuterTheme = 'default';
+        this._browserTheme = 'light';
 
         this._hotkeyHandler.registerActions([
             ['close',             () => { this._onHotkeyClose(); }],
@@ -213,6 +214,11 @@ class Display extends EventDispatcher {
     }
 
     async prepare() {
+        // Theme
+        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
+        mediaQueryList.addEventListener('change', this._onPrefersColorSchemeDarkChange.bind(this));
+        this._onPrefersColorSchemeDarkChange(mediaQueryList);
+
         // State setup
         const {documentElement} = document;
         const {browser} = await yomichan.api.getEnvironmentInfo();
@@ -797,6 +803,11 @@ class Display extends EventDispatcher {
         }
     }
 
+    _onPrefersColorSchemeDarkChange({matches}) {
+        this._browserTheme = (matches ? 'dark' : 'light');
+        this._updateTheme();
+    }
+
     _showTagNotification(tagNode) {
         tagNode = tagNode.parentNode;
         if (tagNode === null) { return; }
@@ -854,6 +865,7 @@ class Display extends EventDispatcher {
         const data = document.documentElement.dataset;
         data.theme = this._popupTheme;
         data.outerTheme = this._popupOuterTheme;
+        data.browserTheme = this._browserTheme;
     }
 
     async _findDictionaryEntries(isKanji, source, wildcardsEnabled, optionsContext) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -31,6 +31,7 @@
  * QueryParser
  * ScrollElement
  * TextScanner
+ * ThemeController
  * dynamicLoader
  */
 
@@ -114,10 +115,7 @@ class Display extends EventDispatcher {
         this._onTagClickBind = this._onTagClick.bind(this);
         this._onMenuButtonClickBind = this._onMenuButtonClick.bind(this);
         this._onMenuButtonMenuCloseBind = this._onMenuButtonMenuClose.bind(this);
-
-        this._popupTheme = 'default';
-        this._popupOuterTheme = 'default';
-        this._browserTheme = 'light';
+        this._themeController = new ThemeController(document.documentElement);
 
         this._hotkeyHandler.registerActions([
             ['close',             () => { this._onHotkeyClose(); }],
@@ -215,9 +213,7 @@ class Display extends EventDispatcher {
 
     async prepare() {
         // Theme
-        const mediaQueryList = window.matchMedia('(prefers-color-scheme: dark)');
-        mediaQueryList.addEventListener('change', this._onPrefersColorSchemeDarkChange.bind(this));
-        this._onPrefersColorSchemeDarkChange(mediaQueryList);
+        this._themeController.prepare();
 
         // State setup
         const {documentElement} = document;
@@ -803,11 +799,6 @@ class Display extends EventDispatcher {
         }
     }
 
-    _onPrefersColorSchemeDarkChange({matches}) {
-        this._browserTheme = (matches ? 'dark' : 'light');
-        this._updateTheme();
-    }
-
     _showTagNotification(tagNode) {
         tagNode = tagNode.parentNode;
         if (tagNode === null) { return; }
@@ -851,21 +842,13 @@ class Display extends EventDispatcher {
     }
 
     _setTheme(options) {
-        let customPopupCss;
-        ({
-            popupTheme: this._popupTheme,
-            popupOuterTheme: this._popupOuterTheme,
-            customPopupCss
-        } = options.general);
-        this._updateTheme();
-        this.setCustomCss(customPopupCss);
-    }
-
-    _updateTheme() {
-        const data = document.documentElement.dataset;
-        data.theme = this._popupTheme;
-        data.outerTheme = this._popupOuterTheme;
-        data.browserTheme = this._browserTheme;
+        const {general} = options;
+        const {popupTheme} = general;
+        this._themeController.theme = popupTheme;
+        this._themeController.outerTheme = general.popupOuterTheme;
+        this._themeController.siteTheme = popupTheme;
+        this._themeController.updateTheme();
+        this.setCustomCss(general.customPopupCss);
     }
 
     async _findDictionaryEntries(isKanji, source, wildcardsEnabled, optionsContext) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -115,6 +115,9 @@ class Display extends EventDispatcher {
         this._onMenuButtonClickBind = this._onMenuButtonClick.bind(this);
         this._onMenuButtonMenuCloseBind = this._onMenuButtonMenuClose.bind(this);
 
+        this._popupTheme = 'default';
+        this._popupOuterTheme = 'default';
+
         this._hotkeyHandler.registerActions([
             ['close',             () => { this._onHotkeyClose(); }],
             ['nextEntry',         this._onHotkeyActionMoveRelative.bind(this, 1)],
@@ -302,8 +305,7 @@ class Display extends EventDispatcher {
 
         this._updateHotkeys(options);
         this._updateDocumentOptions(options);
-        this._updateTheme(options.general.popupTheme);
-        this.setCustomCss(options.general.customPopupCss);
+        this._setTheme(options);
         this._hotkeyHelpController.setOptions(options);
         this._displayGenerator.updateHotkeys();
         this._hotkeyHelpController.setupNode(document.documentElement);
@@ -837,8 +839,21 @@ class Display extends EventDispatcher {
         data.popupActionBarLocation = `${options.general.popupActionBarLocation}`;
     }
 
-    _updateTheme(themeName) {
-        document.documentElement.dataset.theme = themeName;
+    _setTheme(options) {
+        let customPopupCss;
+        ({
+            popupTheme: this._popupTheme,
+            popupOuterTheme: this._popupOuterTheme,
+            customPopupCss
+        } = options.general);
+        this._updateTheme();
+        this.setCustomCss(customPopupCss);
+    }
+
+    _updateTheme() {
+        const data = document.documentElement.dataset;
+        data.theme = this._popupTheme;
+        data.outerTheme = this._popupOuterTheme;
     }
 
     async _findDictionaryEntries(isKanji, source, wildcardsEnabled, optionsContext) {

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -213,6 +213,7 @@ class Display extends EventDispatcher {
 
     async prepare() {
         // Theme
+        this._themeController.siteTheme = 'light';
         this._themeController.prepare();
 
         // State setup
@@ -846,7 +847,6 @@ class Display extends EventDispatcher {
         const {popupTheme} = general;
         this._themeController.theme = popupTheme;
         this._themeController.outerTheme = general.popupOuterTheme;
-        this._themeController.siteTheme = popupTheme;
         this._themeController.updateTheme();
         this.setCustomCss(general.customPopupCss);
     }

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -48,6 +48,7 @@
                 "js/app/popup-factory.js",
                 "js/app/popup-proxy.js",
                 "js/app/popup-window.js",
+                "js/app/theme-controller.js",
                 "js/comm/api.js",
                 "js/comm/cross-frame-api.js",
                 "js/comm/frame-ancestry-handler.js",

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -44,6 +44,7 @@
 <script src="/js/app/frontend.js"></script>
 <script src="/js/app/popup.js"></script>
 <script src="/js/app/popup-factory.js"></script>
+<script src="/js/app/theme-controller.js"></script>
 <script src="/js/comm/api.js"></script>
 <script src="/js/comm/cross-frame-api.js"></script>
 <script src="/js/comm/frame-ancestry-handler.js"></script>

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -97,6 +97,7 @@
 
 <script src="/js/yomichan.js"></script>
 
+<script src="/js/app/theme-controller.js"></script>
 <script src="/js/comm/api.js"></script>
 <script src="/js/comm/cross-frame-api.js"></script>
 <script src="/js/comm/frame-endpoint.js"></script>

--- a/ext/search.html
+++ b/ext/search.html
@@ -84,6 +84,7 @@
 
 <script src="/js/yomichan.js"></script>
 
+<script src="/js/app/theme-controller.js"></script>
 <script src="/js/comm/api.js"></script>
 <script src="/js/comm/clipboard-monitor.js"></script>
 <script src="/js/comm/cross-frame-api.js"></script>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -666,6 +666,7 @@
                         <select data-setting="general.popupTheme" class="short-width short-height">
                             <option value="default">Light</option>
                             <option value="dark">Dark</option>
+                            <option value="browser">Browser</option>
                         </select>
                     </div>
                     <div class="settings-item-group-item">
@@ -674,6 +675,7 @@
                             <option value="auto">Auto</option>
                             <option value="default">Light</option>
                             <option value="dark">Dark</option>
+                            <option value="browser">Browser</option>
                         </select>
                     </div>
                 </div>

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -664,7 +664,7 @@
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Body</div>
                         <select data-setting="general.popupTheme" class="short-width short-height">
-                            <option value="default">Light</option>
+                            <option value="light">Light</option>
                             <option value="dark">Dark</option>
                             <option value="browser">Browser</option>
                         </select>
@@ -672,8 +672,8 @@
                     <div class="settings-item-group-item">
                         <div class="settings-item-group-item-label">Shadow</div>
                         <select data-setting="general.popupOuterTheme" class="short-width short-height">
-                            <option value="auto">Auto</option>
-                            <option value="default">Light</option>
+                            <option value="site">Auto</option>
+                            <option value="light">Light</option>
                             <option value="dark">Dark</option>
                             <option value="browser">Browser</option>
                         </select>

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -286,8 +286,8 @@ function createProfileOptionsUpdatedTestData1() {
             compactTags: false,
             glossaryLayoutMode: 'default',
             mainDictionary: '',
-            popupTheme: 'default',
-            popupOuterTheme: 'default',
+            popupTheme: 'light',
+            popupOuterTheme: 'light',
             customPopupCss: '',
             customPopupOuterCss: '',
             enableWanakana: true,
@@ -600,7 +600,7 @@ function createOptionsUpdatedTestData1() {
             }
         ],
         profileCurrent: 0,
-        version: 17,
+        version: 18,
         global: {
             database: {
                 prefixWildcardsSupported: false


### PR DESCRIPTION
This change adds support for using the browser/OS's preferred color theme for the theme of the Yomichan popups. It also includes some internal cleanup to how the styles are handled, for simplification purposes.

Resolves #2066.