### PR TITLE
Audio certificate error notification

### DIFF
--- a/ext/issues.html
+++ b/ext/issues.html
@@ -42,6 +42,21 @@
         </div></div></div></div>
     </div>
 
+    <h2 id="audio-download-failed-expired-server-certificate">Audio download failed due to an expired server certificate</h2>
+    <div class="settings-group">
+        <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
+            <p>
+                If a website failes to keep its HTTPS certificate up to date,
+                downloads can fail because the browser flags the connection as insecure.
+                This has happened occasionally for some websites that Yomichan interacts with,
+                and the issue is usually resolved within a day.
+            </p>
+            <p>
+                This issue is a server-side issue that Yomichan doesn't have control over.
+            </p>
+        </div></div></div></div>
+    </div>
+
     <h2 id="audio-download-idle-timeout">Audio download was cancelled due to an idle timeout</h2>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">

--- a/ext/issues.html
+++ b/ext/issues.html
@@ -25,7 +25,7 @@
 
     <h1>Yomichan Issues</h1>
 
-    <h2 id="audio-download-failed">Audio download failed due to possible extension permissions error <em>(Chrome)</em></h2>
+    <h2 id="audio-download-failed-permissions-error">Audio download failed due to possible extension permissions error <em>(Chrome)</em></h2>
     <div class="settings-group">
         <div class="settings-item"><div class="settings-item-inner"><div class="settings-item-left"><div class="settings-item-label">
             <p>

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1942,6 +1942,10 @@ class Backend {
                             // The message logged to the console looks like this:
                             //  Access to fetch at '<URL>' from origin 'chrome-extension://<ID>' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
                             return this._createAudioDownloadError('Audio download failed due to possible extension permissions error', 'audio-download-failed-permissions-error', errors);
+                        case 'net::ERR_CERT_DATE_INVALID': // Chrome
+                        case 'Peer’s Certificate has expired.': // Firefox
+                            // This error occurs when a server certificate expires.
+                            return this._createAudioDownloadError('Audio download failed due to an expired server certificate', 'audio-download-failed-expired-server-certificate', errors);
                     }
                 }
             }

--- a/ext/js/background/backend.js
+++ b/ext/js/background/backend.js
@@ -1936,11 +1936,12 @@ class Backend {
                     if (!isObject(error2.data)) { continue; }
                     const {details} = error2.data;
                     if (!isObject(details)) { continue; }
-                    if (details.error === 'net::ERR_FAILED') {
-                        // This is potentially an error due to the extension not having enough URL privileges.
-                        // The message logged to the console looks like this:
-                        //  Access to fetch at '<URL>' from origin 'chrome-extension://<ID>' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
-                        return this._createAudioDownloadError('Audio download failed due to possible extension permissions error', 'audio-download-failed', errors);
+                    switch (details.error) {
+                        case 'net::ERR_FAILED':
+                            // This is potentially an error due to the extension not having enough URL privileges.
+                            // The message logged to the console looks like this:
+                            //  Access to fetch at '<URL>' from origin 'chrome-extension://<ID>' has been blocked by CORS policy: No 'Access-Control-Allow-Origin' header is present on the requested resource. If an opaque response serves your needs, set the request's mode to 'no-cors' to fetch the resource with CORS disabled.
+                            return this._createAudioDownloadError('Audio download failed due to possible extension permissions error', 'audio-download-failed-permissions-error', errors);
                     }
                 }
             }


### PR DESCRIPTION
This change updates the audio download error handling in order to show an error notification in cases of expired server certificates.

Resolves #2242.