### PR TITLE
Exclude documentElement from zoom calculation

### DIFF
--- a/ext/data/schemas/options-schema.json
+++ b/ext/data/schemas/options-schema.json
@@ -438,7 +438,8 @@
                                     "layoutAwareScan",
                                     "matchTypePrefix",
                                     "hidePopupOnCursorExit",
-                                    "hidePopupOnCursorExitDelay"
+                                    "hidePopupOnCursorExitDelay",
+                                    "normalizeCssZoom"
                                 ],
                                 "properties": {
                                     "inputs": {
@@ -706,6 +707,10 @@
                                         "type": "number",
                                         "minimum": 0,
                                         "default": 0
+                                    },
+                                    "normalizeCssZoom": {
+                                        "type": "boolean",
+                                        "default": true
                                     }
                                 }
                             },

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -395,6 +395,7 @@ class Frontend {
         this._textScanner.setOptions({
             inputs: scanningOptions.inputs,
             deepContentScan: scanningOptions.deepDomScan,
+            normalizeCssZoom: scanningOptions.normalizeCssZoom,
             selectText: scanningOptions.selectText,
             delay: scanningOptions.delay,
             touchInputEnabled: scanningOptions.touchInputEnabled,

--- a/ext/js/app/popup.js
+++ b/ext/js/app/popup.js
@@ -680,12 +680,12 @@ class Popup extends EventDispatcher {
      * @returns {SizeRect} The calculated rectangle for where to position the popup.
      */
     _getPosition(sourceRects, writingMode, viewport) {
-        const scale = this._contentScale;
-        const scaleRatio = this._frameSizeContentScale === null ? 1.0 : scale / this._frameSizeContentScale;
-        this._frameSizeContentScale = scale;
+        const contentScale = this._contentScale;
+        const scaleRatio = this._frameSizeContentScale === null ? 1.0 : contentScale / this._frameSizeContentScale;
+        this._frameSizeContentScale = contentScale;
         const frameRect = this._frame.getBoundingClientRect();
-        const frameWidth = Math.max(frameRect.width * scaleRatio, this._initialWidth * scale);
-        const frameHeight = Math.max(frameRect.height * scaleRatio, this._initialHeight * scale);
+        const frameWidth = Math.max(frameRect.width * scaleRatio, this._initialWidth * contentScale);
+        const frameHeight = Math.max(frameRect.height * scaleRatio, this._initialHeight * contentScale);
 
         const horizontal = (writingMode === 'horizontal-tb' || this._verticalTextPosition === 'default');
         let preferAfter;
@@ -700,8 +700,8 @@ class Popup extends EventDispatcher {
             horizontalOffset = this._horizontalOffset2;
             verticalOffset = this._verticalOffset2;
         }
-        horizontalOffset *= scale;
-        verticalOffset *= scale;
+        horizontalOffset *= contentScale;
+        verticalOffset *= contentScale;
 
         let best = null;
         const sourceRectsLength = sourceRects.length;

--- a/ext/js/data/options-util.js
+++ b/ext/js/data/options-util.js
@@ -980,10 +980,12 @@ class OptionsUtil {
     _updateVersion20(options) {
         // Version 20 changes:
         //  Added anki.downloadTimeout.
+        //  Added scanning.normalizeCssZoom.
         //  Fixed general.popupTheme invalid default.
         //  Fixed general.popupOuterTheme invalid default.
         for (const profile of options.profiles) {
             profile.options.anki.downloadTimeout = 0;
+            profile.options.scanning.normalizeCssZoom = true;
             const {general} = profile.options;
             if (general.popupTheme === 'default') {
                 general.popupTheme = 'light';

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -367,6 +367,7 @@ class Display extends EventDispatcher {
             scanning: {
                 inputs: scanningOptions.inputs,
                 deepContentScan: scanningOptions.deepDomScan,
+                normalizeCssZoom: scanningOptions.normalizeCssZoom,
                 selectText: scanningOptions.selectText,
                 delay: scanningOptions.delay,
                 touchInputEnabled: scanningOptions.touchInputEnabled,
@@ -1532,6 +1533,7 @@ class Display extends EventDispatcher {
                 }
             }],
             deepContentScan: scanningOptions.deepDomScan,
+            normalizeCssZoom: scanningOptions.normalizeCssZoom,
             selectText: false,
             delay: scanningOptions.delay,
             touchInputEnabled: false,

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -27,7 +27,7 @@ class DocumentUtil {
         this._cssZoomSupported = (typeof document.createElement('div').style.zoom === 'string');
     }
 
-    getRangeFromPoint(x, y, deepContentScan) {
+    getRangeFromPoint(x, y, {deepContentScan, normalizeCssZoom}) {
         const elements = this._getElementsFromPoint(x, y, deepContentScan);
         let imposter = null;
         let imposterContainer = null;
@@ -52,7 +52,7 @@ class DocumentUtil {
             }
         }
 
-        const range = this._caretRangeFromPointExt(x, y, deepContentScan ? elements : []);
+        const range = this._caretRangeFromPointExt(x, y, deepContentScan ? elements : [], normalizeCssZoom);
         if (range !== null) {
             if (imposter !== null) {
                 this._setImposterStyle(imposterContainer.style, 'z-index', '-2147483646');
@@ -435,7 +435,7 @@ class DocumentUtil {
         return e !== null ? [e] : [];
     }
 
-    _isPointInRange(x, y, range) {
+    _isPointInRange(x, y, range, normalizeCssZoom) {
         // Require a text node to start
         const {startContainer} = range;
         if (startContainer.nodeType !== Node.TEXT_NODE) {
@@ -443,7 +443,7 @@ class DocumentUtil {
         }
 
         // Convert CSS zoom coordinates
-        if (this._cssZoomSupported) {
+        if (this._cssZoomSupported && normalizeCssZoom) {
             ({x, y} = this._convertCssZoomCoordinates(x, y, startContainer));
         }
 
@@ -583,7 +583,7 @@ class DocumentUtil {
         }
     }
 
-    _caretRangeFromPointExt(x, y, elements) {
+    _caretRangeFromPointExt(x, y, elements, normalizeCssZoom) {
         let previousStyles = null;
         try {
             let i = 0;
@@ -596,7 +596,7 @@ class DocumentUtil {
 
                 const startContainer = range.startContainer;
                 if (startContinerPre !== startContainer) {
-                    if (this._isPointInRange(x, y, range)) {
+                    if (this._isPointInRange(x, y, range, normalizeCssZoom)) {
                         return range;
                     }
                     startContinerPre = startContainer;

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -670,8 +670,14 @@ class DocumentUtil {
     }
 
     _convertCssZoomCoordinates(x, y, node) {
+        // documentElement must be excluded because the computer style of its zoom property is inconsistent.
+        // * If CSS `:root{zoom:X;}` is specified, the computed zoom will always report `X`.
+        // * If CSS `:root{zoom:X;}` is not specified, the computed zoom report the browser's zoom level.
+        // Therefor, if CSS root zoom is specified as a value other than 1, the adjusted {x, y} values
+        // would be incorrect, which is not new behaviour.
         const ELEMENT_NODE = Node.ELEMENT_NODE;
-        for (; node !== null; node = node.parentNode) {
+        const {documentElement} = document;
+        for (; node !== null && node !== documentElement; node = node.parentNode) {
             if (node.nodeType !== ELEMENT_NODE) { continue; }
             let {zoom} = getComputedStyle(node);
             if (typeof zoom !== 'string') { continue; }

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -191,10 +191,19 @@ class DocumentUtil {
         // Therefor, if CSS root zoom is specified as a value other than 1, the adjusted {x, y} values
         // would be incorrect, which is not new behaviour.
         let scale = 1;
-        const ELEMENT_NODE = Node.ELEMENT_NODE;
+        const {ELEMENT_NODE, DOCUMENT_FRAGMENT_NODE} = Node;
         const {documentElement} = document;
         for (; node !== null && node !== documentElement; node = node.parentNode) {
-            if (node.nodeType !== ELEMENT_NODE) { continue; }
+            const {nodeType} = node;
+            if (nodeType === DOCUMENT_FRAGMENT_NODE) {
+                const {host} = node;
+                if (typeof host !== 'undefined') {
+                    node = host;
+                }
+                continue;
+            } else if (nodeType !== ELEMENT_NODE) {
+                continue;
+            }
             let {zoom} = getComputedStyle(node);
             if (typeof zoom !== 'string') { continue; }
             zoom = Number.parseFloat(zoom);

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -16,6 +16,7 @@
  */
 
 /* global
+ * DocumentUtil
  * StringUtil
  */
 
@@ -95,11 +96,11 @@ class TextSourceElement {
     }
 
     getRect() {
-        return this._element.getBoundingClientRect();
+        return DocumentUtil.convertRectZoomCoordinates(this._element.getBoundingClientRect(), this._element);
     }
 
     getRects() {
-        return this._element.getClientRects();
+        return DocumentUtil.convertMultipleRectZoomCoordinates(this._element.getClientRects(), this._element);
     }
 
     getWritingMode() {

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -91,11 +91,11 @@ class TextSourceRange {
     }
 
     getRect() {
-        return this._range.getBoundingClientRect();
+        return DocumentUtil.convertRectZoomCoordinates(this._range.getBoundingClientRect(), this._range.startContainer);
     }
 
     getRects() {
-        return this._range.getClientRects();
+        return DocumentUtil.convertMultipleRectZoomCoordinates(this._range.getClientRects(), this._range.startContainer);
     }
 
     getWritingMode() {

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -54,6 +54,7 @@ class TextScanner extends EventDispatcher {
         this._selectionRestoreInfo = null;
 
         this._deepContentScan = false;
+        this._normalizeCssZoom = true;
         this._selectText = false;
         this._delay = 0;
         this._touchInputEnabled = false;
@@ -151,6 +152,7 @@ class TextScanner extends EventDispatcher {
     setOptions({
         inputs,
         deepContentScan,
+        normalizeCssZoom,
         selectText,
         delay,
         touchInputEnabled,
@@ -166,6 +168,9 @@ class TextScanner extends EventDispatcher {
         }
         if (typeof deepContentScan === 'boolean') {
             this._deepContentScan = deepContentScan;
+        }
+        if (typeof normalizeCssZoom === 'boolean') {
+            this._normalizeCssZoom = normalizeCssZoom;
         }
         if (typeof selectText === 'boolean') {
             this._selectText = selectText;
@@ -932,7 +937,10 @@ class TextScanner extends EventDispatcher {
                 return;
             }
 
-            const textSource = this._documentUtil.getRangeFromPoint(x, y, this._deepContentScan);
+            const textSource = this._documentUtil.getRangeFromPoint(x, y, {
+                deepContentScan: this._deepContentScan,
+                normalizeCssZoom: this._normalizeCssZoom
+            });
             try {
                 await this._search(textSource, searchTerms, searchKanji, inputInfo);
             } finally {

--- a/ext/settings.html
+++ b/ext/settings.html
@@ -514,6 +514,34 @@
         <div class="settings-item advanced-only">
             <div class="settings-item-inner">
                 <div class="settings-item-left">
+                    <div class="settings-item-label">Normalize CSS zoom</div>
+                    <div class="settings-item-description">
+                        Correct the pointer location on webpages where CSS <code>zoom</code> is used.
+                        <a tabindex="0" class="more-toggle more-only" data-parent-distance="4">More&hellip;</a>
+                    </div>
+                </div>
+                <div class="settings-item-right">
+                    <label class="toggle"><input type="checkbox" data-setting="scanning.normalizeCssZoom"><span class="toggle-body"><span class="toggle-track"></span><span class="toggle-knob"></span></span></label>
+                </div>
+            </div>
+            <div class="settings-item-children more" hidden>
+                <p>
+                    The non-standard CSS <a href="https://developer.mozilla.org/en-US/docs/Web/CSS/zoom" target="_blank" rel="noopener noreferrer"><code>zoom</code></a> property interferes with the normal calculation of the pointer coordinates when scanning webpages. This property is discouraged from being used and its use is rare, but some webpages may still use it.
+                </p>
+                <p>
+                    Enabling this option, which is on by default, will take the value of this property into account when scanning webpage content. It is currently put behind an option in case there are unforeseen negative side effects.
+                </p>
+                <p>
+                    This setting does not have any effect in Firefox, as it does not implement the <code>zoom</code> property.
+                </p>
+                <p>
+                    <a tabindex="0" class="more-toggle" data-parent-distance="3">Less&hellip;</a>
+                </p>
+            </div>
+        </div>
+        <div class="settings-item advanced-only">
+            <div class="settings-item-inner">
+                <div class="settings-item-left">
                     <div class="settings-item-label">Wildcard scanning</div>
                     <div class="settings-item-description">
                         Enable suffix wildcard when looking up scanned webpage text.

--- a/test/test-document-util.js
+++ b/test/test-document-util.js
@@ -167,7 +167,10 @@ async function testDocumentTextScanningFunctions(dom, {DocumentUtil, TextSourceR
 
         // Test docRangeFromPoint
         const documentUtil = new DocumentUtil();
-        const source = documentUtil.getRangeFromPoint(0, 0, false);
+        const source = documentUtil.getRangeFromPoint(0, 0, {
+            deepContentScan: false,
+            normalizeCssZoom: true
+        });
         switch (resultType) {
             case 'TextSourceRange':
                 assert.strictEqual(getPrototypeOfOrNull(source), TextSourceRange.prototype);

--- a/test/test-options-util.js
+++ b/test/test-options-util.js
@@ -347,6 +347,7 @@ function createProfileOptionsUpdatedTestData1() {
             matchTypePrefix: false,
             hidePopupOnCursorExit: false,
             hidePopupOnCursorExitDelay: 0,
+            normalizeCssZoom: true,
             preventMiddleMouse: {
                 onWebPages: false,
                 onPopupPages: false,


### PR DESCRIPTION
The `documentElement`'s computed `zoom` property is inconsistently reported depending on whether it's assigned in CSS and the browser's zoom level.

Related: https://github.com/FooSoft/yomichan/issues/2226#issuecomment-1242971135