### PR TITLE
Fix the color of links in display footer notifications

### DIFF
--- a/ext/css/display.css
+++ b/ext/css/display.css
@@ -1719,6 +1719,9 @@ button.footer-notification-close-button {
 .tag-details-disambiguation-list>.tag-details-disambiguation:not(:last-child)::after {
     content: var(--disambiguation-separator);
 }
+.footer-notification a {
+    color: var(--notification-text-color);
+}
 
 
 /* Overlays */


### PR DESCRIPTION
By default, links are blue on dark gray, which has poor contrast. This change updates links to be the same color as the text, keeping the underline.

Related: #2143 (shows a link in an error message)