### PR TITLE
Deinflect できる to する

### DIFF
--- a/ext/data/deinflect.json
+++ b/ext/data/deinflect.json
@@ -538,6 +538,7 @@
         {"kanaIn": "ねる", "kanaOut": "ぬ", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "べる", "kanaOut": "ぶ", "rulesIn": ["v1"], "rulesOut": ["v5"]},
         {"kanaIn": "める", "kanaOut": "む", "rulesIn": ["v1"], "rulesOut": ["v5"]},
+        {"kanaIn": "できる", "kanaOut": "する", "rulesIn": ["v1"], "rulesOut": ["vs"]},
         {"kanaIn": "これる", "kanaOut": "くる", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "来れる", "kanaOut": "来る", "rulesIn": ["v1"], "rulesOut": ["vk"]},
         {"kanaIn": "來れる", "kanaOut": "來る", "rulesIn": ["v1"], "rulesOut": ["vk"]}


### PR DESCRIPTION
「できる」 should be de-inflected as the potential form of 「する」。

Otherwise, for example, Yomichan correctly matches 「全うする」 to the meaning of "to accomplish / to fulfill / to carry out", but incorrectly matches 「全うできる」 to 「真っ当・全う・真当」 with meaning "proper / respectable / decent / honest".