### PR TITLE
Fix invalid default values for popupTheme and popupOuterTheme

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -215,12 +215,12 @@
                                     "popupTheme": {
                                         "type": "string",
                                         "enum": ["light", "dark", "browser"],
-                                        "default": "default"
+                                        "default": "light"
                                     },
                                     "popupOuterTheme": {
                                         "type": "string",
                                         "enum": ["light", "dark", "browser", "site"],
-                                        "default": "default"
+                                        "default": "light"
                                     },
                                     "customPopupCss": {
                                         "type": "string",

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -980,8 +980,17 @@ class OptionsUtil {
     _updateVersion20(options) {
         // Version 20 changes:
         //  Added anki.downloadTimeout.
+        //  Fixed general.popupTheme invalid default.
+        //  Fixed general.popupOuterTheme invalid default.
         for (const profile of options.profiles) {
             profile.options.anki.downloadTimeout = 0;
+            const {general} = profile.options;
+            if (general.popupTheme === 'default') {
+                general.popupTheme = 'light';
+            }
+            if (general.popupOuterTheme === 'default') {
+                general.popupOuterTheme = 'light';
+            }
         }
         return options;
     }


### PR DESCRIPTION
Bug introduced in [#2105](https://github.com/FooSoft/yomichan/pull/2105/files#diff-6d795e7332666b6973a3e802a98ed78cb8f7c0d248e8b47b46918a35a38797f7L215-R224).

* [x] TODO : This likely needs a options upgrade to safely handle this case.