### PR TITLE
API loadExtensionScripts

### DIFF
--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -130,7 +130,8 @@ class Backend {
             ['testMecab',                    {async: true,  contentScript: true,  handler: this._onApiTestMecab.bind(this)}],
             ['textHasJapaneseCharacters',    {async: false, contentScript: true,  handler: this._onApiTextHasJapaneseCharacters.bind(this)}],
             ['getTermFrequencies',           {async: true,  contentScript: true,  handler: this._onApiGetTermFrequencies.bind(this)}],
-            ['findAnkiNotes',                {async: true,  contentScript: true,  handler: this._onApiFindAnkiNotes.bind(this)}]
+            ['findAnkiNotes',                {async: true,  contentScript: true,  handler: this._onApiFindAnkiNotes.bind(this)}],
+            ['loadExtensionScripts',         {async: true,  contentScript: true,  handler: this._onApiLoadExtensionScripts.bind(this)}]
         ]);
         this._messageHandlersWithProgress = new Map([
         ]);
@@ -769,6 +770,16 @@ class Backend {
 
     async _onApiFindAnkiNotes({query}) {
         return await this._anki.findNotes(query);
+    }
+
+    async _onApiLoadExtensionScripts({files}, sender) {
+        if (!sender || !sender.tab) { throw new Error('Invalid sender'); }
+        const tabId = sender.tab.id;
+        if (typeof tabId !== 'number') { throw new Error('Sender has invalid tab ID'); }
+        const {frameId} = sender;
+        for (const file of files) {
+            await this._scriptManager.injectScript(file, tabId, frameId, false, true, 'document_start');
+        }
     }
 
     // Command handlers

--- a/ext/js/background/script-manager.js
+++ b/ext/js/background/script-manager.js
@@ -290,6 +290,7 @@ class ScriptManager {
     _injectScriptMV3(file, tabId, frameId, allFrames) {
         return new Promise((resolve, reject) => {
             const details = {
+                injectImmediately: true,
                 files: [file],
                 target: {tabId, allFrames}
             };

--- a/ext/js/comm/api.js
+++ b/ext/js/comm/api.js
@@ -176,6 +176,10 @@ class API {
         return this._invoke('findAnkiNotes', {query});
     }
 
+    loadExtensionScripts(files) {
+        return this._invoke('loadExtensionScripts', {files});
+    }
+
     // Utilities
 
     _createActionPort(timeout=5000) {


### PR DESCRIPTION
This change adds a new `loadExtensionScripts` API function, which can be used to dynamically load more extension scripts, such as content scripts, which shouldn't be loaded using `<script>` tags.