### PR TITLE
Set file extension for aac audio media type

### DIFF
--- a/ext/js/media/media-util.js
+++ b/ext/js/media/media-util.js
@@ -107,6 +107,8 @@ class MediaUtil {
      */
     static getFileExtensionFromAudioMediaType(mediaType) {
         switch (mediaType) {
+            case 'audio/aac':
+                return '.aac';
             case 'audio/mpeg':
             case 'audio/mp3':
                 return '.mp3';


### PR DESCRIPTION
By default, if an audio media type does not appear in this switch statement, it gets the ".mp3" file extension. This causes issues with aac files in the iphone anki app.