### PR TITLE
TextSource* API updates

### DIFF
--- a/ext/js/accessibility/google-docs-util.js
+++ b/ext/js/accessibility/google-docs-util.js
@@ -110,7 +110,7 @@ class GoogleDocsUtil {
             }
         }
         range.setStart(textNode, start);
-        range.setEnd(textNode, end);
+        range.setEnd(textNode, start);
         return range;
     }
 

--- a/ext/js/accessibility/google-docs-util.js
+++ b/ext/js/accessibility/google-docs-util.js
@@ -87,7 +87,7 @@ class GoogleDocsUtil {
         const range = this._getRangeWithPoint(content, x, y, normalizeCssZoom);
         this._setImportantStyle(textStyle, 'pointer-events', 'none');
         this._setImportantStyle(textStyle, 'opacity', '0');
-        return new TextSourceRange(range, '', svgText, element);
+        return TextSourceRange.createFromImposter(range, svgText, element);
     }
 
     static _getRangeWithPoint(textNode, x, y, normalizeCssZoom) {

--- a/ext/js/app/frontend.js
+++ b/ext/js/app/frontend.js
@@ -757,7 +757,7 @@ class Frontend {
     async _scanSelectedText(allowEmptyRange) {
         const range = this._getFirstSelectionRange(allowEmptyRange);
         if (range === null) { return false; }
-        const source = new TextSourceRange(range, range.toString(), null, null);
+        const source = TextSourceRange.create(range);
         await this._textScanner.search(source, {focus: true, restoreSelection: true});
         return true;
     }

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -66,7 +66,7 @@ class DocumentUtil {
                 case 'IMG':
                 case 'BUTTON':
                 case 'SELECT':
-                    return new TextSourceElement(element);
+                    return TextSourceElement.create(element);
                 case 'INPUT':
                     if (element.type === 'text') {
                         imposterSourceElement = element;

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -132,7 +132,7 @@ class DocumentUtil {
         // Scan text
         source = source.clone();
         const startLength = source.setStartOffset(extent, layoutAwareScan);
-        const endLength = source.setEndOffset(extent * 2 - startLength, layoutAwareScan, true);
+        const endLength = source.setEndOffset(extent * 2 - startLength, true, layoutAwareScan);
         const text = source.text();
         const textLength = text.length;
         const textEndAnchor = textLength - endLength;

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -418,6 +418,43 @@ class DocumentUtil {
         }
     }
 
+    /**
+     * Gets the parent writing mode of an element.
+     * See: https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode.
+     * @param {Element} element The HTML element to check.
+     * @returns {string} The writing mode.
+     */
+    static getElementWritingMode(element) {
+        if (element !== null) {
+            const {writingMode} = getComputedStyle(element);
+            if (typeof writingMode === 'string') {
+                return this.normalizeWritingMode(writingMode);
+            }
+        }
+        return 'horizontal-tb';
+    }
+
+    /**
+     * Normalizes a CSS writing mode value by converting non-standard and deprecated values
+     * into their corresponding standard vaules.
+     * @param {string} writingMode The writing mode to normalize.
+     * @returns {string} The normalized writing mode.
+     */
+    static normalizeWritingMode(writingMode) {
+        switch (writingMode) {
+            case 'lr':
+            case 'lr-tb':
+            case 'rl':
+                return 'horizontal-tb';
+            case 'tb':
+                return 'vertical-lr';
+            case 'tb-rl':
+                return 'vertical-rl';
+            default:
+                return writingMode;
+        }
+    }
+
     // Private
 
     static _getActiveButtons(event, array) {

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -85,8 +85,9 @@ class DocumentUtil {
             if (imposter !== null) {
                 this._setImposterStyle(imposterContainer.style, 'z-index', '-2147483646');
                 this._setImposterStyle(imposter.style, 'pointer-events', 'none');
+                return TextSourceRange.createFromImposter(range, imposterContainer, imposterSourceElement);
             }
-            return new TextSourceRange(range, '', imposterContainer, imposterSourceElement);
+            return TextSourceRange.create(range);
         } else {
             if (imposterContainer !== null) {
                 imposterContainer.parentNode.removeChild(imposterContainer);

--- a/ext/js/dom/document-util.js
+++ b/ext/js/dom/document-util.js
@@ -420,6 +420,21 @@ class DocumentUtil {
     }
 
     /**
+     * Offsets an array of DOMRects by a given amount.
+     * @param {DOMRect[]} rects The DOMRects to offset.
+     * @param {number} x The horizontal offset amount.
+     * @param {number} y The vertical offset amount.
+     * @returns {DOMRect} The DOMRects with the offset applied.
+     */
+    static offsetDOMRects(rects, x, y) {
+        const results = [];
+        for (const rect of rects) {
+            results.push(new DOMRect(rect.left + x, rect.top + y, rect.width, rect.height));
+        }
+        return results;
+    }
+
+    /**
      * Gets the parent writing mode of an element.
      * See: https://developer.mozilla.org/en-US/docs/Web/CSS/writing-mode.
      * @param {Element} element The HTML element to check.

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -21,9 +21,9 @@
  */
 
 class TextSourceElement {
-    constructor(element, fullContent=null, startOffset=0, endOffset=0) {
+    constructor(element, fullContent, startOffset, endOffset) {
         this._element = element;
-        this._fullContent = (typeof fullContent === 'string' ? fullContent : TextSourceElement.getElementContent(element));
+        this._fullContent = fullContent;
         this._startOffset = startOffset;
         this._endOffset = endOffset;
         this._content = this._fullContent.substring(this._startOffset, this._endOffset);
@@ -130,7 +130,11 @@ class TextSourceElement {
         return [this._element];
     }
 
-    static getElementContent(element) {
+    static create(element) {
+        return new TextSourceElement(element, this._getElementContent(element), 0, 0);
+    }
+
+    static _getElementContent(element) {
         let content;
         switch (element.nodeName.toUpperCase()) {
             case 'BUTTON':

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -82,10 +82,6 @@ class TextSourceElement {
         return length;
     }
 
-    getRect() {
-        return DocumentUtil.convertRectZoomCoordinates(this._element.getBoundingClientRect(), this._element);
-    }
-
     getRects() {
         return DocumentUtil.convertMultipleRectZoomCoordinates(this._element.getClientRects(), this._element);
     }

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -49,10 +49,6 @@ class TextSourceElement {
         return this._endOffset;
     }
 
-    get isConnected() {
-        return this._element.isConnected;
-    }
-
     clone() {
         return new TextSourceElement(this._element, this._fullContent, this._startOffset, this._endOffset);
     }

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -65,7 +65,7 @@ class TextSourceElement {
         return this._content;
     }
 
-    setEndOffset(length, _layoutAwareScan, fromEnd) {
+    setEndOffset(length, fromEnd) {
         const offset = fromEnd ? this._endOffset : this._startOffset;
         length = Math.min(this._fullContent.length - offset, length);
         if (length > 0) {

--- a/ext/js/dom/text-source-element.js
+++ b/ext/js/dom/text-source-element.js
@@ -86,15 +86,6 @@ class TextSourceElement {
         return length;
     }
 
-    collapse(toStart) {
-        if (toStart) {
-            this._endOffset = this._startOffset;
-        } else {
-            this._startOffset = this._endOffset;
-        }
-        this._content = '';
-    }
-
     getRect() {
         return DocumentUtil.convertRectZoomCoordinates(this._element.getBoundingClientRect(), this._element);
     }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -21,9 +21,9 @@
  */
 
 class TextSourceRange {
-    constructor(range, content, imposterElement, imposterSourceElement) {
+    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement) {
         this._range = range;
-        this._rangeStartOffset = range.startOffset;
+        this._rangeStartOffset = rangeStartOffset;
         this._content = content;
         this._imposterElement = imposterElement;
         this._imposterSourceElement = imposterSourceElement;
@@ -53,7 +53,7 @@ class TextSourceRange {
     }
 
     clone() {
-        return new TextSourceRange(this._range.cloneRange(), this._content, this._imposterElement, this._imposterSourceElement);
+        return new TextSourceRange(this._range.cloneRange(), this._rangeStartOffset, this._content, this._imposterElement, this._imposterSourceElement);
     }
 
     cleanup() {
@@ -147,10 +147,10 @@ class TextSourceRange {
     }
 
     static create(range) {
-        return new TextSourceRange(range, range.toString(), null, null);
+        return new TextSourceRange(range, range.startOffset, range.toString(), null, null);
     }
 
     static createFromImposter(range, imposterElement, imposterSourceElement) {
-        return new TextSourceRange(range, range.toString(), imposterElement, imposterSourceElement);
+        return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement);
     }
 }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -99,7 +99,8 @@ class TextSourceRange {
     }
 
     getWritingMode() {
-        return TextSourceRange.getElementWritingMode(TextSourceRange.getParentElement(this._range.startContainer));
+        const node = this._range.startContainer;
+        return DocumentUtil.getElementWritingMode(node !== null ? node.parentElement : null);
     }
 
     select() {
@@ -141,38 +142,5 @@ class TextSourceRange {
 
     getNodesInRange() {
         return DocumentUtil.getNodesInRange(this._range);
-    }
-
-    static getParentElement(node) {
-        while (node !== null && node.nodeType !== Node.ELEMENT_NODE) {
-            node = node.parentNode;
-        }
-        return node;
-    }
-
-    static getElementWritingMode(element) {
-        if (element !== null) {
-            const style = window.getComputedStyle(element);
-            const writingMode = style.writingMode;
-            if (typeof writingMode === 'string') {
-                return TextSourceRange.normalizeWritingMode(writingMode);
-            }
-        }
-        return 'horizontal-tb';
-    }
-
-    static normalizeWritingMode(writingMode) {
-        switch (writingMode) {
-            case 'lr':
-            case 'lr-tb':
-            case 'rl':
-                return 'horizontal-tb';
-            case 'tb':
-                return 'vertical-lr';
-            case 'tb-rl':
-                return 'vertical-rl';
-            default:
-                return writingMode;
-        }
     }
 }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -66,7 +66,7 @@ class TextSourceRange {
         return this._content;
     }
 
-    setEndOffset(length, layoutAwareScan, fromEnd) {
+    setEndOffset(length, fromEnd, layoutAwareScan) {
         let node;
         let offset;
         if (fromEnd) {

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -85,11 +85,6 @@ class TextSourceRange {
         return length - state.remainder;
     }
 
-    collapse(toStart) {
-        this._range.collapse(toStart);
-        this._content = '';
-    }
-
     getRect() {
         return DocumentUtil.convertRectZoomCoordinates(this._range.getBoundingClientRect(), this._range.startContainer);
     }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -21,13 +21,12 @@
  */
 
 class TextSourceRange {
-    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRect, cachedRects) {
+    constructor(range, rangeStartOffset, content, imposterElement, imposterSourceElement, cachedRects) {
         this._range = range;
         this._rangeStartOffset = rangeStartOffset;
         this._content = content;
         this._imposterElement = imposterElement;
         this._imposterSourceElement = imposterSourceElement;
-        this._cachedRect = cachedRect;
         this._cachedRects = cachedRects;
     }
 
@@ -54,7 +53,6 @@ class TextSourceRange {
             this._content,
             this._imposterElement,
             this._imposterSourceElement,
-            this._cachedRect,
             this._cachedRects
         );
     }
@@ -149,12 +147,11 @@ class TextSourceRange {
     }
 
     static create(range) {
-        return new TextSourceRange(range, range.startOffset, range.toString(), null, null, null, null);
+        return new TextSourceRange(range, range.startOffset, range.toString(), null, null, null);
     }
 
     static createFromImposter(range, imposterElement, imposterSourceElement) {
-        const cachedRect = DocumentUtil.convertRectZoomCoordinates(range.getBoundingClientRect(), range.startContainer);
         const cachedRects = DocumentUtil.convertMultipleRectZoomCoordinates(range.getClientRects(), range.startContainer);
-        return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement, cachedRect, cachedRects);
+        return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement, cachedRects);
     }
 }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -67,11 +67,16 @@ class TextSourceRange {
     }
 
     setEndOffset(length, layoutAwareScan, fromEnd) {
-        const state = (
-            fromEnd ?
-            new DOMTextScanner(this._range.endContainer, this._range.endOffset, !layoutAwareScan, layoutAwareScan).seek(length) :
-            new DOMTextScanner(this._range.startContainer, this._range.startOffset, !layoutAwareScan, layoutAwareScan).seek(length)
-        );
+        let node;
+        let offset;
+        if (fromEnd) {
+            node = this._range.endContainer;
+            offset = this._range.endOffset;
+        } else {
+            node = this._range.startContainer;
+            offset = this._range.startOffset;
+        }
+        const state = new DOMTextScanner(node, offset, !layoutAwareScan, layoutAwareScan).seek(length);
         this._range.setEnd(state.node, state.offset);
         this._content = (fromEnd ? this._content + state.content : state.content);
         return length - state.remainder;

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -143,4 +143,12 @@ class TextSourceRange {
     getNodesInRange() {
         return DocumentUtil.getNodesInRange(this._range);
     }
+
+    static create(range) {
+        return new TextSourceRange(range, range.toString(), null, null);
+    }
+
+    static createFromImposter(range, imposterElement, imposterSourceElement) {
+        return new TextSourceRange(range, range.toString(), imposterElement, imposterSourceElement);
+    }
 }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -45,13 +45,6 @@ class TextSourceRange {
         return this._imposterSourceElement;
     }
 
-    get isConnected() {
-        return (
-            this._range.startContainer.isConnected &&
-            this._range.endContainer.isConnected
-        );
-    }
-
     clone() {
         return new TextSourceRange(this._range.cloneRange(), this._rangeStartOffset, this._content, this._imposterElement, this._imposterSourceElement);
     }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -93,13 +93,6 @@ class TextSourceRange {
         return length - state.remainder;
     }
 
-    getRect() {
-        if (this._imposterElement !== null && !this._imposterElement.isConnected) { return this._cachedRect; }
-        const result = DocumentUtil.convertRectZoomCoordinates(this._range.getBoundingClientRect(), this._range.startContainer);
-        if (this._cachedRect !== null) { this._cachedRect = result; }
-        return result;
-    }
-
     getRects() {
         if (this._imposterElement !== null && !this._imposterElement.isConnected) { return this._cachedRects; }
         const result = DocumentUtil.convertMultipleRectZoomCoordinates(this._range.getClientRects(), this._range.startContainer);

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -99,12 +99,14 @@ class TextSourceRange {
     }
 
     select() {
+        if (this._imposterElement !== null) { return; }
         const selection = window.getSelection();
         selection.removeAllRanges();
         selection.addRange(this._range);
     }
 
     deselect() {
+        if (this._imposterElement !== null) { return; }
         const selection = window.getSelection();
         selection.removeAllRanges();
     }

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -21,11 +21,11 @@
  */
 
 class TextSourceRange {
-    constructor(range, content, imposterContainer, imposterSourceElement) {
+    constructor(range, content, imposterElement, imposterSourceElement) {
         this._range = range;
         this._rangeStartOffset = range.startOffset;
         this._content = content;
-        this._imposterContainer = imposterContainer;
+        this._imposterElement = imposterElement;
         this._imposterSourceElement = imposterSourceElement;
     }
 
@@ -53,12 +53,12 @@ class TextSourceRange {
     }
 
     clone() {
-        return new TextSourceRange(this._range.cloneRange(), this._content, this._imposterContainer, this._imposterSourceElement);
+        return new TextSourceRange(this._range.cloneRange(), this._content, this._imposterElement, this._imposterSourceElement);
     }
 
     cleanup() {
-        if (this._imposterContainer !== null && this._imposterContainer.parentNode !== null) {
-            this._imposterContainer.parentNode.removeChild(this._imposterContainer);
+        if (this._imposterElement !== null && this._imposterElement.parentNode !== null) {
+            this._imposterElement.parentNode.removeChild(this._imposterElement);
         }
     }
 

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -95,9 +95,7 @@ class TextSourceRange {
 
     getRects() {
         if (this._isImposterDisconnected()) { return this._getCachedRects(); }
-        const result = DocumentUtil.convertMultipleRectZoomCoordinates(this._range.getClientRects(), this._range.startContainer);
-        if (this._cachedRects !== null) { this._cachedRects = result; }
-        return result;
+        return DocumentUtil.convertMultipleRectZoomCoordinates(this._range.getClientRects(), this._range.startContainer);
     }
 
     getWritingMode() {

--- a/ext/js/dom/text-source-range.js
+++ b/ext/js/dom/text-source-range.js
@@ -94,14 +94,14 @@ class TextSourceRange {
     }
 
     getRects() {
-        if (this._imposterElement !== null && !this._imposterElement.isConnected) { return this._getCachedRects(); }
+        if (this._isImposterDisconnected()) { return this._getCachedRects(); }
         const result = DocumentUtil.convertMultipleRectZoomCoordinates(this._range.getClientRects(), this._range.startContainer);
         if (this._cachedRects !== null) { this._cachedRects = result; }
         return result;
     }
 
     getWritingMode() {
-        const node = this._range.startContainer;
+        const node = this._isImposterDisconnected() ? this._imposterSourceElement : this._range.startContainer;
         return DocumentUtil.getElementWritingMode(node !== null ? node.parentElement : null);
     }
 
@@ -156,6 +156,10 @@ class TextSourceRange {
         const cachedRects = DocumentUtil.convertMultipleRectZoomCoordinates(range.getClientRects(), range.startContainer);
         const cachedSourceRect = DocumentUtil.convertRectZoomCoordinates(imposterSourceElement.getBoundingClientRect(), imposterSourceElement);
         return new TextSourceRange(range, range.startOffset, range.toString(), imposterElement, imposterSourceElement, cachedRects, cachedSourceRect);
+    }
+
+    _isImposterDisconnected() {
+        return this._imposterElement !== null && !this._imposterElement.isConnected;
     }
 
     _getCachedRects() {

--- a/ext/js/language/text-scanner.js
+++ b/ext/js/language/text-scanner.js
@@ -229,7 +229,7 @@ class TextScanner extends EventDispatcher {
     getTextSourceContent(textSource, length, layoutAwareScan) {
         const clonedTextSource = textSource.clone();
 
-        clonedTextSource.setEndOffset(length, layoutAwareScan, false);
+        clonedTextSource.setEndOffset(length, false, layoutAwareScan);
 
         const includeSelector = this._includeSelector;
         const excludeSelector = this._excludeSelector;
@@ -875,7 +875,7 @@ class TextScanner extends EventDispatcher {
         const {dictionaryEntries, originalTextLength} = await yomichan.api.termsFind(searchText, details, optionsContext);
         if (dictionaryEntries.length === 0) { return null; }
 
-        textSource.setEndOffset(originalTextLength, layoutAwareScan, false);
+        textSource.setEndOffset(originalTextLength, false, layoutAwareScan);
         const sentence = DocumentUtil.extractSentence(
             textSource,
             layoutAwareScan,
@@ -902,7 +902,7 @@ class TextScanner extends EventDispatcher {
         const dictionaryEntries = await yomichan.api.kanjiFind(searchText, optionsContext);
         if (dictionaryEntries.length === 0) { return null; }
 
-        textSource.setEndOffset(1, layoutAwareScan, false);
+        textSource.setEndOffset(1, false, layoutAwareScan);
         const sentence = DocumentUtil.extractSentence(
             textSource,
             layoutAwareScan,
@@ -1127,7 +1127,7 @@ class TextScanner extends EventDispatcher {
                 (excludeSelector !== null && DocumentUtil.anyNodeMatchesSelector(nodes, excludeSelector))
             ) {
                 --length;
-                textSource.setEndOffset(length, layoutAwareScan, false);
+                textSource.setEndOffset(length, false, layoutAwareScan);
             } else {
                 break;
             }

--- a/ext/js/pages/settings/popup-preview-frame.js
+++ b/ext/js/pages/settings/popup-preview-frame.js
@@ -212,7 +212,7 @@ class PopupPreviewFrame {
 
         const range = document.createRange();
         range.selectNodeContents(textNode);
-        const source = new TextSourceRange(range, range.toString(), null, null);
+        const source = TextSourceRange.create(range);
 
         try {
             await this._frontend.setTextSource(source);

--- a/test/test-document-util.js
+++ b/test/test-document-util.js
@@ -160,8 +160,9 @@ async function testDocumentTextScanningFunctions(dom, {DocumentUtil, TextSourceR
             range.setStart(imposter ? imposter : startNode, startOffset);
             range.setEnd(imposter ? imposter : startNode, endOffset);
 
-            // Override getClientRects to return a rect guaranteed to contain (x, y)
+            // Override getClientRects and getBoundingClientRect to return a rect guaranteed to contain (x, y)
             range.getClientRects = () => [new DOMRect(x - 1, y - 1, 2, 2)];
+            range.getBoundingClientRect = () => new DOMRect(x - 1, y - 1, 2, 2);
             return range;
         };
 

--- a/test/test-document-util.js
+++ b/test/test-document-util.js
@@ -160,9 +160,8 @@ async function testDocumentTextScanningFunctions(dom, {DocumentUtil, TextSourceR
             range.setStart(imposter ? imposter : startNode, startOffset);
             range.setEnd(imposter ? imposter : startNode, endOffset);
 
-            // Override getClientRects and getBoundingClientRect to return a rect guaranteed to contain (x, y)
+            // Override getClientRects to return a rect guaranteed to contain (x, y)
             range.getClientRects = () => [new DOMRect(x - 1, y - 1, 2, 2)];
-            range.getBoundingClientRect = () => new DOMRect(x - 1, y - 1, 2, 2);
             return range;
         };
 


### PR DESCRIPTION
This change updates the `TextSourceRange` and `TextSourceElement` APIs to remove anything that is unused, simplify the constructors, and fix an issue related to returning stale rects.

The fixed issue would occur when scanning an element which creates an imposter (such as a textarea) and then the window is resized, which triggers a repositioning of the popup. When this repositioning occurred, it would cause the `getRect/getRects` function to be called, which is selecting a range which is no longer connected to the document, so the popup position would be incorrect.