### PR TITLE
Dictionary validate updates

### DIFF
--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -19,15 +19,7 @@ const fs = require('fs');
 const path = require('path');
 const {performance} = require('perf_hooks');
 const {JSZip} = require('./util');
-const {VM} = require('./vm');
-
-const vm = new VM();
-vm.execute([
-    'js/core.js',
-    'js/general/cache-map.js',
-    'js/data/json-schema.js'
-]);
-const JsonSchema = vm.get('JsonSchema');
+const {createJsonSchema} = require('./schema-validate');
 
 
 function readSchema(relativeFileName) {
@@ -37,8 +29,14 @@ function readSchema(relativeFileName) {
 }
 
 
-async function validateDictionaryBanks(zip, fileNameFormat, schema) {
-    const jsonSchema = new JsonSchema(schema);
+async function validateDictionaryBanks(mode, zip, fileNameFormat, schema) {
+    let jsonSchema;
+    try {
+        jsonSchema = createJsonSchema(mode, schema);
+    } catch (e) {
+        e.message += `\n(in file ${fileNameFormat})}`;
+        throw e;
+    }
     let index = 1;
     while (true) {
         const fileName = fileNameFormat.replace(/\?/, index);
@@ -47,14 +45,20 @@ async function validateDictionaryBanks(zip, fileNameFormat, schema) {
         if (!file) { break; }
 
         const data = JSON.parse(await file.async('string'));
-        jsonSchema.validate(data);
+        try {
+            jsonSchema.validate(data);
+        } catch (e) {
+            e.message += `\n(in file ${fileName})}`;
+            throw e;
+        }
 
         ++index;
     }
 }
 
-async function validateDictionary(archive, schemas) {
-    const indexFile = archive.files['index.json'];
+async function validateDictionary(mode, archive, schemas) {
+    const fileName = 'index.json';
+    const indexFile = archive.files[fileName];
     if (!indexFile) {
         throw new Error('No dictionary index found in archive');
     }
@@ -62,13 +66,19 @@ async function validateDictionary(archive, schemas) {
     const index = JSON.parse(await indexFile.async('string'));
     const version = index.format || index.version;
 
-    new JsonSchema(schemas.index).validate(index);
+    try {
+        const jsonSchema = createJsonSchema(mode, schemas.index);
+        jsonSchema.validate(index);
+    } catch (e) {
+        e.message += `\n(in file ${fileName})}`;
+        throw e;
+    }
 
-    await validateDictionaryBanks(archive, 'term_bank_?.json', version === 1 ? schemas.termBankV1 : schemas.termBankV3);
-    await validateDictionaryBanks(archive, 'term_meta_bank_?.json', schemas.termMetaBankV3);
-    await validateDictionaryBanks(archive, 'kanji_bank_?.json', version === 1 ? schemas.kanjiBankV1 : schemas.kanjiBankV3);
-    await validateDictionaryBanks(archive, 'kanji_meta_bank_?.json', schemas.kanjiMetaBankV3);
-    await validateDictionaryBanks(archive, 'tag_bank_?.json', schemas.tagBankV3);
+    await validateDictionaryBanks(mode, archive, 'term_bank_?.json', version === 1 ? schemas.termBankV1 : schemas.termBankV3);
+    await validateDictionaryBanks(mode, archive, 'term_meta_bank_?.json', schemas.termMetaBankV3);
+    await validateDictionaryBanks(mode, archive, 'kanji_bank_?.json', version === 1 ? schemas.kanjiBankV1 : schemas.kanjiBankV3);
+    await validateDictionaryBanks(mode, archive, 'kanji_meta_bank_?.json', schemas.kanjiMetaBankV3);
+    await validateDictionaryBanks(mode, archive, 'tag_bank_?.json', schemas.tagBankV3);
 }
 
 function getSchemas() {
@@ -85,7 +95,7 @@ function getSchemas() {
 }
 
 
-async function testDictionaryFiles(dictionaryFileNames) {
+async function testDictionaryFiles(mode, dictionaryFileNames) {
     const schemas = getSchemas();
 
     for (const dictionaryFileName of dictionaryFileNames) {
@@ -94,7 +104,7 @@ async function testDictionaryFiles(dictionaryFileNames) {
             console.log(`Validating ${dictionaryFileName}...`);
             const source = fs.readFileSync(dictionaryFileName);
             const archive = await JSZip.loadAsync(source);
-            await validateDictionary(archive, schemas);
+            await validateDictionary(mode, archive, schemas);
             const end = performance.now();
             console.log(`No issues detected (${((end - start) / 1000).toFixed(2)}s)`);
         } catch (e) {
@@ -116,7 +126,13 @@ async function main() {
         return;
     }
 
-    await testDictionaryFiles(dictionaryFileNames);
+    let mode = null;
+    if (dictionaryFileNames[0] === '--ajv') {
+        mode = 'ajv';
+        dictionaryFileNames.splice(0, 1);
+    }
+
+    await testDictionaryFiles(mode, dictionaryFileNames);
 }
 
 

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -38,6 +38,7 @@ function readSchema(relativeFileName) {
 
 
 async function validateDictionaryBanks(zip, fileNameFormat, schema) {
+    const jsonSchema = new JsonSchema(schema);
     let index = 1;
     while (true) {
         const fileName = fileNameFormat.replace(/\?/, index);
@@ -46,7 +47,7 @@ async function validateDictionaryBanks(zip, fileNameFormat, schema) {
         if (!file) { break; }
 
         const data = JSON.parse(await file.async('string'));
-        new JsonSchema(schema).validate(data);
+        jsonSchema.validate(data);
 
         ++index;
     }

--- a/dev/dictionary-validate.js
+++ b/dev/dictionary-validate.js
@@ -121,7 +121,7 @@ async function main() {
     if (dictionaryFileNames.length === 0) {
         console.log([
             'Usage:',
-            '  node dictionary-validate <dictionary-file-names>...'
+            '  node dictionary-validate [--ajv] <dictionary-file-names>...'
         ].join('\n'));
         return;
     }

--- a/dev/schema-validate.js
+++ b/dev/schema-validate.js
@@ -59,7 +59,7 @@ function main() {
     if (args.length < 2) {
         console.log([
             'Usage:',
-            '  node schema-validate <schema-file-name> <data-file-names>...'
+            '  node schema-validate [--ajv] <schema-file-name> <data-file-names>...'
         ].join('\n'));
         return;
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
             "hasInstallScript": true,
             "license": "GPL-3.0-or-later",
             "devDependencies": {
+                "ajv": "^8.11.0",
                 "browserify": "^17.0.0",
                 "css": "^3.0.0",
                 "eslint": "^8.12.0",
@@ -215,6 +216,28 @@
             "engines": {
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/@html-validate/stylish": {
             "version": "2.0.1",
@@ -566,6 +589,22 @@
                 "node": ">=12.21.0"
             }
         },
+        "node_modules/addons-linter/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
         "node_modules/addons-linter/node_modules/eslint": {
             "version": "8.11.0",
             "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
@@ -617,6 +656,12 @@
             "funding": {
                 "url": "https://opencollective.com/eslint"
             }
+        },
+        "node_modules/addons-linter/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
         },
         "node_modules/addons-linter/node_modules/source-map": {
             "version": "0.6.1",
@@ -713,14 +758,14 @@
             }
         },
         "node_modules/ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
             "dependencies": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             },
             "funding": {
@@ -3138,6 +3183,28 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/eslint/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/eslint/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
         "node_modules/espree": {
             "version": "9.3.1",
             "resolved": "https://registry.npmjs.org/espree/-/espree-9.3.1.tgz",
@@ -4171,6 +4238,28 @@
                 "node": ">=6"
             }
         },
+        "node_modules/har-validator/node_modules/ajv": {
+            "version": "6.12.6",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "dev": true,
+            "dependencies": {
+                "fast-deep-equal": "^3.1.1",
+                "fast-json-stable-stringify": "^2.0.0",
+                "json-schema-traverse": "^0.4.1",
+                "uri-js": "^4.2.2"
+            },
+            "funding": {
+                "type": "github",
+                "url": "https://github.com/sponsors/epoberezkin"
+            }
+        },
+        "node_modules/har-validator/node_modules/json-schema-traverse": {
+            "version": "0.4.1",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "dev": true
+        },
         "node_modules/hard-rejection": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/hard-rejection/-/hard-rejection-2.1.0.tgz",
@@ -4389,28 +4478,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/html-validate/node_modules/ajv": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/html-validate/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
         },
         "node_modules/htmlescape": {
             "version": "1.1.1",
@@ -5330,9 +5397,9 @@
             "dev": true
         },
         "node_modules/json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
         "node_modules/json-stable-stringify-without-jsonify": {
@@ -8880,28 +8947,6 @@
                 "node": ">=10.0.0"
             }
         },
-        "node_modules/table/node_modules/ajv": {
-            "version": "8.11.0",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-            "dev": true,
-            "dependencies": {
-                "fast-deep-equal": "^3.1.1",
-                "json-schema-traverse": "^1.0.0",
-                "require-from-string": "^2.0.2",
-                "uri-js": "^4.2.2"
-            },
-            "funding": {
-                "type": "github",
-                "url": "https://github.com/sponsors/epoberezkin"
-            }
-        },
-        "node_modules/table/node_modules/json-schema-traverse": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-            "dev": true
-        },
         "node_modules/tar-stream": {
             "version": "1.6.2",
             "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
@@ -10183,6 +10228,26 @@
                 "js-yaml": "^4.1.0",
                 "minimatch": "^3.0.4",
                 "strip-json-comments": "^3.1.1"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                }
             }
         },
         "@html-validate/stylish": {
@@ -10471,6 +10536,18 @@
                 "yauzl": "2.10.0"
             },
             "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
                 "eslint": {
                     "version": "8.11.0",
                     "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.11.0.tgz",
@@ -10513,6 +10590,12 @@
                         "text-table": "^0.2.0",
                         "v8-compile-cache": "^2.0.3"
                     }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
                 },
                 "source-map": {
                     "version": "0.6.1",
@@ -10589,14 +10672,14 @@
             }
         },
         "ajv": {
-            "version": "6.12.6",
-            "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-            "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+            "version": "8.11.0",
+            "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
+            "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
             "dev": true,
             "requires": {
                 "fast-deep-equal": "^3.1.1",
-                "fast-json-stable-stringify": "^2.0.0",
-                "json-schema-traverse": "^0.4.1",
+                "json-schema-traverse": "^1.0.0",
+                "require-from-string": "^2.0.2",
                 "uri-js": "^4.2.2"
             }
         },
@@ -12533,6 +12616,26 @@
                 "strip-json-comments": "^3.1.0",
                 "text-table": "^0.2.0",
                 "v8-compile-cache": "^2.0.3"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                }
             }
         },
         "eslint-plugin-header": {
@@ -13417,6 +13520,26 @@
             "requires": {
                 "ajv": "^6.12.3",
                 "har-schema": "^2.0.0"
+            },
+            "dependencies": {
+                "ajv": {
+                    "version": "6.12.6",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
+                    "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+                    "dev": true,
+                    "requires": {
+                        "fast-deep-equal": "^3.1.1",
+                        "fast-json-stable-stringify": "^2.0.0",
+                        "json-schema-traverse": "^0.4.1",
+                        "uri-js": "^4.2.2"
+                    }
+                },
+                "json-schema-traverse": {
+                    "version": "0.4.1",
+                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+                    "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+                    "dev": true
+                }
             }
         },
         "hard-rejection": {
@@ -13572,26 +13695,6 @@
                 "minimist": "^1.2.0",
                 "prompts": "^2.0.0",
                 "semver": "^7.0.0"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
-                }
             }
         },
         "htmlescape": {
@@ -14263,9 +14366,9 @@
             "dev": true
         },
         "json-schema-traverse": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-            "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+            "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
             "dev": true
         },
         "json-stable-stringify-without-jsonify": {
@@ -17094,26 +17197,6 @@
                 "slice-ansi": "^4.0.0",
                 "string-width": "^4.2.3",
                 "strip-ansi": "^6.0.1"
-            },
-            "dependencies": {
-                "ajv": {
-                    "version": "8.11.0",
-                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.11.0.tgz",
-                    "integrity": "sha512-wGgprdCvMalC0BztXvitD2hC04YffAvtsUn93JbGXYLAtCUO4xd17mCCZQxUOItiBwZvJScWo8NIvQMQ71rdpg==",
-                    "dev": true,
-                    "requires": {
-                        "fast-deep-equal": "^3.1.1",
-                        "json-schema-traverse": "^1.0.0",
-                        "require-from-string": "^2.0.2",
-                        "uri-js": "^4.2.2"
-                    }
-                },
-                "json-schema-traverse": {
-                    "version": "1.0.0",
-                    "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
-                    "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
-                    "dev": true
-                }
             }
         },
         "tar-stream": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
         "sourceDir": "ext"
     },
     "devDependencies": {
+        "ajv": "^8.11.0",
         "browserify": "^17.0.0",
         "css": "^3.0.0",
         "eslint": "^8.12.0",

--- a/test/test-dictionary.js
+++ b/test/test-dictionary.js
@@ -44,7 +44,7 @@ async function main() {
 
         let error = null;
         try {
-            await dictionaryValidate.validateDictionary(archive, schemas);
+            await dictionaryValidate.validateDictionary(null, archive, schemas);
         } catch (e) {
             error = e;
         }


### PR DESCRIPTION
This change makes `dictionary-validate.js` and `schema-validate.js` able to use https://ajv.js.org as a validator for testing.

This was originally mentioned in https://github.com/FooSoft/yomichan/pull/2129#issuecomment-1126785466:

> I don't know anything about JSON schema validation, and I haven't looked into how Yomichan does it or what engine it uses. My naive hope was that maybe Yomichan could be updated to use a faster validator ([ajv claims to be the fastest](https://github.com/ajv-validator/ajv)) and perhaps that would be enough to solve the problem.