### PR TITLE
Sort using number of definitions

### DIFF
--- a/ext/js/language/translator.js
+++ b/ext/js/language/translator.js
@@ -1402,6 +1402,10 @@ class Translator {
                 if (i !== 0) { return i; }
             }
 
+            // Sort by definition count
+            i = v2.definitions.length - v1.definitions.length;
+            if (i !== 0) { return i; }
+
             // Sort by dictionary order
             i = v1.dictionaryIndex - v2.dictionaryIndex;
             return i;


### PR DESCRIPTION
Improves sorting in situations where a dictionary entry has differing numbers of definitions with the same score. Entries with a larger number of definitions will take priority.

Resolves #2118.