### PR TITLE
Popup positioning improvements

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -565,7 +565,7 @@ class Frontend {
             textSource = this._textScanner.getCurrentTextSource();
             if (textSource === null) { return; }
         }
-        this._showPopupContent(textSource, null);
+        this._showPopupContent(textSource, null, null);
     }
 
     _showContent(textSource, focus, dictionaryEntries, type, sentence, documentTitle, optionsContext) {
@@ -601,7 +601,7 @@ class Frontend {
         this._showPopupContent(textSource, optionsContext, details);
     }
 
-    _showPopupContent(textSource, optionsContext, details=null) {
+    _showPopupContent(textSource, optionsContext, details) {
         const {left, top, width, height} = textSource.getRect();
         this._lastShowPromise = (
             this._popup !== null ?
@@ -661,7 +661,7 @@ class Frontend {
             this._popup !== null &&
             await this._popup.isVisible()
         ) {
-            this._showPopupContent(textSource, null);
+            this._showPopupContent(textSource, null, null);
         }
     }
 

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -603,8 +603,8 @@ class Frontend {
 
     _showPopupContent(textSource, optionsContext, details) {
         const sourceRects = [];
-        for (const {left, top, width, height} of textSource.getRects()) {
-            sourceRects.push({left, top, width, height});
+        for (const {left, top, right, bottom} of textSource.getRects()) {
+            sourceRects.push({left, top, right, bottom});
         }
         this._lastShowPromise = (
             this._popup !== null ?

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -608,7 +608,7 @@ class Frontend {
             this._popup.showContent(
                 {
                     optionsContext,
-                    elementRect: {x: left, y: top, width, height, valid: true},
+                    sourceRect: {x: left, y: top, width, height, valid: true},
                     writingMode: textSource.getWritingMode()
                 },
                 details

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -608,7 +608,7 @@ class Frontend {
             this._popup.showContent(
                 {
                     optionsContext,
-                    sourceRect: {x: left, y: top, width, height},
+                    sourceRect: {left, top, width, height},
                     writingMode: textSource.getWritingMode()
                 },
                 details

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -602,13 +602,16 @@ class Frontend {
     }
 
     _showPopupContent(textSource, optionsContext, details) {
-        const {left, top, width, height} = textSource.getRect();
+        const sourceRects = [];
+        for (const {left, top, width, height} of textSource.getRects()) {
+            sourceRects.push({left, top, width, height});
+        }
         this._lastShowPromise = (
             this._popup !== null ?
             this._popup.showContent(
                 {
                     optionsContext,
-                    sourceRect: {left, top, width, height},
+                    sourceRects,
                     writingMode: textSource.getWritingMode()
                 },
                 details

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -608,7 +608,7 @@ class Frontend {
             this._popup.showContent(
                 {
                     optionsContext,
-                    sourceRect: {x: left, y: top, width, height, valid: true},
+                    sourceRect: {x: left, y: top, width, height},
                     writingMode: textSource.getWritingMode()
                 },
                 details

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -265,6 +265,8 @@ class PopupFactory {
         for (const sourceRect of sourceRects) {
             sourceRect.left += offset.x;
             sourceRect.top += offset.y;
+            sourceRect.right += offset.x;
+            sourceRect.bottom += offset.y;
         }
 
         return await popup.showContent(details, displayDetails);

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -258,8 +258,10 @@ class PopupFactory {
         const popup = this._getPopup(id);
         if (!this._popupCanShow(popup)) { return; }
 
-        const {sourceRect} = details;
-        [sourceRect.left, sourceRect.top] = this._convertPopupPointToRootPagePoint(popup, sourceRect.left, sourceRect.top);
+        const {sourceRects} = details;
+        for (const sourceRect of sourceRects) {
+            [sourceRect.left, sourceRect.top] = this._convertPopupPointToRootPagePoint(popup, sourceRect.left, sourceRect.top);
+        }
 
         return await popup.showContent(details, displayDetails);
     }

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -259,9 +259,7 @@ class PopupFactory {
         if (!this._popupCanShow(popup)) { return; }
 
         const {sourceRect} = details;
-        if (typeof sourceRect !== 'undefined') {
-            [sourceRect.x, sourceRect.y] = this._convertPopupPointToRootPagePoint(popup, sourceRect.x, sourceRect.y);
-        }
+        [sourceRect.x, sourceRect.y] = this._convertPopupPointToRootPagePoint(popup, sourceRect.x, sourceRect.y);
 
         return await popup.showContent(details, displayDetails);
     }

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -258,9 +258,9 @@ class PopupFactory {
         const popup = this._getPopup(id);
         if (!this._popupCanShow(popup)) { return; }
 
-        const {elementRect} = details;
-        if (typeof elementRect !== 'undefined') {
-            [elementRect.x, elementRect.y] = this._convertPopupPointToRootPagePoint(popup, elementRect.x, elementRect.y);
+        const {sourceRect} = details;
+        if (typeof sourceRect !== 'undefined') {
+            [sourceRect.x, sourceRect.y] = this._convertPopupPointToRootPagePoint(popup, sourceRect.x, sourceRect.y);
         }
 
         return await popup.showContent(details, displayDetails);

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -259,7 +259,7 @@ class PopupFactory {
         if (!this._popupCanShow(popup)) { return; }
 
         const {sourceRect} = details;
-        [sourceRect.x, sourceRect.y] = this._convertPopupPointToRootPagePoint(popup, sourceRect.x, sourceRect.y);
+        [sourceRect.left, sourceRect.top] = this._convertPopupPointToRootPagePoint(popup, sourceRect.left, sourceRect.top);
 
         return await popup.showContent(details, displayDetails);
     }

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -250,7 +250,9 @@ class PopupFactory {
 
     async _onApiContainsPoint({id, x, y}) {
         const popup = this._getPopup(id);
-        [x, y] = this._convertPopupPointToRootPagePoint(popup, x, y);
+        const offset = this._getPopupOffset(popup);
+        x += offset.x;
+        y += offset.y;
         return await popup.containsPoint(x, y);
     }
 
@@ -258,9 +260,11 @@ class PopupFactory {
         const popup = this._getPopup(id);
         if (!this._popupCanShow(popup)) { return; }
 
+        const offset = this._getPopupOffset(popup);
         const {sourceRects} = details;
         for (const sourceRect of sourceRects) {
-            [sourceRect.left, sourceRect.top] = this._convertPopupPointToRootPagePoint(popup, sourceRect.left, sourceRect.top);
+            sourceRect.left += offset.x;
+            sourceRect.top += offset.y;
         }
 
         return await popup.showContent(details, displayDetails);
@@ -311,16 +315,15 @@ class PopupFactory {
         return popup;
     }
 
-    _convertPopupPointToRootPagePoint(popup, x, y) {
+    _getPopupOffset(popup) {
         const {parent} = popup;
         if (parent !== null) {
             const popupRect = parent.getFrameRect();
             if (popupRect.valid) {
-                x += popupRect.left;
-                y += popupRect.top;
+                return {x: popupRect.left, y: popupRect.top};
             }
         }
-        return [x, y];
+        return {x: 0, y: 0};
     }
 
     _popupCanShow(popup) {

--- a/ext/js/app/popup-factory.js
+++ b/ext/js/app/popup-factory.js
@@ -314,8 +314,8 @@ class PopupFactory {
         if (parent !== null) {
             const popupRect = parent.getFrameRect();
             if (popupRect.valid) {
-                x += popupRect.x;
-                y += popupRect.y;
+                x += popupRect.left;
+                y += popupRect.top;
             }
         }
         return [x, y];

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -198,6 +198,8 @@ class PopupProxy extends EventDispatcher {
             for (const sourceRect of sourceRects) {
                 sourceRect.left += this._frameOffsetX;
                 sourceRect.top += this._frameOffsetY;
+                sourceRect.right += this._frameOffsetX;
+                sourceRect.bottom += this._frameOffsetY;
             }
         }
         return await this._invokeSafe('PopupFactory.showContent', {id: this._id, details, displayDetails});

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -179,7 +179,8 @@ class PopupProxy extends EventDispatcher {
     async containsPoint(x, y) {
         if (this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
-            [x, y] = this._applyFrameOffset(x, y);
+            x += this._frameOffsetX;
+            y += this._frameOffsetY;
         }
         return await this._invokeSafe('PopupFactory.containsPoint', {id: this._id, x, y}, false);
     }
@@ -195,7 +196,8 @@ class PopupProxy extends EventDispatcher {
             const {sourceRects} = details;
             await this._updateFrameOffset();
             for (const sourceRect of sourceRects) {
-                [sourceRect.left, sourceRect.top] = this._applyFrameOffset(sourceRect.left, sourceRect.top);
+                sourceRect.left += this._frameOffsetX;
+                sourceRect.top += this._frameOffsetY;
             }
         }
         return await this._invokeSafe('PopupFactory.showContent', {id: this._id, details, displayDetails});
@@ -335,9 +337,5 @@ class PopupProxy extends EventDispatcher {
         } finally {
             this._frameOffsetPromise = null;
         }
-    }
-
-    _applyFrameOffset(x, y) {
-        return [x + this._frameOffsetX, y + this._frameOffsetY];
     }
 }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -191,9 +191,11 @@ class PopupProxy extends EventDispatcher {
      */
     async showContent(details, displayDetails) {
         if (this._frameOffsetForwarder !== null) {
-            const {sourceRect} = details;
+            const {sourceRects} = details;
             await this._updateFrameOffset();
-            [sourceRect.left, sourceRect.top] = this._applyFrameOffset(sourceRect.left, sourceRect.top);
+            for (const sourceRect of sourceRects) {
+                [sourceRect.left, sourceRect.top] = this._applyFrameOffset(sourceRect.left, sourceRect.top);
+            }
         }
         return await this._invokeSafe('PopupFactory.showContent', {id: this._id, details, displayDetails});
     }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -40,7 +40,8 @@ class PopupProxy extends EventDispatcher {
         this._frameId = frameId;
         this._frameOffsetForwarder = frameOffsetForwarder;
 
-        this._frameOffset = [0, 0];
+        this._frameOffsetX = 0;
+        this._frameOffsetY = 0;
         this._frameOffsetPromise = null;
         this._frameOffsetUpdatedAt = null;
         this._frameOffsetExpireTimeout = 1000;
@@ -319,8 +320,12 @@ class PopupProxy extends EventDispatcher {
         this._frameOffsetPromise = this._frameOffsetForwarder.getOffset();
         try {
             const offset = await this._frameOffsetPromise;
-            this._frameOffset = offset !== null ? offset : [0, 0];
-            if (offset === null) {
+            if (offset !== null) {
+                this._frameOffsetX = offset[0];
+                this._frameOffsetY = offset[1];
+            } else {
+                this._frameOffsetX = 0;
+                this._frameOffsetY = 0;
                 this.trigger('offsetNotFound');
                 return;
             }
@@ -333,7 +338,6 @@ class PopupProxy extends EventDispatcher {
     }
 
     _applyFrameOffset(x, y) {
-        const [offsetX, offsetY] = this._frameOffset;
-        return [x + offsetX, y + offsetY];
+        return [x + this._frameOffsetX, y + this._frameOffsetY];
     }
 }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -190,8 +190,8 @@ class PopupProxy extends EventDispatcher {
      * @returns {Promise<void>}
      */
     async showContent(details, displayDetails) {
-        const {sourceRect} = details;
         if (this._frameOffsetForwarder !== null) {
+            const {sourceRect} = details;
             await this._updateFrameOffset();
             [sourceRect.left, sourceRect.top] = this._applyFrameOffset(sourceRect.left, sourceRect.top);
         }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -260,7 +260,7 @@ class PopupProxy extends EventDispatcher {
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
-        return {left: 0, top: 0, width: 0, height: 0, valid: false};
+        return {left: 0, top: 0, right: 0, bottom: 0, valid: false};
     }
 
     /**

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -193,7 +193,7 @@ class PopupProxy extends EventDispatcher {
         const {sourceRect} = details;
         if (this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
-            [sourceRect.x, sourceRect.y] = this._applyFrameOffset(sourceRect.x, sourceRect.y);
+            [sourceRect.left, sourceRect.top] = this._applyFrameOffset(sourceRect.left, sourceRect.top);
         }
         return await this._invokeSafe('PopupFactory.showContent', {id: this._id, details, displayDetails});
     }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -185,15 +185,15 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, elementRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
+     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
      * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
      * @returns {Promise<void>}
      */
     async showContent(details, displayDetails) {
-        const {elementRect} = details;
-        if (typeof elementRect !== 'undefined' && this._frameOffsetForwarder !== null) {
+        const {sourceRect} = details;
+        if (typeof sourceRect !== 'undefined' && this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
-            [elementRect.x, elementRect.y] = this._applyFrameOffset(elementRect.x, elementRect.y);
+            [sourceRect.x, sourceRect.y] = this._applyFrameOffset(sourceRect.x, sourceRect.y);
         }
         return await this._invokeSafe('PopupFactory.showContent', {id: this._id, details, displayDetails});
     }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -191,7 +191,7 @@ class PopupProxy extends EventDispatcher {
      */
     async showContent(details, displayDetails) {
         const {sourceRect} = details;
-        if (typeof sourceRect !== 'undefined' && this._frameOffsetForwarder !== null) {
+        if (this._frameOffsetForwarder !== null) {
             await this._updateFrameOffset();
             [sourceRect.x, sourceRect.y] = this._applyFrameOffset(sourceRect.x, sourceRect.y);
         }

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -254,11 +254,11 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {{x: number, y: number, width: number, height: number, valid: boolean}} The rect.
+     * @returns {Popup.Rect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
-        return {x: 0, y: 0, width: 0, height: 0, valid: false};
+        return {left: 0, top: 0, width: 0, height: 0, valid: false};
     }
 
     /**

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -185,8 +185,8 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
-     * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
+     * @param {Popup.ContentDetails} details Settings for the outer popup.
+     * @param {Display.ContentDetails} displayDetails The details parameter passed to `Display.setContent`.
      * @returns {Promise<void>}
      */
     async showContent(details, displayDetails) {

--- a/ext/js/app/popup-proxy.js
+++ b/ext/js/app/popup-proxy.js
@@ -254,7 +254,7 @@ class PopupProxy extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {Popup.Rect} The rect.
+     * @returns {Popup.ValidRect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -229,11 +229,11 @@ class PopupWindow extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {{x: number, y: number, width: number, height: number, valid: boolean}} The rect.
+     * @returns {Popup.Rect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
-        return {x: 0, y: 0, width: 0, height: 0, valid: false};
+        return {left: 0, top: 0, width: 0, height: 0, valid: false};
     }
 
     /**

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -168,7 +168,7 @@ class PopupWindow extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, elementRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
+     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
      * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
      * @returns {Promise<void>}
      */

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -168,8 +168,8 @@ class PopupWindow extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
-     * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
+     * @param {Popup.ContentDetails} details Settings for the outer popup.
+     * @param {Display.ContentDetails} displayDetails The details parameter passed to `Display.setContent`.
      * @returns {Promise<void>}
      */
     async showContent(_details, displayDetails) {

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -233,7 +233,7 @@ class PopupWindow extends EventDispatcher {
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
-        return {left: 0, top: 0, width: 0, height: 0, valid: false};
+        return {left: 0, top: 0, right: 0, bottom: 0, valid: false};
     }
 
     /**

--- a/ext/js/app/popup-window.js
+++ b/ext/js/app/popup-window.js
@@ -229,7 +229,7 @@ class PopupWindow extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {Popup.Rect} The rect.
+     * @returns {Popup.ValidRect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -39,6 +39,16 @@ class Popup extends EventDispatcher {
      */
 
     /**
+     * A rectangle representing a DOM region, similar to DOMRect but with a `valid` property.
+     * @typedef {object} Rect
+     * @property {number} left The left position of the rectangle.
+     * @property {number} left The top position of the rectangle.
+     * @property {number} width The width of the rectangle.
+     * @property {number} height The height of the rectangle.
+     * @property {boolean} valid Whether or not the rectangle is valid.
+     */
+
+    /**
      * Creates a new instance.
      * @param {object} details
      * @param {string} details.id The ID of the popup.
@@ -249,7 +259,7 @@ class Popup extends EventDispatcher {
     async containsPoint(x, y) {
         for (let popup = this; popup !== null && popup.isVisibleSync(); popup = popup.child) {
             const rect = popup.getFrameRect();
-            if (rect.valid && x >= rect.x && y >= rect.y && x < rect.x + rect.width && y < rect.y + rect.height) {
+            if (rect.valid && x >= rect.left && y >= rect.top && x < rect.left + rect.width && y < rect.top + rect.height) {
                 return true;
             }
         }
@@ -337,12 +347,12 @@ class Popup extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {{x: number, y: number, width: number, height: number, valid: boolean}} The rect.
+     * @returns {Rect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
         const {left, top, width, height} = this._frame.getBoundingClientRect();
-        return {x: left, y: top, width, height, valid: true};
+        return {left, top, width, height, valid: true};
     }
 
     /**

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -54,6 +54,17 @@ class Popup extends EventDispatcher {
      */
 
     /**
+     * A rectangle representing a DOM region for placing the popup frame.
+     * @typedef {object} SizeRect
+     * @property {number} left The left position of the rectangle.
+     * @property {number} top The top position of the rectangle.
+     * @property {number} width The width of the rectangle.
+     * @property {number} height The height of the rectangle.
+     * @property {boolean} after Whether or not the rectangle is positioned to the right of the source rectangle.
+     * @property {boolean} below Whether or not the rectangle is positioned below the source rectangle.
+     */
+
+    /**
      * Creates a new instance.
      * @param {object} details
      * @param {string} details.id The ID of the popup.
@@ -567,7 +578,7 @@ class Popup extends EventDispatcher {
             scale,
             writingMode
         ];
-        let [x, y, width, height, below] = (
+        let {left, top, width, height, below} = (
             writingMode === 'horizontal-tb' || this._verticalTextPosition === 'default' ?
             this._getPositionForHorizontalTextMulti(...getPositionArgs) :
             this._getPositionForVerticalTextMulti(...getPositionArgs)
@@ -577,13 +588,13 @@ class Popup extends EventDispatcher {
         frame.dataset.below = `${below}`;
 
         if (this._displayMode === 'full-width') {
-            x = viewport.left;
-            y = below ? viewport.bottom - height : viewport.top;
+            left = viewport.left;
+            top = below ? viewport.bottom - height : viewport.top;
             width = viewport.right - viewport.left;
         }
 
-        frame.style.left = `${x}px`;
-        frame.style.top = `${y}px`;
+        frame.style.left = `${left}px`;
+        frame.style.top = `${top}px`;
         this._setFrameSize(width, height);
 
         this._setVisible(true);
@@ -677,6 +688,9 @@ class Popup extends EventDispatcher {
         return fullscreenElement;
     }
 
+    /**
+     * @returns {SizeRect}
+     */
     _getPositionForHorizontalTextMulti(sourceRects, frameWidth, frameHeight, viewport, offsetScale) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
         const horizontalOffset = this._horizontalOffset * offsetScale;
@@ -685,6 +699,9 @@ class Popup extends EventDispatcher {
         return this._getPositionForHorizontalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferBelow);
     }
 
+    /**
+     * @returns {SizeRect}
+     */
     _getPositionForVerticalTextMulti(sourceRects, frameWidth, frameHeight, viewport, offsetScale, writingMode) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
         const horizontalOffset = this._horizontalOffset2 * offsetScale;
@@ -693,8 +710,11 @@ class Popup extends EventDispatcher {
         return this._getPositionForVerticalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferRight);
     }
 
+    /**
+     * @returns {SizeRect}
+     */
     _getPositionForHorizontalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferBelow) {
-        const [x, w] = this._getConstrainedPosition(
+        const [left, width, after] = this._getConstrainedPosition(
             sourceRect.right - horizontalOffset,
             sourceRect.left + horizontalOffset,
             frameWidth,
@@ -702,7 +722,7 @@ class Popup extends EventDispatcher {
             viewport.right,
             true
         );
-        const [y, h, below] = this._getConstrainedPositionBinary(
+        const [top, height, below] = this._getConstrainedPositionBinary(
             sourceRect.top - verticalOffset,
             sourceRect.bottom + verticalOffset,
             frameHeight,
@@ -710,11 +730,14 @@ class Popup extends EventDispatcher {
             viewport.bottom,
             preferBelow
         );
-        return [x, y, w, h, below];
+        return {left, top, width, height, after, below};
     }
 
+    /**
+     * @returns {SizeRect}
+     */
     _getPositionForVerticalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferRight) {
-        const [x, w] = this._getConstrainedPositionBinary(
+        const [left, width, after] = this._getConstrainedPositionBinary(
             sourceRect.left - horizontalOffset,
             sourceRect.right + horizontalOffset,
             frameWidth,
@@ -722,7 +745,7 @@ class Popup extends EventDispatcher {
             viewport.right,
             preferRight
         );
-        const [y, h, below] = this._getConstrainedPosition(
+        const [top, height, below] = this._getConstrainedPosition(
             sourceRect.bottom - verticalOffset,
             sourceRect.top + verticalOffset,
             frameHeight,
@@ -730,7 +753,7 @@ class Popup extends EventDispatcher {
             viewport.bottom,
             true
         );
-        return [x, y, w, h, below];
+        return {left, top, width, height, after, below};
     }
 
     _isVerticalTextPopupOnRight(positionPreference, writingMode) {

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -677,27 +677,27 @@ class Popup extends EventDispatcher {
         return fullscreenElement;
     }
 
-    _getPositionForHorizontalTextMulti(sourceRects, width, height, viewport, offsetScale) {
+    _getPositionForHorizontalTextMulti(sourceRects, frameWidth, frameHeight, viewport, offsetScale) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
         const horizontalOffset = this._horizontalOffset * offsetScale;
         const verticalOffset = this._verticalOffset * offsetScale;
         const preferBelow = this._horizontalTextPositionBelow;
-        return this._getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow);
+        return this._getPositionForHorizontalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferBelow);
     }
 
-    _getPositionForVerticalTextMulti(sourceRects, width, height, viewport, offsetScale, writingMode) {
+    _getPositionForVerticalTextMulti(sourceRects, frameWidth, frameHeight, viewport, offsetScale, writingMode) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
         const horizontalOffset = this._horizontalOffset2 * offsetScale;
         const verticalOffset = this._verticalOffset2 * offsetScale;
         const preferRight = this._isVerticalTextPopupOnRight(this._verticalTextPosition, writingMode);
-        return this._getPositionForVerticalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferRight);
+        return this._getPositionForVerticalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferRight);
     }
 
-    _getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow) {
+    _getPositionForHorizontalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferBelow) {
         const [x, w] = this._getConstrainedPosition(
             sourceRect.right - horizontalOffset,
             sourceRect.left + horizontalOffset,
-            width,
+            frameWidth,
             viewport.left,
             viewport.right,
             true
@@ -705,7 +705,7 @@ class Popup extends EventDispatcher {
         const [y, h, below] = this._getConstrainedPositionBinary(
             sourceRect.top - verticalOffset,
             sourceRect.bottom + verticalOffset,
-            height,
+            frameHeight,
             viewport.top,
             viewport.bottom,
             preferBelow
@@ -713,11 +713,11 @@ class Popup extends EventDispatcher {
         return [x, y, w, h, below];
     }
 
-    _getPositionForVerticalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferRight) {
+    _getPositionForVerticalText(sourceRect, frameWidth, frameHeight, viewport, horizontalOffset, verticalOffset, preferRight) {
         const [x, w] = this._getConstrainedPositionBinary(
             sourceRect.left - horizontalOffset,
             sourceRect.right + horizontalOffset,
-            width,
+            frameWidth,
             viewport.left,
             viewport.right,
             preferRight
@@ -725,7 +725,7 @@ class Popup extends EventDispatcher {
         const [y, h, below] = this._getConstrainedPosition(
             sourceRect.bottom - verticalOffset,
             sourceRect.top + verticalOffset,
-            height,
+            frameHeight,
             viewport.top,
             viewport.bottom,
             true

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -29,7 +29,7 @@ class Popup extends EventDispatcher {
     /**
      * Information about how popup content should be shown, specifically related to the outer popup frame.
      * @typedef {object} ContentDetails
-     * @property {object} optionsContext The options context for the content to show.
+     * @property {?object} optionsContext The options context for the content to show.
      * @property {object} sourceRect The rectangle of the source content.
      * @property {number} sourceRect.x The left position of the rectangle.
      * @property {number} sourceRect.y The top position of the rectangle.

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -270,9 +270,7 @@ class Popup extends EventDispatcher {
             await this._setOptionsContextIfDifferent(optionsContext);
         }
 
-        if (typeof sourceRect !== 'undefined' && typeof writingMode !== 'undefined') {
-            await this._show(sourceRect, writingMode);
-        }
+        await this._show(sourceRect, writingMode);
 
         if (displayDetails !== null) {
             this._invokeSafe('Display.setContent', {details: displayDetails});

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -90,7 +90,7 @@ class Popup extends EventDispatcher {
         this._horizontalOffset2 = 10;
         this._verticalOffset2 = 0;
         this._verticalTextPosition = 'before';
-        this._horizontalTextPosition = 'below';
+        this._horizontalTextPositionBelow = true;
         this._displayMode = 'default';
         this._scaleRelativeToVisualViewport = true;
         this._useSecureFrameUrl = true;
@@ -681,7 +681,7 @@ class Popup extends EventDispatcher {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
         const horizontalOffset = this._horizontalOffset * offsetScale;
         const verticalOffset = this._verticalOffset * offsetScale;
-        const preferBelow = (this._horizontalTextPosition === 'below');
+        const preferBelow = this._horizontalTextPositionBelow;
         return this._getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow);
     }
 
@@ -739,10 +739,9 @@ class Popup extends EventDispatcher {
                 return !this._isWritingModeLeftToRight(writingMode);
             case 'after':
                 return this._isWritingModeLeftToRight(writingMode);
-            case 'left':
-                return false;
             case 'right':
                 return true;
+            // case 'left':
             default:
                 return false;
         }
@@ -839,7 +838,7 @@ class Popup extends EventDispatcher {
         this._horizontalOffset2 = general.popupHorizontalOffset2;
         this._verticalOffset2 = general.popupVerticalOffset2;
         this._verticalTextPosition = general.popupVerticalTextPosition;
-        this._horizontalTextPosition = general.popupHorizontalTextPosition;
+        this._horizontalTextPositionBelow = (general.popupHorizontalTextPosition === 'below');
         this._displayMode = general.popupDisplayMode;
         this._scaleRelativeToVisualViewport = general.popupScaleRelativeToVisualViewport;
         this._useSecureFrameUrl = general.useSecurePopupFrameUrl;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -870,7 +870,7 @@ class Popup extends EventDispatcher {
         this._horizontalOffset2 = general.popupHorizontalOffset2;
         this._verticalOffset2 = general.popupVerticalOffset2;
         this._verticalTextPosition = general.popupVerticalTextPosition;
-        this._horizontalTextPositionBelow = (general.popupHorizontalTextPosition === 'below');
+        this._horizontalTextPositionBelow = (this._verticalTextPosition === 'below');
         this._displayMode = general.popupDisplayMode;
         this._displayModeIsFullWidth = (this._displayMode === 'full-width');
         this._scaleRelativeToVisualViewport = general.popupScaleRelativeToVisualViewport;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -679,19 +679,21 @@ class Popup extends EventDispatcher {
 
     _getPositionForHorizontalTextMulti(sourceRects, width, height, viewport, offsetScale) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
-        return this._getPositionForHorizontalText(sourceRect, width, height, viewport, offsetScale);
+        const horizontalOffset = this._horizontalOffset * offsetScale;
+        const verticalOffset = this._verticalOffset * offsetScale;
+        const preferBelow = (this._horizontalTextPosition === 'below');
+        return this._getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow);
     }
 
     _getPositionForVerticalTextMulti(sourceRects, width, height, viewport, offsetScale, writingMode) {
         const sourceRect = this._getBoundingSourceRect(sourceRects);
-        return this._getPositionForVerticalText(sourceRect, width, height, viewport, offsetScale, writingMode);
+        const horizontalOffset = this._horizontalOffset2 * offsetScale;
+        const verticalOffset = this._verticalOffset2 * offsetScale;
+        const preferRight = this._isVerticalTextPopupOnRight(this._verticalTextPosition, writingMode);
+        return this._getPositionForVerticalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferRight);
     }
 
-    _getPositionForHorizontalText(sourceRect, width, height, viewport, offsetScale) {
-        const preferBelow = (this._horizontalTextPosition === 'below');
-        const horizontalOffset = this._horizontalOffset * offsetScale;
-        const verticalOffset = this._verticalOffset * offsetScale;
-
+    _getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow) {
         const [x, w] = this._getConstrainedPosition(
             sourceRect.left + sourceRect.width - horizontalOffset,
             sourceRect.left + horizontalOffset,
@@ -711,11 +713,7 @@ class Popup extends EventDispatcher {
         return [x, y, w, h, below];
     }
 
-    _getPositionForVerticalText(sourceRect, width, height, viewport, offsetScale, writingMode) {
-        const preferRight = this._isVerticalTextPopupOnRight(this._verticalTextPosition, writingMode);
-        const horizontalOffset = this._horizontalOffset2 * offsetScale;
-        const verticalOffset = this._verticalOffset2 * offsetScale;
-
+    _getPositionForVerticalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferRight) {
         const [x, w] = this._getConstrainedPositionBinary(
             sourceRect.left - horizontalOffset,
             sourceRect.left + sourceRect.width + horizontalOffset,

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -30,17 +30,22 @@ class Popup extends EventDispatcher {
      * Information about how popup content should be shown, specifically related to the outer popup frame.
      * @typedef {object} ContentDetails
      * @property {?object} optionsContext The options context for the content to show.
-     * @property {object} sourceRect The rectangle of the source content.
-     * @property {number} sourceRect.left The left position of the rectangle.
-     * @property {number} sourceRect.left The top position of the rectangle.
-     * @property {number} sourceRect.width The width of the rectangle.
-     * @property {number} sourceRect.height The height of the rectangle.
+     * @property {Rect} sourceRect The rectangle of the source content.
      * @property {'horizontal-tb' | 'vertical-rl' | 'vertical-lr' | 'sideways-rl' | 'sideways-lr'} writingMode The normalized CSS writing-mode value of the source content.
      */
 
     /**
-     * A rectangle representing a DOM region, similar to DOMRect but with a `valid` property.
+     * A rectangle representing a DOM region, similar to DOMRect.
      * @typedef {object} Rect
+     * @property {number} left The left position of the rectangle.
+     * @property {number} left The top position of the rectangle.
+     * @property {number} width The width of the rectangle.
+     * @property {number} height The height of the rectangle.
+     */
+
+    /**
+     * A rectangle representing a DOM region, similar to DOMRect but with a `valid` property.
+     * @typedef {object} ValidRect
      * @property {number} left The left position of the rectangle.
      * @property {number} left The top position of the rectangle.
      * @property {number} width The width of the rectangle.
@@ -347,7 +352,7 @@ class Popup extends EventDispatcher {
 
     /**
      * Gets the rectangle of the DOM frame, synchronously.
-     * @returns {Rect} The rect.
+     * @returns {ValidRect} The rect.
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -39,8 +39,8 @@ class Popup extends EventDispatcher {
      * @typedef {object} Rect
      * @property {number} left The left position of the rectangle.
      * @property {number} left The top position of the rectangle.
-     * @property {number} width The width of the rectangle.
-     * @property {number} height The height of the rectangle.
+     * @property {number} right The right position of the rectangle.
+     * @property {number} bottom The bottom position of the rectangle.
      */
 
     /**
@@ -695,7 +695,7 @@ class Popup extends EventDispatcher {
 
     _getPositionForHorizontalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferBelow) {
         const [x, w] = this._getConstrainedPosition(
-            sourceRect.left + sourceRect.width - horizontalOffset,
+            sourceRect.right - horizontalOffset,
             sourceRect.left + horizontalOffset,
             width,
             viewport.left,
@@ -704,7 +704,7 @@ class Popup extends EventDispatcher {
         );
         const [y, h, below] = this._getConstrainedPositionBinary(
             sourceRect.top - verticalOffset,
-            sourceRect.top + sourceRect.height + verticalOffset,
+            sourceRect.bottom + verticalOffset,
             height,
             viewport.top,
             viewport.bottom,
@@ -716,14 +716,14 @@ class Popup extends EventDispatcher {
     _getPositionForVerticalText(sourceRect, width, height, viewport, horizontalOffset, verticalOffset, preferRight) {
         const [x, w] = this._getConstrainedPositionBinary(
             sourceRect.left - horizontalOffset,
-            sourceRect.left + sourceRect.width + horizontalOffset,
+            sourceRect.right + horizontalOffset,
             width,
             viewport.left,
             viewport.right,
             preferRight
         );
         const [y, h, below] = this._getConstrainedPosition(
-            sourceRect.top + sourceRect.height - verticalOffset,
+            sourceRect.bottom - verticalOffset,
             sourceRect.top + verticalOffset,
             height,
             viewport.top,
@@ -855,16 +855,14 @@ class Popup extends EventDispatcher {
     }
 
     _getBoundingSourceRect(sourceRects) {
-        let {left, top, width, height} = sourceRects[0];
-        let right = left + width;
-        let bottom = top + height;
+        let {left, top, right, bottom} = sourceRects[0];
         for (let i = 1, ii = sourceRects.length; i < ii; ++i) {
-            const {left: left2, top: top2, width: width2, height: height2} = sourceRects[i];
-            left = Math.min(left, left2);
-            top = Math.min(top, top2);
-            right = Math.max(right, left2 + width2);
-            bottom = Math.max(bottom, top2 + height2);
+            const sourceRect = sourceRects[i];
+            left = Math.min(left, sourceRect.left);
+            top = Math.min(top, sourceRect.top);
+            right = Math.max(right, sourceRect.right);
+            bottom = Math.max(bottom, sourceRect.bottom);
         }
-        return {left, top, width: right - left, height: bottom - top};
+        return {left, top, right, bottom};
     }
 }

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -103,6 +103,7 @@ class Popup extends EventDispatcher {
         this._verticalTextPosition = 'before';
         this._horizontalTextPositionBelow = true;
         this._displayMode = 'default';
+        this._displayModeIsFullWidth = false;
         this._scaleRelativeToVisualViewport = true;
         this._useSecureFrameUrl = true;
         this._useShadowDom = true;
@@ -566,16 +567,15 @@ class Popup extends EventDispatcher {
         const viewport = this._getViewport(this._scaleRelativeToVisualViewport);
         let {left, top, width, height, below} = this._getPosition(sourceRects, writingMode, viewport);
 
-        const frame = this._frame;
-        frame.dataset.popupDisplayMode = this._displayMode;
-        frame.dataset.below = `${below}`;
-
-        if (this._displayMode === 'full-width') {
+        if (this._displayModeIsFullWidth) {
             left = viewport.left;
             top = below ? viewport.bottom - height : viewport.top;
             width = viewport.right - viewport.left;
         }
 
+        const frame = this._frame;
+        frame.dataset.popupDisplayMode = this._displayMode;
+        frame.dataset.below = `${below}`;
         frame.style.left = `${left}px`;
         frame.style.top = `${top}px`;
         this._setFrameSize(width, height);
@@ -871,6 +871,7 @@ class Popup extends EventDispatcher {
         this._verticalTextPosition = general.popupVerticalTextPosition;
         this._horizontalTextPositionBelow = (general.popupHorizontalTextPosition === 'below');
         this._displayMode = general.popupDisplayMode;
+        this._displayModeIsFullWidth = (this._displayMode === 'full-width');
         this._scaleRelativeToVisualViewport = general.popupScaleRelativeToVisualViewport;
         this._useSecureFrameUrl = general.useSecurePopupFrameUrl;
         this._useShadowDom = general.usePopupShadowDom;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -38,7 +38,7 @@ class Popup extends EventDispatcher {
      * A rectangle representing a DOM region, similar to DOMRect.
      * @typedef {object} Rect
      * @property {number} left The left position of the rectangle.
-     * @property {number} left The top position of the rectangle.
+     * @property {number} top The top position of the rectangle.
      * @property {number} right The right position of the rectangle.
      * @property {number} bottom The bottom position of the rectangle.
      */
@@ -47,7 +47,7 @@ class Popup extends EventDispatcher {
      * A rectangle representing a DOM region, similar to DOMRect but with a `valid` property.
      * @typedef {object} ValidRect
      * @property {number} left The left position of the rectangle.
-     * @property {number} left The top position of the rectangle.
+     * @property {number} top The top position of the rectangle.
      * @property {number} right The right position of the rectangle.
      * @property {number} bottom The bottom position of the rectangle.
      * @property {boolean} valid Whether or not the rectangle is valid.

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -246,20 +246,20 @@ class Popup extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, elementRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
+     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
      * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
      * @returns {Promise<void>}
      */
     async showContent(details, displayDetails) {
         if (!this._optionsAssigned) { throw new Error('Options not assigned'); }
 
-        const {optionsContext, elementRect, writingMode} = details;
+        const {optionsContext, sourceRect, writingMode} = details;
         if (optionsContext !== null) {
             await this._setOptionsContextIfDifferent(optionsContext);
         }
 
-        if (typeof elementRect !== 'undefined' && typeof writingMode !== 'undefined') {
-            await this._show(elementRect, writingMode);
+        if (typeof sourceRect !== 'undefined' && typeof writingMode !== 'undefined') {
+            await this._show(sourceRect, writingMode);
         }
 
         if (displayDetails !== null) {
@@ -523,7 +523,7 @@ class Popup extends EventDispatcher {
         }
     }
 
-    async _show(elementRect, writingMode) {
+    async _show(sourceRect, writingMode) {
         const injected = await this._inject();
         if (!injected) { return; }
 
@@ -535,7 +535,7 @@ class Popup extends EventDispatcher {
         const scaleRatio = this._frameSizeContentScale === null ? 1.0 : scale / this._frameSizeContentScale;
         this._frameSizeContentScale = scale;
         const getPositionArgs = [
-            elementRect,
+            sourceRect,
             Math.max(frameRect.width * scaleRatio, this._initialWidth * scale),
             Math.max(frameRect.height * scaleRatio, this._initialHeight * scale),
             viewport,
@@ -652,22 +652,22 @@ class Popup extends EventDispatcher {
         return fullscreenElement;
     }
 
-    _getPositionForHorizontalText(elementRect, width, height, viewport, offsetScale) {
+    _getPositionForHorizontalText(sourceRect, width, height, viewport, offsetScale) {
         const preferBelow = (this._horizontalTextPosition === 'below');
         const horizontalOffset = this._horizontalOffset * offsetScale;
         const verticalOffset = this._verticalOffset * offsetScale;
 
         const [x, w] = this._getConstrainedPosition(
-            elementRect.x + elementRect.width - horizontalOffset,
-            elementRect.x + horizontalOffset,
+            sourceRect.x + sourceRect.width - horizontalOffset,
+            sourceRect.x + horizontalOffset,
             width,
             viewport.left,
             viewport.right,
             true
         );
         const [y, h, below] = this._getConstrainedPositionBinary(
-            elementRect.y - verticalOffset,
-            elementRect.y + elementRect.height + verticalOffset,
+            sourceRect.y - verticalOffset,
+            sourceRect.y + sourceRect.height + verticalOffset,
             height,
             viewport.top,
             viewport.bottom,
@@ -676,22 +676,22 @@ class Popup extends EventDispatcher {
         return [x, y, w, h, below];
     }
 
-    _getPositionForVerticalText(elementRect, width, height, viewport, offsetScale, writingMode) {
+    _getPositionForVerticalText(sourceRect, width, height, viewport, offsetScale, writingMode) {
         const preferRight = this._isVerticalTextPopupOnRight(this._verticalTextPosition, writingMode);
         const horizontalOffset = this._horizontalOffset2 * offsetScale;
         const verticalOffset = this._verticalOffset2 * offsetScale;
 
         const [x, w] = this._getConstrainedPositionBinary(
-            elementRect.x - horizontalOffset,
-            elementRect.x + elementRect.width + horizontalOffset,
+            sourceRect.x - horizontalOffset,
+            sourceRect.x + sourceRect.width + horizontalOffset,
             width,
             viewport.left,
             viewport.right,
             preferRight
         );
         const [y, h, below] = this._getConstrainedPosition(
-            elementRect.y + elementRect.height - verticalOffset,
-            elementRect.y + verticalOffset,
+            sourceRect.y + sourceRect.height - verticalOffset,
+            sourceRect.y + verticalOffset,
             height,
             viewport.top,
             viewport.bottom,

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -27,6 +27,18 @@
  */
 class Popup extends EventDispatcher {
     /**
+     * Information about how popup content should be shown, specifically related to the outer popup frame.
+     * @typedef {object} ContentDetails
+     * @property {object} optionsContext The options context for the content to show.
+     * @property {object} sourceRect The rectangle of the source content.
+     * @property {number} sourceRect.x The left position of the rectangle.
+     * @property {number} sourceRect.y The top position of the rectangle.
+     * @property {number} sourceRect.width The width of the rectangle.
+     * @property {number} sourceRect.height The height of the rectangle.
+     * @property {'horizontal-tb' | 'vertical-rl' | 'vertical-lr' | 'sideways-rl' | 'sideways-lr'} writingMode The normalized CSS writing-mode value of the source content.
+     */
+
+    /**
      * Creates a new instance.
      * @param {object} details
      * @param {string} details.id The ID of the popup.
@@ -246,8 +258,8 @@ class Popup extends EventDispatcher {
 
     /**
      * Shows and updates the positioning and content of the popup.
-     * @param {{optionsContext: object, sourceRect: {x: number, y: number, width: number, height: number}, writingMode: string}} details Settings for the outer popup.
-     * @param {object} displayDetails The details parameter passed to `Display.setContent`; see that function for details.
+     * @param {ContentDetails} details Settings for the outer popup.
+     * @param {Display.ContentDetails} displayDetails The details parameter passed to `Display.setContent`.
      * @returns {Promise<void>}
      */
     async showContent(details, displayDetails) {

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -886,6 +886,10 @@ class Popup extends EventDispatcher {
         await this._setOptionsContext(optionsContext);
     }
 
+    /**
+     * @param {Rect[]} sourceRects
+     * @returns {Rect}
+     */
     _getBoundingSourceRect(sourceRects) {
         switch (sourceRects.length) {
             case 0: return {left: 0, top: 0, right: 0, bottom: 0};

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -565,7 +565,7 @@ class Popup extends EventDispatcher {
         if (!injected) { return; }
 
         const viewport = this._getViewport(this._scaleRelativeToVisualViewport);
-        let {left, top, width, height, below} = this._getPosition(sourceRects, writingMode, viewport);
+        let {left, top, width, height, after, below} = this._getPosition(sourceRects, writingMode, viewport);
 
         if (this._displayModeIsFullWidth) {
             left = viewport.left;
@@ -575,6 +575,7 @@ class Popup extends EventDispatcher {
 
         const frame = this._frame;
         frame.dataset.popupDisplayMode = this._displayMode;
+        frame.dataset.after = `${after}`;
         frame.dataset.below = `${below}`;
         frame.style.left = `${left}px`;
         frame.style.top = `${top}px`;

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -31,8 +31,8 @@ class Popup extends EventDispatcher {
      * @typedef {object} ContentDetails
      * @property {?object} optionsContext The options context for the content to show.
      * @property {object} sourceRect The rectangle of the source content.
-     * @property {number} sourceRect.x The left position of the rectangle.
-     * @property {number} sourceRect.y The top position of the rectangle.
+     * @property {number} sourceRect.left The left position of the rectangle.
+     * @property {number} sourceRect.left The top position of the rectangle.
      * @property {number} sourceRect.width The width of the rectangle.
      * @property {number} sourceRect.height The height of the rectangle.
      * @property {'horizontal-tb' | 'vertical-rl' | 'vertical-lr' | 'sideways-rl' | 'sideways-lr'} writingMode The normalized CSS writing-mode value of the source content.
@@ -668,16 +668,16 @@ class Popup extends EventDispatcher {
         const verticalOffset = this._verticalOffset * offsetScale;
 
         const [x, w] = this._getConstrainedPosition(
-            sourceRect.x + sourceRect.width - horizontalOffset,
-            sourceRect.x + horizontalOffset,
+            sourceRect.left + sourceRect.width - horizontalOffset,
+            sourceRect.left + horizontalOffset,
             width,
             viewport.left,
             viewport.right,
             true
         );
         const [y, h, below] = this._getConstrainedPositionBinary(
-            sourceRect.y - verticalOffset,
-            sourceRect.y + sourceRect.height + verticalOffset,
+            sourceRect.top - verticalOffset,
+            sourceRect.top + sourceRect.height + verticalOffset,
             height,
             viewport.top,
             viewport.bottom,
@@ -692,16 +692,16 @@ class Popup extends EventDispatcher {
         const verticalOffset = this._verticalOffset2 * offsetScale;
 
         const [x, w] = this._getConstrainedPositionBinary(
-            sourceRect.x - horizontalOffset,
-            sourceRect.x + sourceRect.width + horizontalOffset,
+            sourceRect.left - horizontalOffset,
+            sourceRect.left + sourceRect.width + horizontalOffset,
             width,
             viewport.left,
             viewport.right,
             preferRight
         );
         const [y, h, below] = this._getConstrainedPosition(
-            sourceRect.y + sourceRect.height - verticalOffset,
-            sourceRect.y + verticalOffset,
+            sourceRect.top + sourceRect.height - verticalOffset,
+            sourceRect.top + verticalOffset,
             height,
             viewport.top,
             viewport.bottom,

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -48,8 +48,8 @@ class Popup extends EventDispatcher {
      * @typedef {object} ValidRect
      * @property {number} left The left position of the rectangle.
      * @property {number} left The top position of the rectangle.
-     * @property {number} width The width of the rectangle.
-     * @property {number} height The height of the rectangle.
+     * @property {number} right The right position of the rectangle.
+     * @property {number} bottom The bottom position of the rectangle.
      * @property {boolean} valid Whether or not the rectangle is valid.
      */
 
@@ -264,7 +264,7 @@ class Popup extends EventDispatcher {
     async containsPoint(x, y) {
         for (let popup = this; popup !== null && popup.isVisibleSync(); popup = popup.child) {
             const rect = popup.getFrameRect();
-            if (rect.valid && x >= rect.left && y >= rect.top && x < rect.left + rect.width && y < rect.top + rect.height) {
+            if (rect.valid && x >= rect.left && y >= rect.top && x < rect.right && y < rect.bottom) {
                 return true;
             }
         }
@@ -356,8 +356,8 @@ class Popup extends EventDispatcher {
      *   `valid` is `false` for `PopupProxy`, since the DOM node is hosted in a different frame.
      */
     getFrameRect() {
-        const {left, top, width, height} = this._frame.getBoundingClientRect();
-        return {left, top, width, height, valid: true};
+        const {left, top, right, bottom} = this._frame.getBoundingClientRect();
+        return {left, top, right, bottom, valid: true};
     }
 
     /**

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -36,6 +36,11 @@
  */
 
 class Display extends EventDispatcher {
+    /**
+     * Information about how popup content should be shown, specifically related to the inner popup content.
+     * @typedef {object} ContentDetails
+     */
+
     constructor(tabId, frameId, pageType, japaneseUtil, documentFocusController, hotkeyHandler) {
         super();
         this._tabId = tabId;
@@ -341,6 +346,10 @@ class Display extends EventDispatcher {
         this.trigger('optionsUpdated', {options});
     }
 
+    /**
+     * Updates the content of the display.
+     * @param {ContentDetails} details
+     */
     setContent(details) {
         const {focus, params, state, content} = details;
         const historyMode = this._historyHasChanged ? details.historyMode : 'clear';

--- a/ext/js/dom/popup-menu.js
+++ b/ext/js/dom/popup-menu.js
@@ -154,8 +154,8 @@ class PopupMenu extends EventDispatcher {
 
         // Position
         const menu = this._node;
-        const fullRect = this._containerNode.getBoundingClientRect();
-        const sourceRect = this._sourceElement.getBoundingClientRect();
+        const containerNodeRect = this._containerNode.getBoundingClientRect();
+        const sourceElementRect = this._sourceElement.getBoundingClientRect();
         const menuRect = menu.getBoundingClientRect();
         let top = menuRect.top;
         let bottom = menuRect.bottom;
@@ -166,19 +166,19 @@ class PopupMenu extends EventDispatcher {
         }
 
         let x = (
-            sourceRect.left +
-            sourceRect.width * ((-horizontal * horizontalCover + 1) * 0.5) +
+            sourceElementRect.left +
+            sourceElementRect.width * ((-horizontal * horizontalCover + 1) * 0.5) +
             menuRect.width * ((-horizontal + 1) * -0.5)
         );
         let y = (
-            sourceRect.top +
+            sourceElementRect.top +
             (menuRect.top - top) +
-            sourceRect.height * ((-vertical * verticalCover + 1) * 0.5) +
+            sourceElementRect.height * ((-vertical * verticalCover + 1) * 0.5) +
             (bottom - top) * ((-vertical + 1) * -0.5)
         );
 
-        x = Math.max(0.0, Math.min(fullRect.width - menuRect.width, x));
-        y = Math.max(0.0, Math.min(fullRect.height - menuRect.height, y));
+        x = Math.max(0.0, Math.min(containerNodeRect.width - menuRect.width, x));
+        y = Math.max(0.0, Math.min(containerNodeRect.height - menuRect.height, y));
 
         menu.style.left = `${x}px`;
         menu.style.top = `${y}px`;

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -94,6 +94,10 @@ class TextSourceElement {
         return this._element.getBoundingClientRect();
     }
 
+    getRects() {
+        return this.getClientRects();
+    }
+
     getWritingMode() {
         return 'horizontal-tb';
     }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -94,6 +94,10 @@ class TextSourceRange {
         return this._range.getBoundingClientRect();
     }
 
+    getRects() {
+        return this._range.getClientRects();
+    }
+
     getWritingMode() {
         return TextSourceRange.getElementWritingMode(TextSourceRange.getParentElement(this._range.startContainer));
     }


### PR DESCRIPTION
This change does some refactoring to popup positioning and updates how the popup is positioned for source content which spans multiple `DOMRect`s.

The updated algorithm is now:
* Iterate over each `sourceRect`, calculating the popup rect for each rect rather than the full bounding rect.
* If the popup rect doesn't overlap with any other `sourceRect` and if it has the best size, use it as the optimal position.
* If no optimal position is found, calculate the bounding rect of all `sourceRect`s and return that position. (This is the same as the old behaviour.)

Resolves #2124.