### PR TITLE
New StringUtil

### DIFF
--- a/dev/data/manifest-variants.json
+++ b/dev/data/manifest-variants.json
@@ -55,6 +55,7 @@
                     "js/comm/frame-ancestry-handler.js",
                     "js/comm/frame-client.js",
                     "js/comm/frame-offset-forwarder.js",
+                    "js/data/sandbox/string-util.js",
                     "js/dom/dom-text-scanner.js",
                     "js/dom/document-util.js",
                     "js/dom/text-source-element.js",

--- a/ext/js/data/sandbox/string-util.js
+++ b/ext/js/data/sandbox/string-util.js
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2022  Yomichan Authors
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+/**
+ * Class containing generic string utility functions.
+ */
+class StringUtil {
+    /**
+     * Reads code points from a string in the forward direction.
+     * @param {string} text The text to read the code points from.
+     * @param {number} position The index of the first character to read.
+     * @param {number} count The number of code points to read.
+     * @returns {string} The code points from the string.
+     */
+    static readCodePointsForward(text, position, count) {
+        let result = '';
+        for (; count > 0; --count) {
+            const char = text[position];
+            const charCode = char.charCodeAt(0);
+            result += char;
+            if (charCode >= 0xd800 && charCode < 0xdc00 && ++position < text.length) {
+                const char2 = text[position];
+                const charCode2 = char2.charCodeAt(0);
+                if (charCode2 >= 0xdc00 && charCode2 < 0xe000) {
+                    result += char2;
+                }
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Reads code points from a string in the backward direction.
+     * @param {string} text The text to read the code points from.
+     * @param {number} position The index of the first character to read.
+     * @param {number} count The number of code points to read.
+     * @returns {string} The code points from the string.
+     */
+    static readCodePointsBackward(text, position, count) {
+        let result = '';
+        for (; count > 0; --count) {
+            const char = text[position];
+            const charCode = char.charCodeAt(0);
+            result = char + result;
+            if (charCode >= 0xdc00 && charCode < 0xe000 && position > 0) {
+                const char2 = text[position - 1];
+                const charCode2 = char2.charCodeAt(0);
+                if (charCode2 >= 0xd800 && charCode2 < 0xdc00) {
+                    result = char2 + result;
+                }
+            }
+        }
+        return result;
+    }
+}

--- a/ext/js/dom/dom-text-scanner.js
+++ b/ext/js/dom/dom-text-scanner.js
@@ -15,6 +15,10 @@
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+/* global
+ * StringUtil
+ */
+
 /**
  * A class used to scan text in a document.
  */
@@ -146,44 +150,6 @@ class DOMTextScanner {
     // Private
 
     /**
-     * Reads a code point in a string in the forward direction.
-     * @param {string} text The text to read the code point from.
-     * @param {number} position The index of the first character to read.
-     * @returns {string} The code point from the string.
-     */
-    _readCodePointForward(text, position) {
-        let char = text[position];
-        const charCode = char.charCodeAt(0);
-        if (charCode >= 0xd800 && charCode < 0xdc00 && ++position < text.length) {
-            const char2 = text[position];
-            const charCode2 = char2.charCodeAt(0);
-            if (charCode2 >= 0xdc00 && charCode2 < 0xe000) {
-                char += char2;
-            }
-        }
-        return char;
-    }
-
-    /**
-     * Reads a code point in a string in the backward direction.
-     * @param {string} text The text to read the code point from.
-     * @param {number} position The index of the first character to read.
-     * @returns {string} The code point from the string.
-     */
-    _readCodePointBackward(text, position) {
-        let char = text[position];
-        const charCode = char.charCodeAt(0);
-        if (charCode >= 0xdc00 && charCode < 0xe000 && position > 0) {
-            const char2 = text[position - 1];
-            const charCode2 = char2.charCodeAt(0);
-            if (charCode2 >= 0xd800 && charCode2 < 0xdc00) {
-                char = char2 + char;
-            }
-        }
-        return char;
-    }
-
-    /**
      * Seeks forward in a text node.
      * @param {Text} textNode The text node to use.
      * @param {boolean} resetOffset Whether or not the text offset should be reset.
@@ -202,7 +168,7 @@ class DOMTextScanner {
         let newlines = this._newlines;
 
         while (offset < nodeValueLength) {
-            const char = this._readCodePointForward(nodeValue, offset);
+            const char = StringUtil.readCodePointsForward(nodeValue, offset, 1);
             offset += char.length;
             const charAttributes = DOMTextScanner.getCharacterAttributes(char, preserveNewlines, preserveWhitespace);
 
@@ -288,7 +254,7 @@ class DOMTextScanner {
         let newlines = this._newlines;
 
         while (offset > 0) {
-            const char = this._readCodePointBackward(nodeValue, offset - 1);
+            const char = StringUtil.readCodePointsBackward(nodeValue, offset - 1, 1);
             offset -= char.length;
             const charAttributes = DOMTextScanner.getCharacterAttributes(char, preserveNewlines, preserveWhitespace);
 

--- a/ext/manifest.json
+++ b/ext/manifest.json
@@ -54,6 +54,7 @@
                 "js/comm/frame-ancestry-handler.js",
                 "js/comm/frame-client.js",
                 "js/comm/frame-offset-forwarder.js",
+                "js/data/sandbox/string-util.js",
                 "js/dom/dom-text-scanner.js",
                 "js/dom/document-util.js",
                 "js/dom/text-source-element.js",

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -50,8 +50,8 @@
 <script src="/js/comm/frame-ancestry-handler.js"></script>
 <script src="/js/comm/frame-client.js"></script>
 <script src="/js/comm/frame-offset-forwarder.js"></script>
-<script src="/js/dom/document-util.js"></script>
 <script src="/js/data/sandbox/string-util.js"></script>
+<script src="/js/dom/document-util.js"></script>
 <script src="/js/dom/dom-text-scanner.js"></script>
 <script src="/js/dom/text-source-element.js"></script>
 <script src="/js/dom/text-source-range.js"></script>

--- a/ext/popup-preview.html
+++ b/ext/popup-preview.html
@@ -51,6 +51,7 @@
 <script src="/js/comm/frame-client.js"></script>
 <script src="/js/comm/frame-offset-forwarder.js"></script>
 <script src="/js/dom/document-util.js"></script>
+<script src="/js/data/sandbox/string-util.js"></script>
 <script src="/js/dom/dom-text-scanner.js"></script>
 <script src="/js/dom/text-source-element.js"></script>
 <script src="/js/dom/text-source-range.js"></script>

--- a/ext/popup.html
+++ b/ext/popup.html
@@ -104,6 +104,7 @@
 <script src="/js/data/anki-note-builder.js"></script>
 <script src="/js/data/anki-util.js"></script>
 <script src="/js/data/sandbox/array-buffer-util.js"></script>
+<script src="/js/data/sandbox/string-util.js"></script>
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>

--- a/ext/search.html
+++ b/ext/search.html
@@ -91,6 +91,7 @@
 <script src="/js/data/anki-note-builder.js"></script>
 <script src="/js/data/anki-util.js"></script>
 <script src="/js/data/sandbox/array-buffer-util.js"></script>
+<script src="/js/data/sandbox/string-util.js"></script>
 <script src="/js/display/display.js"></script>
 <script src="/js/display/display-anki.js"></script>
 <script src="/js/display/display-audio.js"></script>

--- a/test/test-document-util.js
+++ b/test/test-document-util.js
@@ -94,6 +94,7 @@ async function testDocument1() {
 
     const vm = new VM({document, window, Range, Node});
     vm.execute([
+        'js/data/sandbox/string-util.js',
         'js/dom/dom-text-scanner.js',
         'js/dom/text-source-range.js',
         'js/dom/text-source-element.js',

--- a/test/test-dom-text-scanner.js
+++ b/test/test-dom-text-scanner.js
@@ -166,7 +166,10 @@ async function testDocument1() {
         window.getComputedStyle = createAbsoluteGetComputedStyle(window);
 
         const vm = new VM({document, window, Range, Node});
-        vm.execute('js/dom/dom-text-scanner.js');
+        vm.execute([
+            'js/data/sandbox/string-util.js',
+            'js/dom/dom-text-scanner.js'
+        ]);
         const DOMTextScanner = vm.get('DOMTextScanner');
 
         await testDomTextScanner(dom, {DOMTextScanner});


### PR DESCRIPTION
Moves functions `readCodePointsForward` and `readCodePointsBackward` out of `DOMTextScanner` (#2213) and into a new `StringUtil` class so they can be reused.