### PR TITLE
DocumentUtil static

### DIFF
--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -73,13 +73,11 @@ class Frontend {
         this._pageZoomFactor = 1.0;
         this._contentScale = 1.0;
         this._lastShowPromise = Promise.resolve();
-        this._documentUtil = new DocumentUtil();
         this._textScanner = new TextScanner({
             node: window,
             ignoreElements: this._ignoreElements.bind(this),
             ignorePoint: this._ignorePoint.bind(this),
             getSearchContext: this._getSearchContext.bind(this),
-            documentUtil: this._documentUtil,
             searchTerms: true,
             searchKanji: true
         });

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -20,7 +20,6 @@
  * DisplayGenerator
  * DisplayHistory
  * DisplayNotification
- * DocumentUtil
  * ElementOverflowController
  * FrameEndpoint
  * Frontend

--- a/ext/js/display/display.js
+++ b/ext/js/display/display.js
@@ -121,7 +121,6 @@ class Display extends EventDispatcher {
         this._query = '';
         this._fullQuery = '';
         this._queryOffset = 0;
-        this._documentUtil = new DocumentUtil();
         this._progressIndicator = document.querySelector('#progress-indicator');
         this._progressIndicatorTimer = null;
         this._progressIndicatorVisible = new DynamicProperty(false);
@@ -130,7 +129,6 @@ class Display extends EventDispatcher {
         this._queryParserContainer = document.querySelector('#query-parser-container');
         this._queryParser = new QueryParser({
             getSearchContext: this._getSearchContext.bind(this),
-            documentUtil: this._documentUtil,
             japaneseUtil
         });
         this._contentScrollElement = document.querySelector('#content-scroll');
@@ -1498,7 +1496,6 @@ class Display extends EventDispatcher {
             this._contentTextScanner = new TextScanner({
                 node: window,
                 getSearchContext: this._getSearchContext.bind(this),
-                documentUtil: this._documentUtil,
                 searchTerms: true,
                 searchKanji: false,
                 searchOnClick: true,

--- a/ext/js/display/query-parser.js
+++ b/ext/js/display/query-parser.js
@@ -20,10 +20,9 @@
  */
 
 class QueryParser extends EventDispatcher {
-    constructor({getSearchContext, documentUtil, japaneseUtil}) {
+    constructor({getSearchContext, japaneseUtil}) {
         super();
         this._getSearchContext = getSearchContext;
-        this._documentUtil = documentUtil;
         this._japaneseUtil = japaneseUtil;
         this._text = '';
         this._setTextToken = null;
@@ -39,7 +38,6 @@ class QueryParser extends EventDispatcher {
         this._textScanner = new TextScanner({
             node: this._queryParser,
             getSearchContext,
-            documentUtil,
             searchTerms: true,
             searchKanji: false,
             searchOnClick: true

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -22,11 +22,11 @@
  */
 
 class DocumentUtil {
-    constructor() {
-        this._transparentColorPattern = /rgba\s*\([^)]*,\s*0(?:\.0+)?\s*\)/;
-    }
+    getRangeFromPoint(...args) { return DocumentUtil.getRangeFromPoint(...args); }
 
-    getRangeFromPoint(x, y, {deepContentScan, normalizeCssZoom}) {
+    extractSentence(...args) { return DocumentUtil.extractSentence(...args); }
+
+    static getRangeFromPoint(x, y, {deepContentScan, normalizeCssZoom}) {
         const elements = this._getElementsFromPoint(x, y, deepContentScan);
         let imposter = null;
         let imposterContainer = null;
@@ -90,7 +90,7 @@ class DocumentUtil {
      *   ```
      * @returns {{sentence: string, offset: number}} The sentence and the offset to the original source.
      */
-    extractSentence(source, layoutAwareScan, extent, terminateAtNewlines, terminatorMap, forwardQuoteMap, backwardQuoteMap) {
+    static extractSentence(source, layoutAwareScan, extent, terminateAtNewlines, terminatorMap, forwardQuoteMap, backwardQuoteMap) {
         // Scan text
         source = source.clone();
         const startLength = source.setStartOffset(extent, layoutAwareScan);
@@ -397,11 +397,11 @@ class DocumentUtil {
         }
     }
 
-    _setImposterStyle(style, propertyName, value) {
+    static _setImposterStyle(style, propertyName, value) {
         style.setProperty(propertyName, value, 'important');
     }
 
-    _createImposter(element, isTextarea) {
+    static _createImposter(element, isTextarea) {
         const body = document.body;
         if (body === null) { return [null, null]; }
 
@@ -477,7 +477,7 @@ class DocumentUtil {
         return [imposter, container];
     }
 
-    _getElementsFromPoint(x, y, all) {
+    static _getElementsFromPoint(x, y, all) {
         if (all) {
             // document.elementsFromPoint can return duplicates which must be removed.
             const elements = document.elementsFromPoint(x, y);
@@ -488,7 +488,7 @@ class DocumentUtil {
         return e !== null ? [e] : [];
     }
 
-    _isPointInRange(x, y, range, normalizeCssZoom) {
+    static _isPointInRange(x, y, range, normalizeCssZoom) {
         // Require a text node to start
         const {startContainer} = range;
         if (startContainer.nodeType !== Node.TEXT_NODE) {
@@ -530,11 +530,11 @@ class DocumentUtil {
         return false;
     }
 
-    _isWhitespace(string) {
+    static _isWhitespace(string) {
         return string.trim().length === 0;
     }
 
-    _caretRangeFromPoint(x, y) {
+    static _caretRangeFromPoint(x, y) {
         if (typeof document.caretRangeFromPoint === 'function') {
             // Chrome, Edge
             return document.caretRangeFromPoint(x, y);
@@ -549,7 +549,7 @@ class DocumentUtil {
         return null;
     }
 
-    _caretPositionFromPoint(x, y) {
+    static _caretPositionFromPoint(x, y) {
         const position = document.caretPositionFromPoint(x, y);
         if (position === null) {
             return null;
@@ -586,7 +586,7 @@ class DocumentUtil {
         }
     }
 
-    _caretPositionFromPointNormalizeStyles(x, y, nextElement) {
+    static _caretPositionFromPointNormalizeStyles(x, y, nextElement) {
         const previousStyles = new Map();
         try {
             while (true) {
@@ -638,7 +638,7 @@ class DocumentUtil {
         }
     }
 
-    _caretRangeFromPointExt(x, y, elements, normalizeCssZoom) {
+    static _caretRangeFromPointExt(x, y, elements, normalizeCssZoom) {
         let previousStyles = null;
         try {
             let i = 0;
@@ -670,7 +670,7 @@ class DocumentUtil {
         }
     }
 
-    _disableTransparentElement(elements, i, previousStyles) {
+    static _disableTransparentElement(elements, i, previousStyles) {
         while (true) {
             if (i >= elements.length) {
                 return -1;
@@ -685,13 +685,13 @@ class DocumentUtil {
         }
     }
 
-    _recordPreviousStyle(previousStyles, element) {
+    static _recordPreviousStyle(previousStyles, element) {
         if (previousStyles.has(element)) { return; }
         const style = element.hasAttribute('style') ? element.getAttribute('style') : null;
         previousStyles.set(element, style);
     }
 
-    _revertStyles(previousStyles) {
+    static _revertStyles(previousStyles) {
         for (const [element, style] of previousStyles.entries()) {
             if (style === null) {
                 element.removeAttribute('style');
@@ -701,7 +701,7 @@ class DocumentUtil {
         }
     }
 
-    _isElementTransparent(element) {
+    static _isElementTransparent(element) {
         if (
             element === document.body ||
             element === document.documentElement
@@ -716,13 +716,15 @@ class DocumentUtil {
         );
     }
 
-    _isColorTransparent(cssColor) {
+    static _isColorTransparent(cssColor) {
         return this._transparentColorPattern.test(cssColor);
     }
 
-    _isElementUserSelectAll(element) {
+    static _isElementUserSelectAll(element) {
         return getComputedStyle(element).userSelect === 'all';
     }
 }
+// eslint-disable-next-line no-underscore-dangle
+DocumentUtil._transparentColorPattern = /rgba\s*\([^)]*,\s*0(?:\.0+)?\s*\)/;
 // eslint-disable-next-line no-underscore-dangle
 DocumentUtil._cssZoomSupported = null;

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -22,10 +22,6 @@
  */
 
 class DocumentUtil {
-    getRangeFromPoint(...args) { return DocumentUtil.getRangeFromPoint(...args); }
-
-    extractSentence(...args) { return DocumentUtil.extractSentence(...args); }
-
     static getRangeFromPoint(x, y, {deepContentScan, normalizeCssZoom}) {
         const elements = this._getElementsFromPoint(x, y, deepContentScan);
         let imposter = null;

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -497,7 +497,7 @@ class DocumentUtil {
 
         // Convert CSS zoom coordinates
         if (normalizeCssZoom) {
-            const scale = DocumentUtil.computeZoomScale(startContainer);
+            const scale = this.computeZoomScale(startContainer);
             x /= scale;
             y /= scale;
         }
@@ -509,7 +509,7 @@ class DocumentUtil {
             const {node, offset, content} = new DOMTextScanner(nodePre, offsetPre, true, false).seek(1);
             range.setEnd(node, offset);
 
-            if (!this._isWhitespace(content) && DocumentUtil.isPointInAnyRect(x, y, range.getClientRects())) {
+            if (!this._isWhitespace(content) && this.isPointInAnyRect(x, y, range.getClientRects())) {
                 return true;
             }
         } finally {
@@ -520,7 +520,7 @@ class DocumentUtil {
         const {node, offset, content} = new DOMTextScanner(startContainer, range.startOffset, true, false).seek(-1);
         range.setStart(node, offset);
 
-        if (!this._isWhitespace(content) && DocumentUtil.isPointInAnyRect(x, y, range.getClientRects())) {
+        if (!this._isWhitespace(content) && this.isPointInAnyRect(x, y, range.getClientRects())) {
             // This purposefully leaves the starting offset as modified and sets the range length to 0.
             range.setEnd(node, offset);
             return true;

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -22,7 +22,6 @@
 class TextScanner extends EventDispatcher {
     constructor({
         node,
-        documentUtil,
         getSearchContext,
         ignoreElements=null,
         ignorePoint=null,
@@ -33,7 +32,6 @@ class TextScanner extends EventDispatcher {
     }) {
         super();
         this._node = node;
-        this._documentUtil = documentUtil;
         this._getSearchContext = getSearchContext;
         this._ignoreElements = ignoreElements;
         this._ignorePoint = ignorePoint;
@@ -878,7 +876,7 @@ class TextScanner extends EventDispatcher {
         if (dictionaryEntries.length === 0) { return null; }
 
         textSource.setEndOffset(originalTextLength, layoutAwareScan, false);
-        const sentence = this._documentUtil.extractSentence(
+        const sentence = DocumentUtil.extractSentence(
             textSource,
             layoutAwareScan,
             sentenceScanExtent,
@@ -905,7 +903,7 @@ class TextScanner extends EventDispatcher {
         if (dictionaryEntries.length === 0) { return null; }
 
         textSource.setEndOffset(1, layoutAwareScan, false);
-        const sentence = this._documentUtil.extractSentence(
+        const sentence = DocumentUtil.extractSentence(
             textSource,
             layoutAwareScan,
             sentenceScanExtent,
@@ -937,7 +935,7 @@ class TextScanner extends EventDispatcher {
                 return;
             }
 
-            const textSource = this._documentUtil.getRangeFromPoint(x, y, {
+            const textSource = DocumentUtil.getRangeFromPoint(x, y, {
                 deepContentScan: this._deepContentScan,
                 normalizeCssZoom: this._normalizeCssZoom
             });

--- a/test/test-document-util.js
+++ b/test/test-document-util.js
@@ -166,8 +166,7 @@ async function testDocumentTextScanningFunctions(dom, {DocumentUtil, TextSourceR
         };
 
         // Test docRangeFromPoint
-        const documentUtil = new DocumentUtil();
-        const source = documentUtil.getRangeFromPoint(0, 0, {
+        const source = DocumentUtil.getRangeFromPoint(0, 0, {
             deepContentScan: false,
             normalizeCssZoom: true
         });
@@ -202,7 +201,7 @@ async function testDocumentTextScanningFunctions(dom, {DocumentUtil, TextSourceR
         }
 
         // Test docSentenceExtract
-        const sentenceActual = documentUtil.extractSentence(
+        const sentenceActual = DocumentUtil.extractSentence(
             source,
             false,
             sentenceScanExtent,


### PR DESCRIPTION
This change updates `DocumentUtil` to be entirely a static utility class. The reason that this was originally non-static was due to the use of its `_transparentColorPattern` field, which was stored to cache the regex. However, this can just as easily be assigned to the class itself for the same functionality. This simplifies the class API quite a bit and will no longer require instantiating and sharing instances across various classes.