### PR TITLE
Add an issues page with information about some errors

### DIFF
--- a/ext/info.html
+++ b/ext/info.html
@@ -48,7 +48,7 @@
                 <li>Information and downloadable dictionaries: <a href="https://foosoft.net/projects/yomichan/" rel="noreferrer noopener">Homepage</a></li>
                 <li>Support and source code: <a href="https://github.com/FooSoft/yomichan" rel="noreferrer noopener">Github</a></li>
                 <li>Release notes: <a href="https://github.com/FooSoft/yomichan/releases" rel="noreferrer noopener" data-href-format="https://github.com/FooSoft/yomichan/releases/tag/{version}" id="release-notes-this-version-link">This version</a> | <a href="https://github.com/FooSoft/yomichan/releases" rel="noreferrer noopener">All versions</a></li>
-                <li>More extension information: <a href="/permissions.html">Permissions</a> | <a href="/legal.html">Licenses</a></li>
+                <li>More extension information: <a href="/permissions.html">Permissions</a> | <a href="/legal.html">Licenses</a> | <a href="/issues.html">Issues</a></li>
             </ul>
         </div></div></div></div>
     </div>

--- a/ext/issues.html
+++ b/ext/issues.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1">
+    <title>Yomichan Issues</title>
+    <link rel="icon" type="image/png" href="/images/icon16.png" sizes="16x16">
+    <link rel="icon" type="image/png" href="/images/icon19.png" sizes="19x19">
+    <link rel="icon" type="image/png" href="/images/icon32.png" sizes="32x32">
+    <link rel="icon" type="image/png" href="/images/icon38.png" sizes="38x38">
+    <link rel="icon" type="image/png" href="/images/icon48.png" sizes="48x48">
+    <link rel="icon" type="image/png" href="/images/icon64.png" sizes="64x64">
+    <link rel="icon" type="image/png" href="/images/icon128.png" sizes="128x128">
+    <link rel="stylesheet" type="text/css" href="/css/material.css">
+    <link rel="stylesheet" type="text/css" href="/css/settings.css">
+</head>
+<body>
+
+<!-- Main content -->
+<div class="content-outer"><div class="content">
+<div class="content-left"></div>
+<div class="content-center">
+
+    <span tabindex="-1" id="content-scroll-focus"></span>
+
+    <h1>Yomichan Issues</h1>
+
+    <h2 id="audio-download-failed">Audio download failed due to possible extension permissions error <em>(Chrome)</em></h2>
+    <div class="settings-group">
+        <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
+            <p>
+                Depending on the extension's configuration, Yomichan can sometimes run into issues with
+                downloading audio files while creating Anki cards.
+                This may be due to a permissions issue where Yomichan hasn't been granted access to
+                the sites hosting the audio files.
+            </p>
+            <p>
+                Check the <em>Site access</em> section of the
+                <a tabindex="0" class="extension-settings-link" data-special-url="chrome://extensions/?id={id}">extension settings pages</a>
+                and grant the extension access to <em>all sites</em> or add the specific audio host URLs.
+            </p>
+        </div></div></div></div>
+    </div>
+
+    <div class="footer-padding"></div>
+
+</div>
+<div class="content-right"></div>
+</div></div>
+
+<!-- Scripts -->
+<script src="/js/dom/document-focus-controller.js"></script>
+<script src="/js/extension/environment.js"></script>
+<script src="/js/pages/common/extension-content-controller.js"></script>
+
+<script src="/js/pages/generic-page-main.js"></script>
+
+</body>
+</html>

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1909,7 +1909,10 @@ class Backend {
                         // The message logged to the console looks like this:
                         //  Access to fetch at '<URL>' from origin 'chrome-extension://<ID>' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
                         const result = new Error('Audio download failed due to possible extension permissions error');
-                        result.data = {errors};
+                        result.data = {
+                            errors,
+                            referenceUrl: '/issues.html'
+                        };
                         return result;
                     }
                 }

--- a/ext/js/display/display-generator.js
+++ b/ext/js/display/display-generator.js
@@ -220,7 +220,23 @@ class DisplayGenerator {
         for (const error of errors) {
             const div = document.createElement('li');
             div.className = 'anki-note-error-message';
-            this._setTextContent(div, isObject(error) && typeof error.message === 'string' ? error.message : `${error}`);
+            let message = isObject(error) && typeof error.message === 'string' ? error.message : `${error}`;
+            let link = null;
+            if (isObject(error) && isObject(error.data)) {
+                const {referenceUrl} = error.data;
+                if (typeof referenceUrl === 'string') {
+                    message = message.trimEnd();
+                    if (!/[.!?]^/.test()) { message += '.'; }
+                    message += ' ';
+                    link = document.createElement('a');
+                    link.href = referenceUrl;
+                    link.target = '_blank';
+                    link.rel = 'noreferrer noopener';
+                    link.textContent = 'More info';
+                }
+            }
+            this._setTextContent(div, message);
+            if (link !== null) { div.appendChild(link); }
             list.appendChild(div);
         }
 


### PR DESCRIPTION
Follow-up of #2161: this change adds an issues page which will be used to show more detailed information about errors Yomichan may encounter.

Also related to #2157.