### PR TITLE
Add new structured content features: lists and the HTML `lang` attribute

### DIFF
--- a/dev/data/structured-content-overrides.css
+++ b/dev/data/structured-content-overrides.css
@@ -61,3 +61,16 @@
     display: none;
     /* remove-property background-color vertical-align width height margin-left background-color position */
 }
+.gloss-sc-ol,
+.gloss-sc-ul {
+    /* remove-property padding-left */
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] {
+    /* remove-rule */
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] .gloss-sc-li {
+    /* remove-rule */
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] .gloss-sc-li:not(:first-child)::before {
+    /* remove-rule */
+}

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -235,3 +235,23 @@
     padding: 0.25em;
     vertical-align: top;
 }
+.gloss-sc-ol {
+    padding-left: var(--list-padding2);
+}
+.gloss-sc-ul {
+    padding-left: var(--list-padding2);
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] {
+    display: inline;
+    list-style: none;
+    padding-left: 0;
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] .gloss-sc-li {
+    display: inline;
+}
+:root[data-glossary-layout-mode=compact] .gloss-sc-ul[data-sc-content=glossary] .gloss-sc-li:not(:first-child)::before {
+    white-space: pre-wrap;
+    content: var(--compact-list-separator);
+    display: inline;
+    color: var(--text-color-light3);
+}

--- a/ext/css/structured-content.css
+++ b/ext/css/structured-content.css
@@ -235,9 +235,7 @@
     padding: 0.25em;
     vertical-align: top;
 }
-.gloss-sc-ol {
-    padding-left: var(--list-padding2);
-}
+.gloss-sc-ol,
 .gloss-sc-ul {
     padding-left: var(--list-padding2);
 }

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -95,7 +95,7 @@
                             "properties": {
                                 "tag": {
                                     "type": "string",
-                                    "enum": ["span", "div"]
+                                    "enum": ["span", "div", "ol", "ul", "li"]
                                 },
                                 "content": {
                                     "$ref": "#/definitions/structuredContent"
@@ -276,6 +276,10 @@
                 "marginBottom": {
                     "type": "number",
                     "default": 0
+                },
+                "listStyleType": {
+                    "type": "string",
+                    "default": "disc"
                 }
             }
         }

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -54,7 +54,7 @@
                                 },
                                 "lang": {
                                     "type": "string",
-                                    "description": "Defines the language of an element in the format defined by RFC 5646"
+                                    "description": "Defines the language of an element in the format defined by RFC 5646."
                                 }
                             }
                         },
@@ -89,7 +89,7 @@
                                 },
                                 "lang": {
                                     "type": "string",
-                                    "description": "Defines the language of an element in the format defined by RFC 5646"
+                                    "description": "Defines the language of an element in the format defined by RFC 5646."
                                 }
                             }
                         },
@@ -116,7 +116,7 @@
                                 },
                                 "lang": {
                                     "type": "string",
-                                    "description": "Defines the language of an element in the format defined by RFC 5646"
+                                    "description": "Defines the language of an element in the format defined by RFC 5646."
                                 }
                             }
                         },
@@ -221,7 +221,7 @@
                                 },
                                 "lang": {
                                     "type": "string",
-                                    "description": "Defines the language of an element in the format defined by RFC 5646"
+                                    "description": "Defines the language of an element in the format defined by RFC 5646."
                                 }
                             }
                         }

--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -51,6 +51,10 @@
                                 },
                                 "data": {
                                     "$ref": "#/definitions/structuredContentData"
+                                },
+                                "lang": {
+                                    "type": "string",
+                                    "description": "Defines the language of an element in the format defined by RFC 5646"
                                 }
                             }
                         },
@@ -82,6 +86,10 @@
                                 },
                                 "style": {
                                     "$ref": "#/definitions/structuredContentStyle"
+                                },
+                                "lang": {
+                                    "type": "string",
+                                    "description": "Defines the language of an element in the format defined by RFC 5646"
                                 }
                             }
                         },
@@ -105,6 +113,10 @@
                                 },
                                 "style": {
                                     "$ref": "#/definitions/structuredContentStyle"
+                                },
+                                "lang": {
+                                    "type": "string",
+                                    "description": "Defines the language of an element in the format defined by RFC 5646"
                                 }
                             }
                         },
@@ -206,6 +218,10 @@
                                     "type": "string",
                                     "description": "The URL for the link. URLs starting with a ? are treated as internal links to other dictionary content.",
                                     "pattern": "^(?:https?:|\\?)[\\w\\W]*"
+                                },
+                                "lang": {
+                                    "type": "string",
+                                    "description": "Defines the language of an element in the format defined by RFC 5646"
                                 }
                             }
                         }

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -56,6 +56,9 @@ class StructuredContentGenerator {
                 return this._createStructuredContentElement(tag, content, dictionary, 'table-cell', true, true);
             case 'div':
             case 'span':
+            case 'ol':
+            case 'ul':
+            case 'li':
                 return this._createStructuredContentElement(tag, content, dictionary, 'simple', true, true);
             case 'img':
                 return this.createDefinitionImage(content, dictionary);
@@ -239,7 +242,8 @@ class StructuredContentGenerator {
             marginTop,
             marginLeft,
             marginRight,
-            marginBottom
+            marginBottom,
+            listStyleType
         } = contentStyle;
         if (typeof fontStyle === 'string') { style.fontStyle = fontStyle; }
         if (typeof fontWeight === 'string') { style.fontWeight = fontWeight; }
@@ -254,6 +258,7 @@ class StructuredContentGenerator {
         if (typeof marginLeft === 'number') { style.marginLeft = `${marginLeft}em`; }
         if (typeof marginRight === 'number') { style.marginRight = `${marginRight}em`; }
         if (typeof marginBottom === 'number') { style.marginBottom = `${marginBottom}em`; }
+        if (typeof listStyleType === 'string') { style.listStyleType = listStyleType; }
     }
 
     _createLinkElement(content, dictionary) {

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -207,8 +207,9 @@ class StructuredContentGenerator {
 
     _createStructuredContentElement(tag, content, dictionary, type, hasChildren, hasStyle) {
         const node = this._createElement(tag, `gloss-sc-${tag}`);
-        const {data} = content;
+        const {data, lang} = content;
         if (typeof data === 'object' && data !== null) { this._setElementDataset(node, data); }
+        if (typeof lang === 'string') { node.lang = lang; }
         switch (type) {
             case 'table-cell':
                 {
@@ -273,6 +274,9 @@ class StructuredContentGenerator {
 
         const text = this._createElement('span', 'gloss-link-text');
         node.appendChild(text);
+
+        const {lang} = content;
+        if (typeof lang === 'string') { node.lang = lang; }
 
         const child = this.createStructuredContent(content.content, dictionary);
         if (child !== null) { text.appendChild(child); }

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -241,6 +241,68 @@
                     {"tag": "li", "style": {"listStyleType": "'③'"}, "content": "まるさん"},
                     {"tag": "li", "style": {"listStyleType": "'④'"}, "content": "まるよん"}
                 ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "div", "lang": "?????", "style": {"fontSize": "xxx-large"}, "content": "直次茶冷 (invalid lang)"},
+                {"tag": "div", "lang": "ja-JP", "style": {"fontSize": "xxx-large"}, "content": "直次茶冷 (lang=ja-JP)"},
+                {"tag": "div", "lang": "zh-CN", "style": {"fontSize": "xxx-large"}, "content": "直次茶冷 (lang=zh-CN)"},
+                {"tag": "div", "lang": "zh-TW", "style": {"fontSize": "xxx-large"}, "content": "直次茶冷 (lang=zh-TW)"}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ul", "style": {"listStyleType": "japanese-formal"}, "content": [
+                    {"tag": "li", "content": ["【", {"tag": "a", "href": "?query=直次茶冷&wildcards=off", "content": "直次茶冷"}, "】(default)"]},
+                    {"tag": "li", "content": ["【", {"tag": "a", "href": "?query=直次茶冷&wildcards=off", "content": "直次茶冷", "lang": "ja"}, "】(lang=ja)"]},
+                    {"tag": "li", "content": ["【", {"tag": "a", "href": "?query=直次茶冷&wildcards=off", "content": "直次茶冷", "lang": "zh-CN"}, "】(lang=zh-CN)"]},
+                    {"tag": "li", "content": ["【", {"tag": "a", "href": "?query=直次茶冷&wildcards=off", "content": "直次茶冷", "lang": "zh-TW"}, "】(lang=zh-TW)"]}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "table", "lang": "", "content": [
+                    {"tag": "thead", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "th", "content": "JP"},
+                            {"tag": "th", "content": "SC"},
+                            {"tag": "th", "content": "TC"},
+                            {"tag": "th", "content": "??"}
+                        ]}
+                    ]},
+                    {"tag": "tbody", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "lang": "ja-JP", "content": "直次茶冷"},
+                            {"tag": "td", "lang": "zh-CN", "content": "直次茶冷"},
+                            {"tag": "td", "lang": "zh-TW", "content": "直次茶冷"},
+                            {"tag": "td", "content": "直次茶冷"}
+                        ]}
+                    ]}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "table", "lang": "ja", "content": [
+                    {"tag": "thead", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "th", "content": "lang=ja applied to whole table"}
+                        ]}
+                    ]},
+                    {"tag": "tbody", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "content": "直次茶冷"}
+                        ]}
+                    ]}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "table", "lang": "zh-CN", "content": [
+                    {"tag": "thead", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "th", "content": "lang=zh-CN applied to whole table"}
+                        ]}
+                    ]},
+                    {"tag": "tbody", "content": [
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "content": "直次茶冷"}
+                        ]}
+                    ]}
+                ]}
             ]}
         ],
         100, "P E1"

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -204,6 +204,43 @@
                         "external link"
                     ]
                 }
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ul", "content": [
+                    {"tag": "li", "content": "Unordered list item 1"},
+                    {"tag": "li", "content": "Unordered list item 2"},
+                    {"tag": "li", "content": "Unordered list item 3"}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ol", "content": [
+                    {"tag": "li", "content": "Ordered list item 1"},
+                    {"tag": "li", "content": "Ordered list item 2"},
+                    {"tag": "li", "content": "Ordered list item 3"}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ol", "style": {"listStyleType": "hiragana-iroha"}, "content": [
+                    {"tag": "li", "content": "List item i"},
+                    {"tag": "li", "content": "List item ro"},
+                    {"tag": "li", "content": "List item ha"}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ul", "content": [
+                    {"tag": "li", "style": {"listStyleType": "'⇄'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["Antonym"]}, "】"]},
+                    {"tag": "li", "style": {"listStyleType": "'🔄'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["References and is referenced by"]}, "】"]},
+                    {"tag": "li", "style": {"listStyleType": "'➡'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["References"]}, "】"]},
+                    {"tag": "li", "style": {"listStyleType": "'⬅'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["Referenced by"]}, "】"]}
+                ]}
+            ]},
+            {"type": "structured-content", "content": [
+                {"tag": "ol", "content": [
+                    {"tag": "li", "style": {"listStyleType": "'①'"}, "content": "まるいち"},
+                    {"tag": "li", "style": {"listStyleType": "'②'"}, "content": "まるに"},
+                    {"tag": "li", "style": {"listStyleType": "'③'"}, "content": "まるさん"},
+                    {"tag": "li", "style": {"listStyleType": "'④'"}, "content": "まるよん"}
+                ]}
             ]}
         ],
         100, "P E1"


### PR DESCRIPTION
## Structured Content `lang` Attribute 

Authors of dictionaries for Yomichan may want to include content from various languages, so I think this is a valuable feature. JMDict, for example, includes Japanese loanword source-words from over 60 different languages.

<details>
  <summary>Characters 直次茶冷 displayed in structured content glosses</summary>

⚠The current version of Yomichan seems to apply `lang="ja"` attributes to standard glosses which contain Japanese characters, but not to structured content glosses. By default, most browsers will render the characters "直次茶冷" in simplified Chinese. 
![html_lang](https://user-images.githubusercontent.com/8003332/168375044-69692794-951e-4cbc-9b31-bd8eed415f19.png)
</details>

## Structured Content Lists
The current way in which I have inserted supplemental information into JMdict glossaries (see: https://github.com/FooSoft/yomichan/issues/1165) is a little awkward. When the "compact glossaries" option is enabled, all of the information is grouped and compacted together. It will be easier for the user to parse the information if the different types of information are broken into separate sections. My idea is to break them up into separate unordered lists, each with its own `list-style-type`.

<details>
  <summary>読む</summary>

![yomu](https://user-images.githubusercontent.com/8003332/168377455-941f3f40-4c6c-48b7-87aa-4fb1774f073d.png)
</details>

<details>
  <summary>読む (compact glossaries)</summary>

![yomu](https://user-images.githubusercontent.com/8003332/168377789-2c0c3f1a-e432-4b6c-b18e-45cc8eb674ed.png)
</details>

<details>
  <summary>元 ("compact glossaries" and "group related terms" mode)</summary>

![moto](https://user-images.githubusercontent.com/8003332/168377935-d712c34e-9208-45e1-94bf-2bd03dcb93aa.png)
</details>

<details>
  <summary>アルバイト</summary>

![arubaito](https://user-images.githubusercontent.com/8003332/168378136-17ec7fae-557f-4a86-b24b-2de80b2a184a.png)
</details>

<details>
  <summary>欠席</summary>

![kesseki](https://user-images.githubusercontent.com/8003332/168378217-addd6cde-2064-48fb-b637-45ceab854458.png)
</details>

<details>
  <summary>ちりも積もれば山となる</summary>

![chiri](https://user-images.githubusercontent.com/8003332/168378423-0ae8d8a0-eec2-46a8-b2b3-2a333c9d1567.png)
</details>

I've included tests for these new structured content features in the file `test/data/dictionaries/valid-dictionary1/term_bank_1.json`.

Additionally, here is a new version of JMdict for Yomichan which uses the new features.
[jmdict_english_info_glosses_2022_05_13.zip](https://github.com/FooSoft/yomichan/files/8690986/jmdict_english_info_glosses_2022_05_13.zip)

This version takes over 30 minutes to validate during the import process, so it is probably not viable for distribution unless Yomichan's validation procedure is optimized. Glosses that do not contain supplemental information are not inserted into structured content containers (they are formatted identically to the current production version of the dictionary), so I don't think there are any additional optimizations I can make to the dictionary without cutting content.

Here is a version of the new JMdict dictionary that does not contain external reference notes (i.e. notes that indicate when an entry is referenced by another entry). On my PC it takes about 10 minutes to validate.
[jmdict_english_info_glosses_no_ext_xrefs_2022_05_13.zip](https://github.com/FooSoft/yomichan/files/8691017/jmdict_english_info_glosses_no_ext_xrefs_2022_05_13.zip)

I'm open to suggestions on how to improve the appearance of the new JMdict dictionary. I still need to clean up the code in my branch of yomichan-import a bit, but I think I'm out of ideas for additional features to add.