### PR TITLE
Add firefox-mv3 build target

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -267,6 +267,46 @@
                 "js/dom/simple-dom-parser.js",
                 "lib/parse5.js"
             ]
+        },
+        {
+            "name": "firefox-mv3",
+            "inherit": "firefox",
+            "fileName": "yomichan-firefox-mv3.xpi",
+            "modifications": [
+                {"action": "set",    "path": ["manifest_version"], "value": 3},
+                {"action": "set",    "path": ["browser_specific_settings", "gecko", "strict_min_version"], "value": "101.0"},
+                {"action": "move",   "path": ["browser_action"], "newPath": ["action"]},
+                {"action": "delete", "path": ["background", "persistent"]},
+                {"action": "move",   "path": ["content_security_policy"], "newPath": ["content_security_policy_old"]},
+                {"action": "set",    "path": ["content_security_policy"], "value": {}},
+                {"action": "move",   "path": ["content_security_policy_old"], "newPath": ["content_security_policy", "extension_pages"]},
+                {"action": "remove", "path": ["permissions"], "item": "<all_urls>"},
+                {"action": "add",    "path": ["permissions"], "items": ["scripting"]},
+                {"action": "set",    "path": ["host_permissions"], "value": ["<all_urls>"], "after": "optional_permissions"},
+                {"action": "remove", "path": ["optional_permissions"], "item": "webNavigation"},
+                {"action": "move",   "path": ["web_accessible_resources"], "newPath": ["web_accessible_resources_old"]},
+                {
+                    "action": "set",
+                    "path": ["web_accessible_resources"],
+                    "value": [
+                        {
+                            "resources": [],
+                            "matches": [
+                                "http://*/*",
+                                "https://*/*",
+                                "file://*/*"
+                            ]
+                        }
+                    ],
+                    "after": "web_accessible_resources_old"
+                },
+                {"action": "move",   "path": ["web_accessible_resources_old"], "newPath": ["web_accessible_resources", 0, "resources"]}
+            ],
+            "excludeFiles": [
+                "sw.js",
+                "js/dom/simple-dom-parser.js",
+                "lib/parse5.js"
+            ]
         }
     ]
 }


### PR DESCRIPTION
This is largely untested, other than that it is able to be loaded. Currently generates the following warning:

```
Reading manifest: Error processing content_security_policy.extension_pages: ‘script-src’ directive contains a forbidden 'unsafe-eval' keyword
```

https://blog.mozilla.org/addons/2022/05/18/manifest-v3-in-firefox-recap-next-steps/