### PR TITLE
Add color option for structured content

### DIFF
--- a/ext/data/schemas/dictionary-term-bank-v3-schema.json
+++ b/ext/data/schemas/dictionary-term-bank-v3-schema.json
@@ -254,6 +254,15 @@
                     "type": "string",
                     "default": "medium"
                 },
+                "color": {
+                    "type": "string",
+                    "enum": ["black", "white", "gray", "red", "blue", "yellow", "green", "purple", "orange"],
+                    "default": "black"
+                },
+                "colorRGBA": {
+                    "type": "string",
+                    "default": "#000000FF"
+                },
                 "textDecorationLine": {
                     "oneOf": [
                         {

--- a/ext/js/display/sandbox/structured-content-generator.js
+++ b/ext/js/display/sandbox/structured-content-generator.js
@@ -263,6 +263,8 @@ class StructuredContentGenerator {
             fontStyle,
             fontWeight,
             fontSize,
+            color,
+            colorRGBA,
             textDecorationLine,
             verticalAlign,
             textAlign,
@@ -275,6 +277,10 @@ class StructuredContentGenerator {
         if (typeof fontStyle === 'string') { style.fontStyle = fontStyle; }
         if (typeof fontWeight === 'string') { style.fontWeight = fontWeight; }
         if (typeof fontSize === 'string') { style.fontSize = fontSize; }
+        if (typeof color === 'string') { style.color = color; }
+        if (typeof colorRGBA === 'string' && colorRGBA.length === 9 && colorRGBA.match(/#[0-9A-Fa-f]{8}/g)) {
+            style.color = colorRGBA;
+        }
         if (typeof verticalAlign === 'string') { style.verticalAlign = verticalAlign; }
         if (typeof textAlign === 'string') { style.textAlign = textAlign; }
         if (typeof textDecorationLine === 'string') {

--- a/test/data/dictionaries/valid-dictionary1/term_bank_1.json
+++ b/test/data/dictionaries/valid-dictionary1/term_bank_1.json
@@ -93,6 +93,8 @@
                 {"tag": "div", "style": {"fontSize": "x-large"}, "content": "fontSize:x-large"},
                 {"tag": "div", "style": {"fontSize": "xx-large"}, "content": "fontSize:xx-large"},
                 {"tag": "div", "style": {"fontSize": "xxx-large"}, "content": "fontSize:xxx-large"},
+                {"tag": "div", "style": {"color": "red"}, "content": "color:red"},
+                {"tag": "div", "style": {"colorRGBA": "#ABC123FF"}, "content": "colorRGBA:#ABC123FF"},
                 {"tag": "div", "style": {"textDecorationLine": "none"}, "content": "textDecorationLine:none "},
                 {"tag": "div", "style": {"textDecorationLine": "underline"}, "content": "textDecorationLine:underline "},
                 {"tag": "div", "style": {"textDecorationLine": "overline"}, "content": "textDecorationLine:overline "},


### PR DESCRIPTION
### Add support for the [color property](https://developer.mozilla.org/en-US/docs/Web/CSS/color)
It's nice to have some more variation aviable when it comes to designing dictionary-entries.
A few basic color names can be used, or any valid RGBA value.