### PR TITLE
Add new structured content styling options

### DIFF
--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -252,7 +252,6 @@
                 },
                 "fontSize": {
                     "type": "string",
-                    "enum": ["xx-small", "x-small", "small", "medium", "large", "x-large", "xx-large", "xxx-large"],
                     "default": "medium"
                 },
                 "textDecorationLine": {
@@ -276,6 +275,11 @@
                     "type": "string",
                     "enum": ["baseline", "sub", "super", "text-top", "text-bottom", "middle", "top", "bottom"],
                     "default": "baseline"
+                },
+                "textAlign": {
+                    "type": "string",
+                    "enum": ["start", "end", "left", "right", "center", "justify", "justify-all", "match-parent"],
+                    "default": "start"
                 },
                 "marginTop": {
                     "type": "number",

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -265,6 +265,7 @@ class StructuredContentGenerator {
             fontSize,
             textDecorationLine,
             verticalAlign,
+            textAlign,
             marginTop,
             marginLeft,
             marginRight,
@@ -275,6 +276,7 @@ class StructuredContentGenerator {
         if (typeof fontWeight === 'string') { style.fontWeight = fontWeight; }
         if (typeof fontSize === 'string') { style.fontSize = fontSize; }
         if (typeof verticalAlign === 'string') { style.verticalAlign = verticalAlign; }
+        if (typeof textAlign === 'string') { style.textAlign = textAlign; }
         if (typeof textDecorationLine === 'string') {
             style.textDecoration = textDecorationLine;
         } else if (Array.isArray(textDecorationLine)) {

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -83,9 +83,13 @@
                 {"tag": "div", "style": {"fontWeight": "bold"}, "content": "fontWeight:bold"},
                 {"tag": "div", "style": {"fontSize": "xx-small"}, "content": "fontSize:xx-small"},
                 {"tag": "div", "style": {"fontSize": "x-small"}, "content": "fontSize:x-small"},
+                {"tag": "div", "style": {"fontSize": "70%"}, "content": "fontSize:70%"},
+                {"tag": "div", "style": {"fontSize": "smaller"}, "content": "fontSize:smaller"},
                 {"tag": "div", "style": {"fontSize": "small"}, "content": "fontSize:small"},
                 {"tag": "div", "style": {"fontSize": "medium"}, "content": "fontSize:medium"},
                 {"tag": "div", "style": {"fontSize": "large"}, "content": "fontSize:large"},
+                {"tag": "div", "style": {"fontSize": "larger"}, "content": "fontSize:larger"},
+                {"tag": "div", "style": {"fontSize": "130%"}, "content": "fontSize:130%"},
                 {"tag": "div", "style": {"fontSize": "x-large"}, "content": "fontSize:x-large"},
                 {"tag": "div", "style": {"fontSize": "xx-large"}, "content": "fontSize:xx-large"},
                 {"tag": "div", "style": {"fontSize": "xxx-large"}, "content": "fontSize:xxx-large"},
@@ -137,6 +141,15 @@
                         ]},
                         {"tag": "tr", "content": [
                             {"tag": "td", "content": "Cell A4"}
+                        ]},
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "content": "Cell A5", "colSpan": 4, "style": {"textAlign": "left"}}
+                        ]},
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "content": "Cell A6", "colSpan": 4, "style": {"textAlign": "center"}}
+                        ]},
+                        {"tag": "tr", "content": [
+                            {"tag": "td", "content": "Cell A7", "colSpan": 4, "style": {"textAlign": "right"}}
                         ]}
                     ]},
                     {"tag": "tfoot", "content": [
@@ -230,8 +243,8 @@
                 {"tag": "ul", "content": [
                     {"tag": "li", "style": {"listStyleType": "'⇄'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["Antonym"]}, "】"]},
                     {"tag": "li", "style": {"listStyleType": "'🔄'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["References and is referenced by"]}, "】"]},
-                    {"tag": "li", "style": {"listStyleType": "'➡'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["References"]}, "】"]},
-                    {"tag": "li", "style": {"listStyleType": "'⬅'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["Referenced by"]}, "】"]}
+                    {"tag": "li", "style": {"listStyleType": "'➡️'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["References"]}, "】"]},
+                    {"tag": "li", "style": {"listStyleType": "'⬅️'"}, "content": ["【", {"tag": "a", "href": "?query=よみ&wildcards=off", "content": ["Referenced by"]}, "】"]}
                 ]}
             ]},
             {"type": "structured-content", "content": [


### PR DESCRIPTION
## Allow for arbitrary string assignment to the [font-size property](https://developer.mozilla.org/en-US/docs/Web/CSS/font-size).

Currently, only absolute font-size properties are allowed in styles specified by dictionaries. These font sizes do not scale when the popup scaling factor setting is adjusted in the "Popup Position & Size" section of the Yomichan settings. It would be useful if we could allow relative sizes (smaller, larger, 80%, etc.). I don't think there's any harm in allowing arbitrary strings in this field.

<details>
  <summary>Test dictionary in popup at 100% scale</summary>

![scale100](https://user-images.githubusercontent.com/8003332/179905981-536b8477-682a-4646-a43d-2a17de819853.png)
</details>
<details>
  <summary>Test dictionary in popup at 200% scale. The texts with absolute sizes remain the same.</summary>

![scale200](https://user-images.githubusercontent.com/8003332/179906108-cf9c6f81-a17c-4195-ad47-e2baa3d50120.png)
</details>
<details>
  <summary>Cross-reference summaries in my JMdict dictionary which use this property</summary>

![summaries](https://user-images.githubusercontent.com/8003332/179906210-1c77ee41-4d0e-41fa-8962-237df4ac1b4d.png)
</details>

## Add support for the [text-align property](https://developer.mozilla.org/en-US/docs/Web/CSS/text-align).

The text-align property is needed to center content in table cells. I'd like to use this functionality in my [new orthography dictionary](https://github.com/FooSoft/yomichan/issues/2183#issuecomment-1189670598).

<details>
  <summary>Test dictionary demonstrating the text-align property</summary>

![align](https://user-images.githubusercontent.com/8003332/179906684-2a86de2a-d364-45ea-94a8-e3dbbddd5542.png)
</details>

<details>
  <summary>Example from the orthography dictionary</summary>

![aligned](https://user-images.githubusercontent.com/8003332/179869261-bbbab7e4-7b39-4048-89ae-81db0856bf79.png)
</details>
