### PR TITLE
Fix unnecessary margin on search box in Firefox

### DIFF
--- a/ext/css/search.css
+++ b/ext/css/search.css
@@ -86,6 +86,7 @@ h1 {
     font-family: 'Helvetica Neue', Helvetica, Arial, sans-serif;
     white-space: pre-wrap;
     z-index: 1;
+    margin: 0;
 }
 .search-button {
     flex: 0 0 auto;


### PR DESCRIPTION
Firefox default textbox style seems to have this, so it needs to be forced to 0.