### PR TITLE
Do not change selection if user selected text manually

### DIFF
--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -759,7 +759,7 @@ class TextScanner extends EventDispatcher {
             eventListenerInfos.push(...this._getMouseClickOnlyEventListeners2(capture));
         }
 
-        eventListenerInfos.push(this._getManualSelectionChangeByUserListener(capture));
+        eventListenerInfos.push(this._getManualSelectionChangeByUserListener());
 
         for (const args of eventListenerInfos) {
             this._eventListeners.addEventListener(...args);
@@ -822,13 +822,13 @@ class TextScanner extends EventDispatcher {
         return entries;
     }
 
-    _getManualSelectionChangeByUserListener(capture) {
+    _getManualSelectionChangeByUserListener() {
         const callback = () => {
             if (this._yomichanIsChangingTextSelectionNow) { return; }
             this._userHasNotSelectedAnythingManually = window.getSelection().isCollapsed;
         };
 
-        return [document, 'selectionchange', callback, capture];
+        return [document, 'selectionchange', callback];
     }
 
     _getTouch(touchList, identifier) {

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -144,6 +144,7 @@ class TextScanner extends EventDispatcher {
 
         if (value) {
             this._hookEvents();
+            this._userHasNotSelectedAnythingManually = window.getSelection().isCollapsed;
         }
     }
 

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -377,6 +377,11 @@ class TextScanner extends EventDispatcher {
         this._preventNextClickScan = true;
     }
 
+    _onSelectionChangeCheckUserSelection() {
+        if (this._yomichanIsChangingTextSelectionNow) { return; }
+        this._userHasNotSelectedAnythingManually = window.getSelection().isCollapsed;
+    }
+
     _onSearchClickMouseDown(e) {
         if (e.button !== 0) { return; }
         this._resetPreventNextClickScan();
@@ -760,7 +765,7 @@ class TextScanner extends EventDispatcher {
             eventListenerInfos.push(...this._getMouseClickOnlyEventListeners2(capture));
         }
 
-        eventListenerInfos.push(this._getManualSelectionChangeByUserListener());
+        eventListenerInfos.push(this._getSelectionChangeCheckUserSelectionListener());
 
         for (const args of eventListenerInfos) {
             this._eventListeners.addEventListener(...args);
@@ -823,13 +828,8 @@ class TextScanner extends EventDispatcher {
         return entries;
     }
 
-    _getManualSelectionChangeByUserListener() {
-        const callback = () => {
-            if (this._yomichanIsChangingTextSelectionNow) { return; }
-            this._userHasNotSelectedAnythingManually = window.getSelection().isCollapsed;
-        };
-
-        return [document, 'selectionchange', callback];
+    _getSelectionChangeCheckUserSelectionListener() {
+        return [document, 'selectionchange', this._onSelectionChangeCheckUserSelection.bind(this)];
     }
 
     _getTouch(touchList, identifier) {


### PR DESCRIPTION
While this works for me, please note that I have no idea what I am doing.
![image](https://user-images.githubusercontent.com/1710718/175561055-962b2dd9-f65c-4e44-86b0-c84b9656b951.png)
Particularly, I am not sure about the `setTimeout()` bit, and about all the possible edge cases. This also could be slightly optimized by only hooking `selectionchange` when select text is on, but the extra complexity is probably not worth it.

Closes #2071.