### PR TITLE
Add a warning about the future of the Google docs workaround

### DIFF
--- a/ext/settings.html
+++ b/ext/settings.html
@@ -1947,7 +1947,7 @@
                 <div class="settings-item-left">
                     <div class="settings-item-label">
                         Force HTML-based rendering for Google Docs
-                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">(?)</a>
+                        <a tabindex="0" class="more-toggle more-only danger-text" data-parent-distance="4">(?)</a>
                     </div>
                 </div>
                 <div class="settings-item-right">
@@ -1961,6 +1961,9 @@
                     rendering to display content<sup><a href="https://workspaceupdates.googleblog.com/2021/05/Google-Docs-Canvas-Based-Rendering-Update.html" target="_blank" rel="noopener noreferrer">[2]</a></sup>,
                     which prevents Yomichan from being able to scan text.
                     Enabling this option will force HTML-based rendering to be used.
+                </p>
+                <p class="danger-text">
+                    This is a workaround and it is likely that Google will unfortunately remove support for this workaround in the future.
                 </p>
                 <p>
                     <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>


### PR DESCRIPTION
Adds warning text "_This is a workaround and it is likely that Google will unfortunately remove support for this workaround in the future._"