### PR TITLE
Optimize AnkiConnect.findNoteIds

### DIFF
--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -155,16 +155,7 @@ class AnkiConnect {
         await this._checkVersion();
         const actions = [];
         for (const note of notes) {
-            let query = '';
-            switch (this._getDuplicateScopeFromNote(note)) {
-                case 'deck':
-                    query = `"deck:${this._escapeQuery(note.deckName)}" `;
-                    break;
-                case 'deck-root':
-                    query = `"deck:${this._escapeQuery(AnkiUtil.getRootDeckName(note.deckName))}" `;
-                    break;
-            }
-            query += this._fieldsToQuery(note.fields);
+            const query = this._getNoteQuery(note);
             actions.push({action: 'findNotes', params: {query}});
         }
         return await this._invoke('multi', {actions});
@@ -314,5 +305,19 @@ class AnkiConnect {
             }
         }
         return null;
+    }
+
+    _getNoteQuery(note) {
+        let query = '';
+        switch (this._getDuplicateScopeFromNote(note)) {
+            case 'deck':
+                query = `"deck:${this._escapeQuery(note.deckName)}" `;
+                break;
+            case 'deck-root':
+                query = `"deck:${this._escapeQuery(AnkiUtil.getRootDeckName(note.deckName))}" `;
+                break;
+        }
+        query += this._fieldsToQuery(note.fields);
+        return query;
     }
 }

--- a/ext/js/comm/anki-connect.js
+++ b/ext/js/comm/anki-connect.js
@@ -153,7 +153,8 @@ class AnkiConnect {
     async findNoteIds(notes) {
         if (!this._enabled) { return []; }
         await this._checkVersion();
-        const actions = notes.map((note) => {
+        const actions = [];
+        for (const note of notes) {
             let query = '';
             switch (this._getDuplicateScopeFromNote(note)) {
                 case 'deck':
@@ -164,8 +165,8 @@ class AnkiConnect {
                     break;
             }
             query += this._fieldsToQuery(note.fields);
-            return {action: 'findNotes', params: {query}};
-        });
+            actions.push({action: 'findNotes', params: {query}});
+        }
         return await this._invoke('multi', {actions});
     }
 


### PR DESCRIPTION
This change updates `AnkiConnect.findNoteIds` to not run multiple of the same query. Instead, it will run the query only once and internally distribute the results into resulting array.

Addresses part of the issue mentioned in #2184.