### PR TITLE
Simplify assignment of _contentType = 'clear'

### DIFF
--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -637,8 +637,7 @@ class Display extends EventDispatcher {
                     this._setContentExtensionUnloaded();
                     break;
                 default:
-                    type = 'clear';
-                    this._contentType = type;
+                    this._contentType = 'clear';
                     this._clearContent();
                     break;
             }


### PR DESCRIPTION
`type` is not subsequently used, so omit it's assignment.